### PR TITLE
fix(daemon): make pipeline shutdown timeouts configurable

### DIFF
--- a/scripts/sw-daemon-test.sh
+++ b/scripts/sw-daemon-test.sh
@@ -2061,6 +2061,38 @@ test_optimize_scheduled_via_self_optimize() {
     fi
 }
 
+test_shutdown_timeout_loaded_from_config() {
+    local daemon_src="$SCRIPT_DIR/sw-daemon.sh"
+    # load_config() must read both DAEMON_SHUTDOWN_TIMEOUT and PIPELINE_KILL_GRACE from config
+    if ! awk '/^load_config\(\)/{in_fn=1} in_fn && /^\}$/{in_fn=0} in_fn' "$daemon_src" \
+        | grep -q 'daemon_shutdown_timeout'; then
+        echo "DAEMON_SHUTDOWN_TIMEOUT not loaded from config in load_config()"
+        return 1
+    fi
+    if ! awk '/^load_config\(\)/{in_fn=1} in_fn && /^\}$/{in_fn=0} in_fn' "$daemon_src" \
+        | grep -q 'pipeline_kill_grace'; then
+        echo "PIPELINE_KILL_GRACE not loaded from config in load_config()"
+        return 1
+    fi
+}
+
+test_shutdown_timeout_used_in_cleanup() {
+    local daemon_src="$SCRIPT_DIR/sw-daemon.sh"
+    local pipeline_src="$SCRIPT_DIR/sw-pipeline.sh"
+    # cleanup_on_exit in sw-daemon.sh must reference DAEMON_SHUTDOWN_TIMEOUT (not hardcoded sleep 5)
+    if ! awk '/^cleanup_on_exit\(\)/{in_fn=1} in_fn && /^\}$/{in_fn=0} in_fn' "$daemon_src" \
+        | grep -q 'DAEMON_SHUTDOWN_TIMEOUT'; then
+        echo "cleanup_on_exit in sw-daemon.sh does not reference DAEMON_SHUTDOWN_TIMEOUT"
+        return 1
+    fi
+    # cleanup_on_exit in sw-pipeline.sh must reference PIPELINE_KILL_GRACE (not hardcoded sleep 2)
+    if ! awk '/^cleanup_on_exit\(\)/{in_fn=1} in_fn && /^\}$/{in_fn=0} in_fn' "$pipeline_src" \
+        | grep -q 'PIPELINE_KILL_GRACE'; then
+        echo "cleanup_on_exit in sw-pipeline.sh does not reference PIPELINE_KILL_GRACE"
+        return 1
+    fi
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2155,6 +2187,8 @@ main() {
         "test_daemon_single_instance_behavioral:SingleInstance: behavioral — live PID blocks, stale PID yields STALE"
         "test_optimize_not_spawned_in_reap:Optimize: optimize_full_analysis not spawned as background job in daemon-dispatch.sh"
         "test_optimize_scheduled_via_self_optimize:Optimize: daemon_self_optimize called on OPTIMIZE_INTERVAL cadence in poll loop"
+        "test_shutdown_timeout_loaded_from_config:ShutdownTimeout: DAEMON_SHUTDOWN_TIMEOUT and PIPELINE_KILL_GRACE loaded from config"
+        "test_shutdown_timeout_used_in_cleanup:ShutdownTimeout: cleanup_on_exit uses configurable variables not hardcoded sleeps"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-daemon.sh
+++ b/scripts/sw-daemon.sh
@@ -453,6 +453,16 @@ load_config() {
     SELF_OPTIMIZE=$(jq -r '.self_optimize // false' "$config_file")
     OPTIMIZE_INTERVAL=$(jq -r '.optimize_interval // '"$(type policy_get >/dev/null 2>&1 && policy_get ".daemon.optimize_interval_cycles" "10" || echo "10")"'' "$config_file")
 
+    # pipeline shutdown grace periods (seconds)
+    DAEMON_SHUTDOWN_TIMEOUT=$(jq -r '.daemon_shutdown_timeout // 30' "$config_file")
+    export DAEMON_SHUTDOWN_TIMEOUT
+    PIPELINE_KILL_GRACE=$(jq -r '.pipeline_kill_grace // 25' "$config_file")
+    export PIPELINE_KILL_GRACE
+    if [[ "$PIPELINE_KILL_GRACE" -ge "$DAEMON_SHUTDOWN_TIMEOUT" ]]; then
+        PIPELINE_KILL_GRACE=$((DAEMON_SHUTDOWN_TIMEOUT - 5))
+        daemon_log WARN "pipeline_kill_grace >= daemon_shutdown_timeout — clamped to ${PIPELINE_KILL_GRACE}s"
+    fi
+
     # intelligence engine settings (default "auto" = enable when Claude CLI available)
     INTELLIGENCE_ENABLED=$(jq -r '.intelligence.enabled // "auto"' "$config_file")
     INTELLIGENCE_CACHE_TTL=$(jq -r '.intelligence.cache_ttl_seconds // 3600' "$config_file")
@@ -645,8 +655,8 @@ cleanup_on_exit() {
                 fi
             done <<< "$child_pids"
             if [[ $killed -gt 0 ]]; then
-                daemon_log INFO "Sent SIGTERM to ${killed} pipeline process(es) — waiting 5s"
-                sleep 5
+                daemon_log INFO "Sent SIGTERM to ${killed} pipeline process(es) — waiting ${DAEMON_SHUTDOWN_TIMEOUT:-30}s"
+                sleep "${DAEMON_SHUTDOWN_TIMEOUT:-30}"
                 # Force-kill any that didn't exit
                 while IFS= read -r cpid; do
                     [[ -z "$cpid" ]] && continue

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -710,7 +710,7 @@ cleanup_on_exit() {
         _our_pgid=$(ps -o pgid= -p $$ 2>/dev/null | tr -d ' ') || true
         if [[ "${_our_pgid:-}" == "$$" ]]; then
             kill -- -$$ 2>/dev/null || true
-            sleep 2
+            sleep "${PIPELINE_KILL_GRACE:-25}"
             kill -9 -- -$$ 2>/dev/null || true
         fi
     fi


### PR DESCRIPTION
## Summary

- Replaces hardcoded `sleep 5` in `sw-daemon.sh cleanup_on_exit` with `DAEMON_SHUTDOWN_TIMEOUT` (default 30s)
- Replaces hardcoded `sleep 2` in `sw-pipeline.sh cleanup_on_exit` with `PIPELINE_KILL_GRACE` (default 25s)
- Both values loaded from `daemon-config.json` and exported for subprocess inheritance
- Clamp guard: if `pipeline_kill_grace >= daemon_shutdown_timeout`, clamped to `daemon_shutdown_timeout - 5` with WARN log
- Updates daemon log message to reflect the variable value
- 2 new structural tests (77 total, all passing)

Fixes #286.

## Test plan

- [x] `bash scripts/sw-daemon-test.sh` — 77/77 passing
- [x] `npm test` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)