### PR TITLE
fix(loop): reject DoD pass verdict when items array is missing or empty

### DIFF
--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -1569,11 +1569,13 @@ else
     assert_fail "DoD has empty-output guard with diagnostic warning"
 fi
 
-# Test: DoD rejects pass verdict when items array is missing or empty (#253)
-if grep -q 'verdict is pass but items array is missing or empty' "$SCRIPT_DIR/sw-loop.sh"; then
-    assert_pass "DoD rejects pass verdict with missing items array"
+# Test: DoD rejects pass verdict when items is missing, not an array, or empty (#253)
+# The guard uses a type-checking jq expression so non-array items (string, object) are
+# also rejected — not just a missing or empty array.
+if grep -q 'verdict is pass but items array is missing, not an array, or empty' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "DoD rejects pass verdict when items is missing, not an array, or empty"
 else
-    assert_fail "DoD rejects pass verdict with missing items array"
+    assert_fail "DoD rejects pass verdict when items is missing, not an array, or empty"
 fi
 
 # Test: DoD verdict parsed from JSON verdict field (not plain text DOD_PASS)

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1339,10 +1339,10 @@ DOD_PROMPT
     # model skipped the per-item checklist evaluation — reject it as incomplete.
     if [[ "$dod_verdict" == "pass" ]]; then
         local dod_item_count
-        dod_item_count="$(jq '.items | length' "$dod_log" 2>/dev/null || echo "0")"
+        dod_item_count="$(jq 'if (.items | type) == "array" then (.items | length) else 0 end' "$dod_log" 2>/dev/null || echo "0")"
         dod_item_count="${dod_item_count// /}"
         if [[ "${dod_item_count:-0}" -eq 0 ]]; then
-            warn "DoD: verdict is pass but items array is missing or empty — treating as fail"
+            warn "DoD: verdict is pass but items array is missing, not an array, or empty — treating as fail"
             return 1
         fi
         echo -e "  ${GREEN}✓${RESET} Definition of Done: satisfied"


### PR DESCRIPTION
## Summary

Hardens DoD structural validation from #254 (re: #253).

- Replace `.items | length` with a type-checked jq expression: non-array `items` values (strings, objects) now also cause the pass verdict to be rejected, not just missing or empty arrays
- Update diagnostic warning message to reflect the broader check
- Update test assertion to match new warning text

## Test plan

- [x] `bash scripts/sw-loop-test.sh` — all DoD assertions pass including updated structural check
- [x] `npm test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)