### PR TITLE
fix: strip markdown formatting from triage response parsing

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -215,10 +215,10 @@ jobs:
             fi
           fi
 
-          # Parse response
-          APPROVED=$(echo "$RESPONSE" | grep -i "^APPROVED:" | head -1 | awk '{print $2}' | tr '[:upper:]' '[:lower:]')
-          COMPLEXITY=$(echo "$RESPONSE" | grep -i "^COMPLEXITY:" | head -1 | awk '{print $2}' | tr '[:upper:]' '[:lower:]')
-          REASON=$(echo "$RESPONSE" | grep -i "^REASON:" | head -1 | sed 's/^REASON: *//')
+          # Parse response (strip leading whitespace, backticks, asterisks from Claude markdown)
+          APPROVED=$(echo "$RESPONSE" | sed 's/^[ \t`*]*//' | grep -i "^APPROVED:" | head -1 | awk '{print $2}' | tr -d '`*' | tr '[:upper:]' '[:lower:]')
+          COMPLEXITY=$(echo "$RESPONSE" | sed 's/^[ \t`*]*//' | grep -i "^COMPLEXITY:" | head -1 | awk '{print $2}' | tr -d '`*' | tr '[:upper:]' '[:lower:]')
+          REASON=$(echo "$RESPONSE" | sed 's/^[ \t`*]*//' | grep -i "^REASON:" | head -1 | sed 's/^REASON: *//i' | tr -d '`')
 
           # Fail-safe defaults: never auto-approve on parse failure
           APPROVED="${APPROVED:-false}"


### PR DESCRIPTION
## Summary
- Strips leading whitespace, backticks, and asterisks from Claude's triage response before parsing `APPROVED:`, `COMPLEXITY:`, and `REASON:` fields
- Removes inline markdown artifacts from parsed values
- Fixes CI pipeline rejecting all issues because Claude wraps responses in markdown formatting

## Test plan
- [ ] Apply `shipwright` label to an open issue and confirm the triage step logs `Approved: true` instead of the parse-failure rejection
- [ ] Verify fallback defaults still activate when Claude returns empty/garbage

Generated with Claude Code