### PR TITLE
fix: address code review feedback from #153

### DIFF
--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1010,44 +1010,14 @@ Update the design to address these violations, then rebuild."
     fi
 }
 
-compound_rebuild_with_feedback() {
-    local feedback_file="$ARTIFACTS_DIR/quality-feedback.md"
+# _write_quality_feedback <route> <output_file>
+# Collects all quality findings into a single markdown file. Extracted from
+# compound_rebuild_with_feedback() to allow direct testing without mocking
+# the full build loop.
+_write_quality_feedback() {
+    local route="${1:-correctness}"
+    local feedback_file="${2:-$ARTIFACTS_DIR/quality-feedback.md}"
 
-    # ── Intelligence: classify findings and determine routing ──
-    local route="correctness"
-    route=$(classify_quality_findings 2>/dev/null) || route="correctness"
-
-    # ── Build structured findings JSON alongside markdown ──
-    local structured_findings="[]"
-    local s_total_critical=0 s_total_major=0 s_total_minor=0
-
-    if [[ -f "$ARTIFACTS_DIR/classified-findings.json" ]]; then
-        s_total_critical=$(jq -r '.security // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
-        s_total_major=$(jq -r '.correctness // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
-        s_total_minor=$(jq -r '.style // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
-    fi
-
-    local tmp_qf
-    tmp_qf="$(mktemp)"
-    jq -n \
-        --arg route "$route" \
-        --argjson total_critical "$s_total_critical" \
-        --argjson total_major "$s_total_major" \
-        --argjson total_minor "$s_total_minor" \
-        '{route: $route, total_critical: $total_critical, total_major: $total_major, total_minor: $total_minor}' \
-        > "$tmp_qf" 2>/dev/null && mv "$tmp_qf" "$ARTIFACTS_DIR/quality-findings.json" || rm -f "$tmp_qf"
-
-    # ── Architecture route: backtrack to design instead of rebuild ──
-    if [[ "$route" == "architecture" ]]; then
-        info "Architecture-level findings detected — attempting backtrack to design"
-        if pipeline_backtrack_to_stage "design" "architecture_violation" 2>/dev/null; then
-            return 0
-        fi
-        # Backtrack failed or already used — fall through to standard rebuild
-        warn "Backtrack unavailable — falling through to standard rebuild"
-    fi
-
-    # Collect all findings (prioritized by classification)
     {
         echo "# Quality Feedback — Issues to Fix"
         echo ""
@@ -1098,6 +1068,47 @@ compound_rebuild_with_feedback() {
             fi
         fi
     } > "$feedback_file"
+}
+
+compound_rebuild_with_feedback() {
+    local feedback_file="$ARTIFACTS_DIR/quality-feedback.md"
+
+    # ── Intelligence: classify findings and determine routing ──
+    local route="correctness"
+    route=$(classify_quality_findings 2>/dev/null) || route="correctness"
+
+    # ── Build structured findings JSON alongside markdown ──
+    local structured_findings="[]"
+    local s_total_critical=0 s_total_major=0 s_total_minor=0
+
+    if [[ -f "$ARTIFACTS_DIR/classified-findings.json" ]]; then
+        s_total_critical=$(jq -r '.security // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
+        s_total_major=$(jq -r '.correctness // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
+        s_total_minor=$(jq -r '.style // 0' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "0")
+    fi
+
+    local tmp_qf
+    tmp_qf="$(mktemp)"
+    jq -n \
+        --arg route "$route" \
+        --argjson total_critical "$s_total_critical" \
+        --argjson total_major "$s_total_major" \
+        --argjson total_minor "$s_total_minor" \
+        '{route: $route, total_critical: $total_critical, total_major: $total_major, total_minor: $total_minor}' \
+        > "$tmp_qf" 2>/dev/null && mv "$tmp_qf" "$ARTIFACTS_DIR/quality-findings.json" || rm -f "$tmp_qf"
+
+    # ── Architecture route: backtrack to design instead of rebuild ──
+    if [[ "$route" == "architecture" ]]; then
+        info "Architecture-level findings detected — attempting backtrack to design"
+        if pipeline_backtrack_to_stage "design" "architecture_violation" 2>/dev/null; then
+            return 0
+        fi
+        # Backtrack failed or already used — fall through to standard rebuild
+        warn "Backtrack unavailable — falling through to standard rebuild"
+    fi
+
+    # Collect all findings (prioritized by classification)
+    _write_quality_feedback "$route" "$feedback_file"
 
     # Validate feedback file has actual content
     if [[ ! -s "$feedback_file" ]]; then
@@ -1329,7 +1340,7 @@ stage_compound_quality() {
     local _cascade_diff=""
     _cascade_diff=$(git diff "${BASE_BRANCH:-main}...HEAD" 2>/dev/null | head -5000) || _cascade_diff=""
     if [[ -n "$_cascade_diff" ]] && [[ $(echo "$_cascade_diff" | wc -l) -ge 5000 ]]; then
-        warn "Diff truncated at 5000 lines — audit findings for files beyond this limit may be incomplete"
+        warn "Diff may be truncated at 5000 lines — audit findings for files beyond this limit may be incomplete"
     fi
     local _cascade_plan=""
     if [[ -f "$ARTIFACTS_DIR/plan.md" ]]; then
@@ -1639,14 +1650,16 @@ ${_cascade_test_tail}"
             # Count only findings not seen in a prior cycle (cross-cycle dedup)
             local neg_issues=0
             if [[ -z "$_neg_prev_categories" ]]; then
-                neg_issues=$(echo "$_neg_current_categories" | grep -c . 2>/dev/null || echo "0")
+                neg_issues=$(echo "$_neg_current_categories" | grep -c . 2>/dev/null || true)
+                neg_issues=${neg_issues:-0}
             else
                 neg_issues=$(comm -23 \
                     <(echo "$_neg_current_categories") \
                     <(echo "$_neg_prev_categories") \
-                    | grep -c . 2>/dev/null || echo "0")
+                    | grep -c . 2>/dev/null || true)
+                neg_issues=${neg_issues:-0}
             fi
-            current_issue_count=$((current_issue_count + ${neg_issues:-0}))
+            current_issue_count=$((current_issue_count + neg_issues))
 
             # Accumulate categories for next cycle's dedup
             if [[ -n "$_neg_current_categories" ]]; then
@@ -1799,7 +1812,7 @@ All quality checks clean:
                 if [[ -z "$_cascade_diff" ]]; then
                     warn "Git diff failed after rebuild — cascade will operate without diff context"
                 elif [[ $(echo "$_cascade_diff" | wc -l) -ge 5000 ]]; then
-                    warn "Diff truncated at 5000 lines — audit findings for files beyond this limit may be incomplete"
+                    warn "Diff may be truncated at 5000 lines — audit findings for files beyond this limit may be incomplete"
                 fi
                 _cascade_prebuild_commit="$_post_rebuild_commit"
             else

--- a/scripts/sw-lib-pipeline-intelligence-test.sh
+++ b/scripts/sw-lib-pipeline-intelligence-test.sh
@@ -412,27 +412,14 @@ assert_pass "pipeline_security_source_scan handles many vulnerabilities"
 # ═══════════════════════════════════════════════════════════════════════════════
 print_test_section "staleness preamble in quality feedback"
 
-# Test: negative-review.md content is preceded by staleness warning in feedback output
-# compound_rebuild_with_feedback() collects feedback into a temp file; we verify
-# the preamble appears before the actual review content.
+# Test: _write_quality_feedback() emits staleness preamble before negative-review content
+# Calls the real extracted helper to verify the production implementation, not a copy.
 neg_review_content="[Critical] precondition() is stripped in Release builds"
 echo "$neg_review_content" > "$ARTIFACTS_DIR/negative-review.md"
+local_feedback_file="$ARTIFACTS_DIR/quality-feedback.md"
 
-# Capture the feedback block output by sourcing the relevant section via a subshell
-feedback_output=$(
-    ARTIFACTS_DIR="$ARTIFACTS_DIR"
-    {
-        if [[ -f "$ARTIFACTS_DIR/negative-review.md" ]]; then
-            echo "## Negative Prompting Concerns"
-            echo "NOTE: These findings were generated against a PREVIOUS version of the code."
-            echo "Re-read the actual current source files before making changes."
-            echo "If a finding references code that has already been fixed, skip it."
-            echo ""
-            cat "$ARTIFACTS_DIR/negative-review.md"
-            echo ""
-        fi
-    }
-)
+_write_quality_feedback "correctness" "$local_feedback_file"
+feedback_output=$(cat "$local_feedback_file")
 
 # Preamble must appear before the actual review content
 preamble_line=$(echo "$feedback_output" | grep -n "PREVIOUS version" | head -1 | cut -d: -f1)
@@ -446,17 +433,12 @@ fi
 
 # Test: preamble is present even when negative-review.md has multiple criticals
 printf "[Critical] issue one\n[Critical] issue two\n" > "$ARTIFACTS_DIR/negative-review.md"
-has_preamble=$(
-    {
-        if [[ -f "$ARTIFACTS_DIR/negative-review.md" ]]; then
-            echo "NOTE: These findings were generated against a PREVIOUS version of the code."
-            cat "$ARTIFACTS_DIR/negative-review.md"
-        fi
-    } | grep -c "PREVIOUS version" || echo "0"
-)
+_write_quality_feedback "correctness" "$local_feedback_file"
+has_preamble=$(grep -c "PREVIOUS version" "$local_feedback_file" 2>/dev/null || true)
+has_preamble=${has_preamble:-0}
 assert_eq "staleness preamble present with multiple criticals" "1" "$has_preamble"
 
 # Cleanup
-rm -f "$ARTIFACTS_DIR/negative-review.md"
+rm -f "$ARTIFACTS_DIR/negative-review.md" "$local_feedback_file"
 
 print_test_results


### PR DESCRIPTION
## Summary

Follow-up to #167 addressing code review feedback from Codex and Copilot.

- **P1 bug fix**: `grep -c . || echo "0"` produced double output (`"0\n0"`) when negative-review.md exists but has no `[Critical]` lines, because `grep -c` exits 1 on no-match, emitting `0`, then `|| echo "0"` appends another `0`. The arithmetic expansion then raised a syntax error, aborting `compound_quality` on a clean negative review. Fixed with `|| true` + `${var:-0}` default in both branches.
- **Test accuracy**: Staleness preamble test was testing a hardcoded copy of the feedback-collection code rather than the real implementation. Extracted `_write_quality_feedback(route, file)` from `compound_rebuild_with_feedback()` and updated the test to call it directly — now catches regressions in the actual production path.
- **Nit**: Same `grep -c || echo "0"` double-output pattern fixed in test file.
- **Nit**: "Diff truncated" warning text changed to "Diff may be truncated" since the check runs against the already-truncated output.

## Test plan

- [ ] `bash scripts/sw-lib-pipeline-intelligence-test.sh` — all 54 tests pass
- [ ] `bash scripts/sw-lib-compound-audit-test.sh` — all 56 tests pass
- [ ] Verify `_write_quality_feedback` exists as a standalone function: `grep -n "_write_quality_feedback" scripts/lib/pipeline-intelligence.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)