### PR TITLE
fix(workflow): pass issue metadata via env to prevent shell injection

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -117,10 +117,11 @@ jobs:
       - name: Vet issue alignment and determine strategy
         if: steps.skip.conclusion == 'skipped'
         id: triage
+        env:
+          TITLE: ${{ steps.issue.outputs.title }}
+          LABELS: ${{ steps.issue.outputs.labels }}
+          AUTHOR: ${{ steps.issue.outputs.author }}
         run: |
-          TITLE="${{ steps.issue.outputs.title }}"
-          LABELS="${{ steps.issue.outputs.labels }}"
-          AUTHOR="${{ steps.issue.outputs.author }}"
           BODY=$(cat /tmp/issue-body.txt 2>/dev/null || echo "")
 
           # Build triage prompt with strategy engine


### PR DESCRIPTION
## Summary
- Move `TITLE`, `LABELS`, `AUTHOR` from inline bash assignments to the step's `env:` block in the triage workflow step
- GitHub Actions handles quoting when values are passed via `env:`, preventing shell injection when issue titles contain double quotes

## Root Cause
The triage step used `TITLE="${{ steps.issue.outputs.title }}"` inline in bash. Any title containing `"` broke shell string parsing, causing `exit code 127: not: command not found`.

## Test plan
- [ ] Create a test issue with double quotes in the title (e.g. `Test "quoted" title`)
- [ ] Verify the triage workflow step completes without shell errors

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)