### PR TITLE
fix: stage_intake no longer pollutes global TEST_CMD

### DIFF
--- a/scripts/lib/pipeline-stages.sh
+++ b/scripts/lib/pipeline-stages.sh
@@ -90,11 +90,12 @@ stage_intake() {
     suggested_template=$(template_for_type "$TASK_TYPE")
     info "Detected: ${BOLD}$TASK_TYPE${RESET} → team template: ${CYAN}$suggested_template${RESET}"
 
-    # 3. Auto-detect test command if not provided
+    # 3. Display detected test command — informational only; stage_build auto-detects per-iteration
     if [[ -z "$TEST_CMD" ]]; then
-        TEST_CMD=$(detect_test_cmd)
-        if [[ -n "$TEST_CMD" ]]; then
-            info "Auto-detected test: ${DIM}$TEST_CMD${RESET}"
+        local _detected_test_cmd
+        _detected_test_cmd=$(detect_test_cmd)
+        if [[ -n "$_detected_test_cmd" ]]; then
+            info "Auto-detected test: ${DIM}$_detected_test_cmd${RESET}"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- `stage_intake` was calling `detect_test_cmd` and writing the result to the global `TEST_CMD` variable
- This caused `stage_build` to see a non-empty `TEST_CMD` and skip its own per-iteration auto-detection path entirely
- Net effect: every build loop iteration ran the full test suite, defeating the smart targeting work from PRs #20–#22
- Fix: intake now detects for **display only** (local variable), leaving `TEST_CMD` empty so `stage_build` can auto-detect fresh each iteration

## Test plan

- [x] `bash -n scripts/lib/pipeline-stages.sh` — syntax clean
- [x] Full regression (`npm test`) — all suites pass
- [ ] Verify zpod pipeline now runs targeted tests on fast iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)