### PR TITLE
fix: use _timeout helper in plan stage for macOS compatibility

### DIFF
--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -385,7 +385,7 @@ ${_skill_prompts}
     _plan_timeout=$(_config_get_int "plan.claude_timeout" 3600 2>/dev/null || echo 3600)
     for _plan_attempt in 1 2 3; do
         : > "$plan_file"
-        timeout "$_plan_timeout" claude --print --model "$plan_model" --max-turns 25 \
+        _timeout "$_plan_timeout" claude --print --model "$plan_model" --max-turns 25 \
             --dangerously-skip-permissions "$plan_prompt" < /dev/null > "$plan_file" 2>"$_token_log"
         _plan_exit=$?
         if [[ "$_plan_exit" -eq 124 ]]; then


### PR DESCRIPTION
## Summary

- Replaces bare `timeout` call with `_timeout` from `compat.sh` in the plan stage of `pipeline-stages-intake.sh`
- `timeout` is a GNU coreutils command not available on macOS by default, causing the plan stage to silently fail with `timeout: command not found` → empty output → `Plan generation failed — empty output`
- `_timeout` gracefully falls back to `gtimeout` (coreutils via Homebrew) or runs without a timeout if neither is available — consistent with how all other scripts in Shipwright handle this

## Test plan

- [x] Ran `scripts/sw-lib-pipeline-stages-test.sh` — all 34 tests pass including `stage_plan`
- [x] Verified the existing `mock_binary "timeout"` in the test harness continues to work correctly since `_timeout` calls `timeout` when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)