### PR TITLE
fix: ensure --disallowed-tools is terminated by a flag before prompt

### DIFF
--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -656,6 +656,7 @@ Fix these issues in the new plan."
 
                 claude --print --model "$plan_model" --max-turns 25 \
                     --disallowed-tools "EnterPlanMode,ExitPlanMode" \
+                    --dangerously-skip-permissions \
                     "$regen_prompt" < /dev/null > "$plan_file" 2>"$_token_log" || true
                 parse_claude_tokens "$_token_log"
 
@@ -859,8 +860,9 @@ ${_skill_prompts}
     fi
 
     local _token_log="${ARTIFACTS_DIR}/.claude-tokens-design.log"
-    claude --print --model "$design_model" --max-turns 25 --dangerously-skip-permissions \
+    claude --print --model "$design_model" --max-turns 25 \
         --disallowed-tools "EnterPlanMode,ExitPlanMode" \
+        --dangerously-skip-permissions \
         "$design_prompt" < /dev/null > "$design_file" 2>"$_token_log" || true
     parse_claude_tokens "$_token_log"
 


### PR DESCRIPTION
## Summary

- Fix 2 broken `--disallowed-tools` call sites where the prompt positional argument was consumed by the variadic flag parser
- Ensure `--dangerously-skip-permissions` always follows `--disallowed-tools` as a terminator before the prompt

Closes #229

## Root Cause

Claude CLI's `--disallowed-tools` is variadic (`<tools...>`) — it consumes all subsequent non-flag arguments until it hits another `--` flag. At 2 of the 10 call sites added in PR #228, the prompt followed directly and was eaten as a tool name.

## Changes

| Line | Before | After |
|------|--------|-------|
| 658 | `--disallowed-tools "..." "$regen_prompt"` (missing `--dangerously-skip-permissions` entirely) | `--disallowed-tools "..." --dangerously-skip-permissions "$regen_prompt"` |
| 862 | `--dangerously-skip-permissions --disallowed-tools "..." "$design_prompt"` | `--disallowed-tools "..." --dangerously-skip-permissions "$design_prompt"` |

## Test plan

- [x] `sw-pipeline-test.sh` — 58/58 passed
- [x] `sw-loop-test.sh` — 119/119 passed
- [x] Audited all 10 `--disallowed-tools` sites — remaining 8 are safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)