### PR TITLE
fix: configurable maxdepth for dead-code fixture scan in sw-hygiene.sh

### DIFF
--- a/.claude/daemon-config.json
+++ b/.claude/daemon-config.json
@@ -18,7 +18,7 @@
   "pipeline_template": "autonomous",
   "auto_template": false,
   "last_optimization": {
-    "timestamp": "2026-03-02T23:16:05Z",
+    "timestamp": "2026-03-09T23:02:46Z",
     "adjustments": "compound_quality enabled (CFR 25% > 20%); merge stage recommended (deploy freq 3.0/week); "
   }
 }

--- a/scripts/sw-hygiene.sh
+++ b/scripts/sw-hygiene.sh
@@ -71,6 +71,7 @@ show_help() {
     echo ""
     echo -e "${BOLD}ENVIRONMENT${RESET}"
     echo -e "  ${CYAN}SHIPWRIGHT_HYGIENE_DEAD_CODE_TIMEOUT_S${RESET}  Dead-code scan timeout in seconds (default: 20)"
+    echo -e "  ${CYAN}SHIPWRIGHT_HYGIENE_FIND_MAX_DEPTH${RESET}       Max directory depth for fixture scan (default: 5)"
     echo ""
     echo -e "${BOLD}EXAMPLES${RESET}"
     echo -e "  ${DIM}shipwright hygiene scan${RESET}                # Full scan"
@@ -93,6 +94,7 @@ detect_dead_code() {
     local partial_reasons=""
     func_limit=$(_config_get_int "limits.function_scan_limit" 1000)
     dead_code_timeout="${SHIPWRIGHT_HYGIENE_DEAD_CODE_TIMEOUT_S:-$(_config_get_int "limits.dead_code_timeout_seconds" 20)}"
+    find_max_depth="${SHIPWRIGHT_HYGIENE_FIND_MAX_DEPTH:-$(_config_get_int "limits.find_max_depth" 5)}"
     case "$dead_code_timeout" in
         ''|*[!0-9-]*)
             warn "Invalid dead-code timeout '$dead_code_timeout'; falling back to 20s."
@@ -202,7 +204,8 @@ detect_dead_code() {
             warn "Orphaned test fixture: $(basename "$fixture")"
             orphaned_tests=$((orphaned_tests + 1))
         fi
-    done < <(find "$REPO_DIR" -name "*.fixture" -type f 2>/dev/null)
+    done < <(find "$REPO_DIR" -maxdepth "$find_max_depth" -name "*.fixture" -type f \
+        ! -path '*/node_modules/*' ! -path '*/.git/*' 2>/dev/null)
 
     [[ $VERBOSE == true ]] && {
         info "Dead code summary: $unused_functions unused functions, $unused_scripts scripts, $orphaned_tests fixtures"


### PR DESCRIPTION
## Summary

- `sw-hygiene.sh dead-code` Phase 4 (fixture scan) was running an unbounded `find` over the entire repo, crawling `node_modules`, `.git`, and all subdirectories — causing hangs of 1+ hour
- Added `-maxdepth` flag (default: 5) and exclusions for `node_modules` and `.git` directories
- Depth is configurable via `SHIPWRIGHT_HYGIENE_FIND_MAX_DEPTH` env var or `limits.find_max_depth` config key

## Test plan

- [ ] Run `bash scripts/sw-hygiene.sh dead-code` — should complete in seconds
- [ ] Run `SHIPWRIGHT_HYGIENE_FIND_MAX_DEPTH=2 bash scripts/sw-hygiene.sh dead-code` — verify override works
- [ ] Run `npm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)