### PR TITLE
fix(loop): remove --json-schema from DoD gate, add empty-output guard

### DIFF
--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -1548,11 +1548,25 @@ else
     assert_pass "DoD diff is not truncated with head -200"
 fi
 
-# Test: DoD uses --json-schema for structured output
+# Test: DoD does NOT use --json-schema (flag causes empty output — see #253)
 if grep -A5 'dod_flags' "$SCRIPT_DIR/sw-loop.sh" | grep -q '\-\-json-schema'; then
-    assert_pass "DoD evaluator uses --json-schema for structured output"
+    assert_fail "DoD evaluator must NOT use --json-schema (causes empty claude -p output)"
 else
-    assert_fail "DoD evaluator uses --json-schema for structured output"
+    assert_pass "DoD evaluator does not use --json-schema"
+fi
+
+# Test: DoD prompt embeds explicit JSON format instruction (replaces CLI schema enforcement)
+if grep -q 'Respond with ONLY a JSON object' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "DoD prompt embeds explicit JSON format instruction"
+else
+    assert_fail "DoD prompt embeds explicit JSON format instruction"
+fi
+
+# Test: DoD has empty-output guard before verdict parsing (surfaces broken CLI invocations)
+if grep -q 'claude -p returned empty output' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "DoD has empty-output guard with diagnostic warning"
+else
+    assert_fail "DoD has empty-output guard with diagnostic warning"
 fi
 
 # Test: DoD verdict parsed from JSON verdict field (not plain text DOD_PASS)

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1301,7 +1301,8 @@ ${diff_content}
 For each item in the Definition of Done, determine if the project satisfies it.
 The runtime facts above are verified by the harness — trust them as ground truth.
 
-IMPORTANT: You MUST respond using the exact JSON schema provided. No prose, no hedging.
+IMPORTANT: Respond with ONLY a JSON object — no prose, no markdown fences. Format:
+{"verdict":"pass","items":[{"item":"...","satisfied":true,"reason":"..."}],"summary":"..."}
 - Set "verdict" to "pass" if ALL items are satisfied. Set it to "fail" if ANY item is not satisfied.
 - For each DoD item, add an entry to "items" with the item text and whether it passes.
 - In "summary", briefly explain your verdict (1-2 sentences max).
@@ -1310,10 +1311,8 @@ DOD_PROMPT
     local dod_log="$LOG_DIR/dod-iter-${ITERATION}.log"
     local dod_model
     dod_model="$(select_audit_model)"
-    local dod_schema='{"type":"object","properties":{"verdict":{"type":"string","enum":["pass","fail"]},"items":{"type":"array","items":{"type":"object","properties":{"item":{"type":"string"},"satisfied":{"type":"boolean"},"reason":{"type":"string"}},"required":["item","satisfied"]}},"summary":{"type":"string"}},"required":["verdict","items","summary"]}'
     local dod_flags=()
     dod_flags+=("--model" "$dod_model")
-    dod_flags+=("--json-schema" "$dod_schema")
     dod_flags+=("--disallowed-tools" "EnterPlanMode,ExitPlanMode")
     if $SKIP_PERMISSIONS; then
         dod_flags+=("--dangerously-skip-permissions")
@@ -1321,6 +1320,16 @@ DOD_PROMPT
 
     local dod_err_log="${dod_log%.log}-stderr.log"
     claude -p "$dod_prompt" "${dod_flags[@]}" > "$dod_log" 2>"$dod_err_log" || true
+
+    # Guard: if claude -p returned nothing, surface a diagnostic rather than silently failing.
+    local dod_log_bytes
+    dod_log_bytes="$(wc -c < "$dod_log" 2>/dev/null || echo "0")"
+    dod_log_bytes="${dod_log_bytes// /}"
+    if [[ ! -s "$dod_log" ]] || [[ "$dod_log_bytes" -le 2 ]]; then
+        warn "DoD: claude -p returned empty output — check CLI flags and model availability"
+        warn "DoD log: $dod_log (${dod_log_bytes} bytes), stderr: $dod_err_log"
+        return 1
+    fi
 
     # Parse structured JSON output: verdict field must be "pass"
     local dod_verdict


### PR DESCRIPTION
## Summary

- Removes `--json-schema` from the `claude -p` DoD invocation — the flag causes the CLI to return empty output silently (exit 0, 1-byte log, 0-byte stderr), making DoD always fail
- Embeds the expected JSON format directly in the prompt text to maintain structured output without the broken CLI flag
- Adds an explicit empty-output guard before verdict parsing so broken invocations surface a clear diagnostic warning instead of silently falling through to "not satisfied"
- Updates tests: flips the `--json-schema` assertion to verify absence, adds tests for the prompt format instruction and empty-output guard

## Root Cause

Commit `f7fa4c7` (PR #236) introduced `--json-schema "$dod_schema"` to `dod_flags`. This flag causes `claude -p` to return nothing — old DoD logs were 1716–2176 bytes; current logs are 1 byte. The `DOD_PASS` grep fallback also fails since the output is empty, not just unparseable JSON.

The loop never exits because the circuit breaker resets `CONSECUTIVE_FAILURES=0` whenever tests pass (intentional design), and auto-extend keeps adding iterations while DoD fails.

## Test plan

- [x] `./scripts/sw-pipeline-test.sh` — 60/60 pass
- [x] `./scripts/sw-loop-test.sh` — 160/160 pass (includes 3 new DoD-specific assertions)
- [ ] Live loop run: confirm `dod-iter-N.log` is non-empty and `jq -r '.verdict'` returns `"pass"` or `"fail"`

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)