### PR TITLE
fix(loop): exit when all gates pass regardless of commits (#271)

### DIFF
--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -1790,6 +1790,41 @@ else
     assert_fail "early exit runs run_holistic_gate before completing"
 fi
 
+# Test: holistic gate prompt includes actual diff content (not just stats)
+if grep -q 'branch_diff' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "holistic gate collects branch_diff for prompt"
+else
+    assert_fail "holistic gate collects branch_diff for prompt"
+fi
+
+# Test: holistic gate prompt includes Evaluation Rules with default-to-FAIL bias
+if grep -q 'Default to FAIL' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "holistic gate prompt has default-to-FAIL conservative bias"
+else
+    assert_fail "holistic gate prompt has default-to-FAIL conservative bias"
+fi
+
+# Test: holistic gate prompt requires per-component goal verification
+if grep -q 'each distinct component' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "holistic gate prompt requires per-component goal verification"
+else
+    assert_fail "holistic gate prompt requires per-component goal verification"
+fi
+
+# Test: branch_diff is sanitized to prevent delimiter injection
+if grep -q 'REDACTED:HOLISTIC:PASS\|REDACTED:HOLISTIC:FAIL' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "branch_diff sanitized to prevent holistic gate delimiter injection"
+else
+    assert_fail "branch_diff sanitized to prevent holistic gate delimiter injection"
+fi
+
+# Test: diff truncation notice in prompt (so model knows to rely on stats for large branches)
+if grep -q 'may be truncated' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "holistic gate prompt notes diff may be truncated"
+else
+    assert_fail "holistic gate prompt notes diff may be truncated"
+fi
+
 # Test: new_commits recomputed after post-audit cleanup commit
 if grep -B5 'Quality gates' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'commits_after_cleanup'; then
     assert_pass "new_commits recomputed after post-audit cleanup"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1488,7 +1488,12 @@ run_holistic_gate() {
         || git -C "$PROJECT_ROOT" merge-base "$base_branch" HEAD 2>/dev/null || echo "")"
     if [[ -n "$merge_base" ]]; then
         branch_stat="$(git -C "$PROJECT_ROOT" diff --stat "${merge_base}..HEAD" 2>/dev/null | head -40 || echo "(none)")"
-        branch_diff="$(git -C "$PROJECT_ROOT" diff "${merge_base}..HEAD" 2>/dev/null | head -150 || echo "(none)")"
+        # Cap at 300 lines and sanitize gate delimiter tokens to prevent prompt injection
+        # via diff content that happens to contain <<<HOLISTIC:PASS>>> or similar strings.
+        branch_diff="$(git -C "$PROJECT_ROOT" diff "${merge_base}..HEAD" 2>/dev/null \
+            | head -300 \
+            | sed 's/<<<HOLISTIC:PASS>>>/[REDACTED:HOLISTIC:PASS]/g; s/<<<HOLISTIC:FAIL>>>/[REDACTED:HOLISTIC:FAIL]/g' \
+            || echo "(none)")"
     else
         branch_stat="(unable to determine base)"
         branch_diff="(unable to determine base)"
@@ -1521,13 +1526,13 @@ ${branch_stat}
 NOTE: If the loop was restarted after prior work, "this loop run" may show only minor fixes
 while "full branch" shows the complete feature. Use the full branch diff to judge goal achievement.
 
-## Full Branch Diff (first 150 lines — read this to verify what actually changed)
+## Full Branch Diff (first 300 lines — may be truncated; rely on stats above for files not shown)
 ${branch_diff}
 
 ## Evaluation Rules
 - Default to FAIL. Only output PASS if you are certain every component of the goal is complete.
 - Partial completion is FAIL. Gaps in test coverage for new behavior are FAIL.
-- If the diff above is insufficient to judge completeness, that is FAIL.
+- If the diff is truncated, use the stats section above to assess files not shown; do not FAIL solely due to truncation.
 
 ## Your Task
 For each distinct component of the goal, explicitly state whether it is complete or missing.


### PR DESCRIPTION
## Summary

- Removes the `new_commits == 0` guard from the early-exit path so the loop exits as soon as all quality gates pass, even when the agent made commits in that iteration
- Strengthens the holistic gate prompt with actual diff content (`git diff`, capped 150 lines), a conservative default-to-FAIL bias, and per-component goal verification
- Updates event name `loop.early_exit_no_changes` → `loop.early_exit_gates_passed` and log message to reflect the new behavior

Closes #271

## Root Cause

The fallback early-exit (`GATES_PASSED_NO_SIGNAL=true && new_commits == 0 && run_holistic_gate`) was introduced as a safety net because the holistic gate wasn't reliable enough to be the sole arbiter. This made the loop unable to exit in the most common success scenario: agent finishes work, makes commits, all gates pass.

The holistic gate already fires during the gate check pipeline (line ~1452) and can pass there — but the loop still didn't exit because the only fallback exit required zero commits. The fix makes the holistic gate reliable enough to trust, then removes the guard.

## Test plan

- [x] All 1119 existing tests pass (`npm test`)
- [ ] Loop exits in the same iteration the agent finishes work (no extra idle iteration required)
- [ ] Partial completion fails holistic gate and loop continues
- [ ] Restart on already-complete work still exits cleanly
- [ ] Circuit breaker still trips after 3 low-progress iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)