### PR TITLE
fix(ci): install bubblewrap/socat and increase smoke timeout to fix integration-claude

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install dependencies
         if: env.SKIP_CLAUDE != 'true'
-        run: sudo apt-get update && sudo apt-get install -y tmux jq
+        run: sudo apt-get update && sudo apt-get install -y tmux jq bubblewrap socat
 
       - name: Install Claude Code CLI
         if: env.SKIP_CLAUDE != 'true'

--- a/scripts/sw-integration-claude-test.sh
+++ b/scripts/sw-integration-claude-test.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/lib/test-helpers.sh"
 # shellcheck disable=SC2034
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUDGET_TARGET_USD="0.25"
-SCRIPT_TIMEOUT=120
+SCRIPT_TIMEOUT=180
 
 # ─── Skip when no Claude auth (CI without secret, local dev) ─────────────────
 if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]] && [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then


### PR DESCRIPTION
## Summary

- Install `bubblewrap` and `socat` in the `integration-claude` job's apt-get step so Claude Code's sandbox starts cleanly (eliminates the startup-overhead warning path)
- Increase `SCRIPT_TIMEOUT` from 120s to 180s in `sw-integration-claude-test.sh` to give cold GitHub Actions runners adequate headroom

## Root cause

The `integration-claude` CI job failed on the #246 merge with `FAIL: Claude smoke timed out after 120s` (exit code 124). The stderr showed `⚠ Sandbox disabled: bubblewrap (bwrap) not installed, socat not installed`. The workflow only installed `tmux jq` — sandbox dependencies were missing, adding startup overhead. The 120s timeout was too tight for the cold runner.

## Test plan

- [ ] CI `integration-claude` job passes on this branch
- [ ] Sandbox warning no longer appears in step log
- [ ] Smoke test completes well under 180s

🤖 Generated with [Claude Code](https://claude.com/claude-code)