### PR TITLE
fix(daemon): skip patrol and decision engine while daemon is auth-paused

### DIFF
--- a/scripts/lib/daemon-poll.sh
+++ b/scripts/lib/daemon-poll.sh
@@ -1221,9 +1221,16 @@ daemon_poll_loop() {
         active_count_now=$(get_active_count || echo 0)
         if [[ "$issue_count_now" -eq 0 ]] && [[ "$active_count_now" -eq 0 ]]; then
             if [[ -f "$PAUSE_FLAG" ]]; then
-                # Daemon is paused (e.g. auth failure) — skip patrol and decision engine
-                daemon_log INFO "Daemon paused — skipping patrol and decision engine"
-                emit_event "patrol.skipped_paused" "reason=pause_flag"
+                # Daemon is paused (e.g. auth failure) — skip patrol and decision engine.
+                # Emit skip event at the same cadence patrol would normally run (PATROL_INTERVAL)
+                # to avoid replacing patrol spam with skip-event spam.
+                local now_e
+                now_e=$(now_epoch || date +%s)
+                if [[ $((now_e - LAST_PATROL_EPOCH)) -ge "$PATROL_INTERVAL" ]]; then
+                    daemon_log INFO "Daemon paused — skipping patrol and decision engine"
+                    emit_event "patrol.skipped_paused" "reason=pause_flag"
+                    LAST_PATROL_EPOCH=$now_e
+                fi
             else
                 local now_e
                 now_e=$(now_epoch || date +%s)

--- a/scripts/sw-daemon-test.sh
+++ b/scripts/sw-daemon-test.sh
@@ -957,17 +957,27 @@ test_patrol_untested_detection() {
 
 test_patrol_guards_quiet_period_when_paused() {
     local poll_src="$SCRIPT_DIR/lib/daemon-poll.sh"
-    # The quiet-period block must contain a PAUSE_FLAG check that gates both
-    # daemon_patrol and the decision engine — verify the guard exists in the block
-    grep -A 5 'issue_count_now.*-eq 0.*active_count_now.*-eq 0' "$poll_src" | grep -q 'PAUSE_FLAG' || \
-        { echo "daemon_poll_loop quiet-period block missing PAUSE_FLAG guard — patrol and decision engine run while paused"; return 1; }
-    # Both daemon_patrol and sw-decide.sh must appear inside the else branch (after the PAUSE_FLAG check)
+    # Extract the quiet-period if/else block
     local block
     block="$(awk '/issue_count_now.*-eq 0.*active_count_now.*-eq 0/,/^        fi$/' "$poll_src" 2>/dev/null || true)"
-    echo "$block" | grep -q 'daemon_patrol' || \
-        { echo "daemon_patrol not found inside quiet-period block"; return 1; }
-    echo "$block" | grep -q 'sw-decide.sh' || \
-        { echo "sw-decide.sh not found inside quiet-period block"; return 1; }
+    [[ -n "$block" ]] || \
+        { echo "Failed to locate daemon_poll_loop quiet-period block in daemon-poll.sh"; return 1; }
+    # Split into paused (then) branch and else branch on the first bare 'else'
+    local paused_branch else_branch
+    paused_branch="$(printf '%s\n' "$block" | sed '/^[[:space:]]*else[[:space:]]*$/,$d')"
+    else_branch="$(printf '%s\n' "$block" | sed '1,/^[[:space:]]*else[[:space:]]*$/d')"
+    [[ -n "$else_branch" ]] || \
+        { echo "Quiet-period block is missing an else branch — daemon_patrol/decision engine not guarded"; return 1; }
+    # daemon_patrol and sw-decide.sh must NOT be in the paused branch
+    echo "$paused_branch" | grep -q 'daemon_patrol' && \
+        { echo "daemon_patrol must not run while PAUSE_FLAG is set (found in paused branch)"; return 1; }
+    echo "$paused_branch" | grep -q 'sw-decide.sh' && \
+        { echo "sw-decide.sh must not run while PAUSE_FLAG is set (found in paused branch)"; return 1; }
+    # Both must appear in the else (active) branch
+    echo "$else_branch" | grep -q 'daemon_patrol' || \
+        { echo "daemon_patrol not found inside quiet-period else branch"; return 1; }
+    echo "$else_branch" | grep -q 'sw-decide.sh' || \
+        { echo "sw-decide.sh not found inside quiet-period else branch"; return 1; }
 }
 
 test_patrol_emits_skip_event() {
@@ -975,9 +985,13 @@ test_patrol_emits_skip_event() {
     # When paused, a patrol.skipped_paused event must be emitted for observability
     grep -q 'patrol.skipped_paused' "$poll_src" || \
         { echo "Missing patrol.skipped_paused event emission — skip not observable via events.jsonl"; return 1; }
-    # Must be inside the PAUSE_FLAG check (not unconditional)
-    grep -B 3 'patrol.skipped_paused' "$poll_src" | grep -q 'PAUSE_FLAG' || \
-        { echo "patrol.skipped_paused event not guarded by PAUSE_FLAG check"; return 1; }
+    # Must be emitted inside the PAUSE_FLAG-guarded block (not unconditionally)
+    local pause_block
+    pause_block="$(awk '/if \[\[ -f "\$PAUSE_FLAG" \]\]/{in_block=1} in_block{print} in_block && /^[[:space:]]*fi$/{exit}' "$poll_src" 2>/dev/null || true)"
+    [[ -n "$pause_block" ]] || \
+        { echo "if [[ -f \"\$PAUSE_FLAG\" ]] block not found in daemon-poll.sh"; return 1; }
+    echo "$pause_block" | grep -q 'patrol.skipped_paused' || \
+        { echo "patrol.skipped_paused event not emitted inside PAUSE_FLAG-guarded block"; return 1; }
 }
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
$(cat <<'EOF'
Closes #283

## Summary

- **Root cause**: `daemon_poll_loop()` quiet-period block ran `daemon_patrol --once` and the decision engine unconditionally when no issues were queued or active. During an auth-pause (`PAUSE_FLAG` set by `daemon_preflight_auth_check`), the queue is always empty — so patrol fired every cycle, producing 2,073 `patrol.started` events vs ~11 expected over 650 minutes. Patrol also calls `gh issue create`, making the problem self-compounding.
- **Fix**: Add a `PAUSE_FLAG` check inside the quiet-period block. When paused, emit `patrol.skipped_paused` for observability and skip both patrol and the decision engine. When not paused, behavior is unchanged.
- **Auto-resume**: `daemon_poll_issues()` already handles `resume_after` expiry and removes the pause flag, so patrol unblocks on the next cycle after resumption — no duplicate logic needed here.
- **Tests**: 2 new structural tests added (73 total, all passing).

## Test plan

- [x] `bash scripts/sw-daemon-test.sh` — 73/73 pass
- [x] `npm test` — no regressions
- [ ] Manual: start daemon, confirm `patrol.started` appears during quiet cycle → `touch ~/.shipwright/daemon-pause.flag` → confirm `patrol.skipped_paused` appears and no `patrol.started` → remove flag → confirm patrol resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)