### PR TITLE
fix: inject quality gates passed hint when loop silently continues (#234)

### DIFF
--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -1351,11 +1351,24 @@ else
 fi
 
 # Test: GATES_PASSED_NO_SIGNAL is only set when COMPLETION_REJECTED is not true
-if grep -A5 'GATES_PASSED_NO_SIGNAL=true' "$SCRIPT_DIR/sw-loop.sh" | grep -qv 'COMPLETION_REJECTED.*true' || \
-   grep -B3 'GATES_PASSED_NO_SIGNAL=true' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'COMPLETION_REJECTED.*!=.*true'; then
+if grep -B3 'GATES_PASSED_NO_SIGNAL=true' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'COMPLETION_REJECTED.*!=.*true'; then
     assert_pass "GATES_PASSED_NO_SIGNAL=true guarded by COMPLETION_REJECTED check"
 else
     assert_fail "GATES_PASSED_NO_SIGNAL=true guarded by COMPLETION_REJECTED check"
+fi
+
+# Test: GATES_PASSED_NO_SIGNAL is only set when QUALITY_GATES_ENABLED
+if grep -B5 'GATES_PASSED_NO_SIGNAL=true' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'QUALITY_GATES_ENABLED'; then
+    assert_pass "GATES_PASSED_NO_SIGNAL=true guarded by QUALITY_GATES_ENABLED check"
+else
+    assert_fail "GATES_PASSED_NO_SIGNAL=true guarded by QUALITY_GATES_ENABLED check"
+fi
+
+# Test: GATES_PASSED_NO_SIGNAL is only set when audit passed
+if grep -B5 'GATES_PASSED_NO_SIGNAL=true' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'AUDIT_RESULT'; then
+    assert_pass "GATES_PASSED_NO_SIGNAL=true guarded by AUDIT_RESULT check"
+else
+    assert_fail "GATES_PASSED_NO_SIGNAL=true guarded by AUDIT_RESULT check"
 fi
 
 # Test: compose_rejection_notice_section handles GATES_PASSED_NO_SIGNAL branch
@@ -1379,11 +1392,18 @@ else
     assert_fail "compose_rejection_notice_section() still handles COMPLETION_REJECTED path"
 fi
 
-# Test: GATES_PASSED_NO_SIGNAL reset after use (no state leak into next iteration)
-if grep -A20 'GATES_PASSED_NO_SIGNAL.*true' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'GATES_PASSED_NO_SIGNAL=false'; then
-    assert_pass "GATES_PASSED_NO_SIGNAL reset to false after use (no state leak)"
+# Test: COMPLETION_REJECTED and GATES_PASSED_NO_SIGNAL reset at top of each iteration
+# (not inside compose_rejection_notice_section subshell where resets are no-ops)
+if grep -A5 'Reset per-iteration completion signal flags' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'COMPLETION_REJECTED=false'; then
+    assert_pass "COMPLETION_REJECTED reset in main loop before prompt build (not in subshell)"
 else
-    assert_fail "GATES_PASSED_NO_SIGNAL reset to false after use (no state leak)"
+    assert_fail "COMPLETION_REJECTED reset in main loop before prompt build (not in subshell)"
+fi
+
+if grep -A5 'Reset per-iteration completion signal flags' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'GATES_PASSED_NO_SIGNAL=false'; then
+    assert_pass "GATES_PASSED_NO_SIGNAL reset in main loop before prompt build (not in subshell)"
+else
+    assert_fail "GATES_PASSED_NO_SIGNAL reset in main loop before prompt build (not in subshell)"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1527,7 +1527,6 @@ AUDIT_FEEDBACK
 
 compose_rejection_notice_section() {
     if $COMPLETION_REJECTED; then
-        COMPLETION_REJECTED=false
         cat <<'REJECTION'
 ## ⚠ Completion Rejected
 Your previous LOOP_COMPLETE was REJECTED because quality gates did not pass.
@@ -1535,10 +1534,9 @@ Review the audit feedback and test results above, fix the issues, then try again
 Do NOT output LOOP_COMPLETE until all quality checks pass.
 REJECTION
     elif [[ "${GATES_PASSED_NO_SIGNAL:-false}" == "true" ]]; then
-        GATES_PASSED_NO_SIGNAL=false
         cat <<'GATES_PASSED'
 ## ✓ Quality Gates Passed
-All quality checks passed on the previous iteration. If the goal is fully achieved, output LOOP_COMPLETE to finish the loop.
+All configured quality gates (tests, uncommitted changes, DoD) passed on the previous iteration. If the goal is fully achieved and any audit issues above are addressed, output LOOP_COMPLETE to finish the loop.
 GATES_PASSED
     fi
 }
@@ -2127,6 +2125,12 @@ run_single_agent_loop() {
         }
         ITERATION=$(( ITERATION + 1 ))
 
+        # Reset per-iteration completion signal flags before prompt is built.
+        # These cannot be reset inside compose_rejection_notice_section() because
+        # that function runs in a $(...) subshell and side effects don't persist.
+        COMPLETION_REJECTED=false
+        GATES_PASSED_NO_SIGNAL=false
+
         # Emit iteration start event for pipeline visibility
         if type emit_event >/dev/null 2>&1; then
             emit_event "loop.iteration_start" \
@@ -2354,9 +2358,13 @@ ${GOAL}"
             return 0
         fi
 
-        # If gates passed but agent never emitted LOOP_COMPLETE, hint next iteration
+        # If gates passed but agent never emitted LOOP_COMPLETE, hint next iteration.
+        # Only set when quality gates are actually enabled (disabled runs default
+        # QUALITY_GATE_PASSED=true unconditionally) and audit also passed.
         GATES_PASSED_NO_SIGNAL=false
-        if $QUALITY_GATE_PASSED && [[ "${COMPLETION_REJECTED:-false}" != "true" ]]; then
+        if $QUALITY_GATES_ENABLED && $QUALITY_GATE_PASSED && \
+           [[ "${COMPLETION_REJECTED:-false}" != "true" ]] && \
+           [[ "${AUDIT_RESULT:-pass}" == "pass" ]]; then
             GATES_PASSED_NO_SIGNAL=true
         fi
 


### PR DESCRIPTION
## Summary

- When quality gates pass but the agent doesn't emit `LOOP_COMPLETE`, the loop previously continued silently — the agent had no signal its work was sufficient
- This caused empty follow-up iterations (nothing left to implement) that tripped the circuit breaker on complete work
- Observed on #232: fix was complete in iteration 3, circuit breaker tripped in iteration 4

## Changes

**`scripts/sw-loop.sh`**
- After `guard_completion()`, sets `GATES_PASSED_NO_SIGNAL=true` when quality gates passed but `COMPLETION_REJECTED` is not set
- Updated `compose_rejection_notice_section()` with a second branch: injects a "Quality Gates Passed — output LOOP_COMPLETE to finish the loop" hint into the next iteration prompt
- Flag is reset after use to prevent state leaking across iterations

**`scripts/sw-loop-test.sh`**
- 6 new tests covering: flag set correctly, hint injected, state reset, existing rejection path unchanged, mutual exclusivity of the two branches

## Design notes

The dual-condition requirement (agent signal + harness verification) is preserved — this is feedback only, not auto-acceptance. The asymmetry between the two rejection paths is now closed:

| Scenario | Agent feedback |
|---|---|
| LOOP_COMPLETE emitted + gates fail | Rejection notice injected ✓ (existing) |
| LOOP_COMPLETE not emitted + gates pass | Quality gates passed hint injected ✓ (new) |

## Test plan

- [x] All 125 loop tests pass (`bash scripts/sw-loop-test.sh`)
- [x] 6 new tests covering the `GATES_PASSED_NO_SIGNAL` logic all pass

Closes #234
Related to #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)