### PR TITLE
fix(test): use dynamic epoch in cost dashboard test to prevent date drift

### DIFF
--- a/scripts/sw-cost-test.sh
+++ b/scripts/sw-cost-test.sh
@@ -196,18 +196,20 @@ else
 fi
 
 # Functional test: write mock events and verify dashboard parses them
-# Use a dynamic epoch (1 day ago) so the entry is always within the period window,
-# regardless of what date the CI runner reports.
+# Use dynamic timestamps (now - 24h) so the entry is always within the period window,
+# regardless of what date the CI runner reports. Both ts and ts_epoch are derived from
+# the same epoch so the fixture stays self-consistent.
 _mock_epoch=$(( $(date +%s) - 86400 ))
+_mock_ts=$(date -u -r "$_mock_epoch" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$_mock_epoch" +%Y-%m-%dT%H:%M:%SZ)
 mkdir -p "$TEST_TEMP_DIR/home/.shipwright"
-printf '{"ts":"2026-03-01T10:00:00Z","type":"loop.context_efficiency","iteration":"1","raw_prompt_chars":"200000","trimmed_prompt_chars":"180000","trim_ratio":"10.0","budget_utilization":"100.0","budget_chars":"180000","job_id":"test-1"}\n' \
-    > "$TEST_TEMP_DIR/home/.shipwright/events.jsonl"
-printf '{"ts":"2026-03-01T10:01:00Z","type":"loop.context_efficiency","iteration":"2","raw_prompt_chars":"150000","trimmed_prompt_chars":"150000","trim_ratio":"0.0","budget_utilization":"83.3","budget_chars":"180000","job_id":"test-1"}\n' \
-    >> "$TEST_TEMP_DIR/home/.shipwright/events.jsonl"
+printf '{"ts":"%s","type":"loop.context_efficiency","iteration":"1","raw_prompt_chars":"200000","trimmed_prompt_chars":"180000","trim_ratio":"10.0","budget_utilization":"100.0","budget_chars":"180000","job_id":"test-1"}\n' \
+    "$_mock_ts" > "$TEST_TEMP_DIR/home/.shipwright/events.jsonl"
+printf '{"ts":"%s","type":"loop.context_efficiency","iteration":"2","raw_prompt_chars":"150000","trimmed_prompt_chars":"150000","trim_ratio":"0.0","budget_utilization":"83.3","budget_chars":"180000","job_id":"test-1"}\n' \
+    "$_mock_ts" >> "$TEST_TEMP_DIR/home/.shipwright/events.jsonl"
 
 # Also need cost data for the dashboard to run
-printf '{"entries":[{"ts":"2026-03-01T10:00:00Z","ts_epoch":%d,"input_tokens":50000,"output_tokens":10000,"cost_usd":1.50,"model":"opus","stage":"build","issue":"1"}],"summary":{}}\n' \
-    "$_mock_epoch" > "$TEST_TEMP_DIR/home/.shipwright/costs.json"
+printf '{"entries":[{"ts":"%s","ts_epoch":%d,"input_tokens":50000,"output_tokens":10000,"cost_usd":1.50,"model":"opus","stage":"build","issue":"1"}],"summary":{}}\n' \
+    "$_mock_ts" "$_mock_epoch" > "$TEST_TEMP_DIR/home/.shipwright/costs.json"
 cat > "$TEST_TEMP_DIR/home/.shipwright/budget.json" <<'BUDEOF'
 {"daily_budget_usd":0,"enabled":false}
 BUDEOF


### PR DESCRIPTION
## Summary

- The hardcoded `ts_epoch` (1772125200 = 2026-02-26T17:00Z) in the cost dashboard functional test was 36 minutes outside the 30-day cutoff when the system clock reached 2026-03-28, causing CI to report "No cost entries in the last 30 day(s)."
- Replace with a runtime-computed epoch (`now - 24h`) so the mock entry is always within the 30-day period window regardless of when CI runs

## Test plan

- [x] `bash scripts/sw-cost-test.sh` — all cost tests pass including "Dashboard renders CONTEXT EFFICIENCY with event data" and "Dashboard shows avg budget utilization"
- [x] `npm test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)