### PR TITLE
fix(compound-audit): inject full file contents into audit prompts

### DIFF
--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -65,7 +65,7 @@ Do NOT report non-edge-case issues."
 # ─── compound_audit_build_prompt ───────────────────────────────────────────
 # Builds the full prompt for a specific agent type.
 #
-# Usage: compound_audit_build_prompt "logic" "$diff" "$plan" "$prev_findings_json" "$test_evidence" "$file_contents"
+# Usage: compound_audit_build_prompt "logic" "$diff" "$plan" "$prev_findings_json" ["$test_evidence"] ["$file_contents"]
 compound_audit_build_prompt() {
     local agent_type="$1"
     local diff="$2"
@@ -94,8 +94,8 @@ The diff shows CHANGES only — not the complete codebase.
     local file_contents_section=""
     if [[ -n "$file_contents" ]]; then
         file_contents_section="
-## Current File State (complete files as they exist right now)
-This is ground truth. The diff above shows CHANGES only.
+## Current File State (HEAD/committed versions of all changed files)
+This is ground truth from the repository HEAD. The diff above shows CHANGES only.
 Use this section to verify imports, function definitions, and symbols before flagging them.
 
 VERIFICATION RULE: Before reporting any finding about a missing import, undefined symbol,
@@ -252,7 +252,7 @@ compound_audit_collect_file_contents() {
 
         local content_len="${#content}"
         if [[ $((total_chars + content_len)) -gt "$max_chars" ]]; then
-            output="${output}### ${file} (${line_count} lines — skipped: 40k char budget exhausted)${nl}${nl}"
+            output="${output}### ${file} (${line_count} lines — skipped: char budget exhausted at ${max_chars})${nl}${nl}"
             continue
         fi
 

--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -65,13 +65,14 @@ Do NOT report non-edge-case issues."
 # ─── compound_audit_build_prompt ───────────────────────────────────────────
 # Builds the full prompt for a specific agent type.
 #
-# Usage: compound_audit_build_prompt "logic" "$diff" "$plan" "$prev_findings_json" "$test_evidence"
+# Usage: compound_audit_build_prompt "logic" "$diff" "$plan" "$prev_findings_json" "$test_evidence" "$file_contents"
 compound_audit_build_prompt() {
     local agent_type="$1"
     local diff="$2"
     local plan_summary="$3"
     local prev_findings="$4"
     local test_evidence="${5:-}"
+    local file_contents="${6:-}"
 
     # Get agent-specific instructions
     local varname="_COMPOUND_AGENT_PROMPTS_${agent_type}"
@@ -90,6 +91,21 @@ The diff shows CHANGES only — not the complete codebase.
 "
     fi
 
+    local file_contents_section=""
+    if [[ -n "$file_contents" ]]; then
+        file_contents_section="
+## Current File State (complete files as they exist right now)
+This is ground truth. The diff above shows CHANGES only.
+Use this section to verify imports, function definitions, and symbols before flagging them.
+
+VERIFICATION RULE: Before reporting any finding about a missing import, undefined symbol,
+absent function, or unresolved reference — first search the 'Current File State' section
+below. If the symbol appears there, do NOT report it as missing.
+
+${file_contents}
+"
+    fi
+
     cat <<EOF
 ${specialization}
 
@@ -104,6 +120,7 @@ ${plan_summary}
 ## Previously Found Issues (do NOT repeat these)
 ${prev_findings}
 ${evidence_section}
+${file_contents_section}
 ## Output Format
 Return ONLY valid JSON (no markdown, no explanation):
 {"findings":[{"severity":"critical|high|medium|low","category":"${agent_type}","file":"path/to/file","line":0,"description":"One sentence","evidence":"The specific code","suggestion":"How to fix"}]}
@@ -178,6 +195,73 @@ _COMPOUND_TRIGGERS_security="injection|auth|secret|credential|permission|bypass|
 _COMPOUND_TRIGGERS_error_handling="catch|swallow|silent|ignore.*error|missing.*error|unchecked|unhandled"
 _COMPOUND_TRIGGERS_performance="O\\(n|loop.*loop|unbounded|pagination|cache|memory.*leak|quadratic"
 _COMPOUND_TRIGGERS_edge_case="boundary|empty.*input|null.*check|zero.*length|unicode|concurrent|race"
+
+# ─── compound_audit_collect_file_contents ──────────────────────────────────
+# Collects current full-file content for all files changed vs BASE_BRANCH.
+# Binary files, deleted files, and files exceeding 800 lines are marked with
+# a skip reason; the total char budget defaults to 40,000.
+#
+# Usage: compound_audit_collect_file_contents [max_chars=40000]
+# Output: Multi-file fenced block with real newlines, or empty string.
+compound_audit_collect_file_contents() {
+    local max_chars="${1:-40000}"
+    local base="${BASE_BRANCH:-main}"
+    local total_chars=0
+    local nl=$'\n'
+    local output=""
+
+    # --no-renames: ensures renamed files appear as delete+add pairs so the
+    # path field is a single real path (not "old => new" syntax that breaks
+    # every downstream git show / cat).
+    local numstat
+    numstat=$(git diff --no-renames --numstat "${base}...HEAD" 2>/dev/null) || return 0
+    [[ -z "$numstat" ]] && return 0
+
+    local added deleted file
+    while IFS=$'\t' read -r added deleted file; do
+        [[ -z "$file" ]] && continue
+
+        # Binary files have "-" for both counts in numstat.
+        if [[ "$added" == "-" && "$deleted" == "-" ]]; then
+            output="${output}### ${file} (binary — skipped)${nl}${nl}"
+            continue
+        fi
+
+        # Deleted: absent from worktree AND absent from HEAD tree.
+        if [[ ! -e "$file" ]] && ! git cat-file -e "HEAD:${file}" 2>/dev/null; then
+            output="${output}### ${file} (deleted)${nl}${nl}"
+            continue
+        fi
+
+        # Prefer HEAD content (authoritative post-commit state); fall back to
+        # worktree for edge cases like staged-but-uncommitted files.
+        local content=""
+        content=$(git show "HEAD:${file}" 2>/dev/null) || content=$(cat "$file" 2>/dev/null) || {
+            output="${output}### ${file} (unreadable — skipped)${nl}${nl}"
+            continue
+        }
+
+        local line_count
+        line_count=$(printf '%s' "$content" | wc -l | tr -d ' ')
+        line_count=${line_count:-0}
+
+        if [[ "$line_count" -gt 800 ]]; then
+            output="${output}### ${file} (${line_count} lines — skipped: exceeds 800-line limit)${nl}${nl}"
+            continue
+        fi
+
+        local content_len="${#content}"
+        if [[ $((total_chars + content_len)) -gt "$max_chars" ]]; then
+            output="${output}### ${file} (${line_count} lines — skipped: 40k char budget exhausted)${nl}${nl}"
+            continue
+        fi
+
+        total_chars=$((total_chars + content_len))
+        output="${output}### ${file} (${line_count} lines)${nl}\`\`\`${nl}${content}${nl}\`\`\`${nl}${nl}"
+    done <<< "$numstat"
+
+    printf '%s' "$output"
+}
 
 # ─── compound_audit_escalate ──────────────────────────────────────────────
 # Scans findings for trigger keywords, returns space-separated specialist list.
@@ -277,7 +361,7 @@ compound_audit_converged() {
 # ─── compound_audit_run_cycle ─────────────────────────────────────────────
 # Runs multiple agents in parallel and collects their findings.
 #
-# Usage: compound_audit_run_cycle "logic integration completeness" "$diff" "$plan" "$prev_findings" $cycle "$test_evidence"
+# Usage: compound_audit_run_cycle "logic integration completeness" "$diff" "$plan" "$prev_findings" $cycle "$test_evidence" "$file_contents"
 # Output: Merged JSON array of all findings
 compound_audit_run_cycle() {
     local agents="$1"
@@ -286,6 +370,7 @@ compound_audit_run_cycle() {
     local prev_findings="$4"
     local cycle="$5"
     local test_evidence="${6:-}"
+    local file_contents="${7:-}"
 
     local model="${COMPOUND_AUDIT_MODEL:-haiku}"
     local temp_dir
@@ -300,7 +385,7 @@ compound_audit_run_cycle() {
     local agent
     for agent in $agents; do
         local prompt
-        prompt=$(compound_audit_build_prompt "$agent" "$diff" "$plan_summary" "$prev_findings" "$test_evidence")
+        prompt=$(compound_audit_build_prompt "$agent" "$diff" "$plan_summary" "$prev_findings" "$test_evidence" "$file_contents")
 
         (
             local output

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1496,6 +1496,12 @@ stage_compound_quality() {
         _cascade_plan=$(head -200 "$ARTIFACTS_DIR/plan.md" 2>/dev/null) || true
     fi
 
+    # Collect full file contents to provide ground truth for import/symbol verification
+    local _cascade_file_contents=""
+    if type compound_audit_collect_file_contents >/dev/null 2>&1; then
+        _cascade_file_contents=$(compound_audit_collect_file_contents 40000 2>/dev/null) || _cascade_file_contents=""
+    fi
+
     # Capture test evidence to prevent "diff=codebase" false criticals in audit agents
     local _cascade_test_evidence=""
     local _cascade_test_log="$ARTIFACTS_DIR/test-results.log"
@@ -1717,7 +1723,7 @@ ${_cascade_test_tail}"
             info "Running compound audit cascade (agents: $_cascade_active_agents)..."
 
             local cascade_findings
-            cascade_findings=$(compound_audit_run_cycle "$_cascade_active_agents" "$_cascade_diff" "$_cascade_plan" "$_cascade_all_findings" "$cycle" "$_cascade_test_evidence") || cascade_findings="[]"
+            cascade_findings=$(compound_audit_run_cycle "$_cascade_active_agents" "$_cascade_diff" "$_cascade_plan" "$_cascade_all_findings" "$cycle" "$_cascade_test_evidence" "$_cascade_file_contents") || cascade_findings="[]"
 
             # Dedup within this cycle
             if type compound_audit_dedup_structural >/dev/null 2>&1; then
@@ -1970,6 +1976,9 @@ All quality checks clean:
                     warn "Git diff failed after rebuild — cascade will operate without diff context"
                 elif [[ $(echo "$_cascade_diff" | wc -l) -ge 5000 ]]; then
                     warn "Diff may be truncated at 5000 lines — audit findings for files beyond this limit may be incomplete"
+                fi
+                if type compound_audit_collect_file_contents >/dev/null 2>&1; then
+                    _cascade_file_contents=$(compound_audit_collect_file_contents 40000 2>/dev/null) || _cascade_file_contents=""
                 fi
                 _cascade_prebuild_commit="$_post_rebuild_commit"
             else

--- a/scripts/sw-lib-compound-audit-test.sh
+++ b/scripts/sw-lib-compound-audit-test.sh
@@ -544,7 +544,7 @@ _repo=$(_setup_collect_repo "4")
     git -c user.email=t@t -c user.name=t commit -q -m modify
 )
 result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
-assert_contains "Budget exhausted marker present" "$result" "budget exhausted"
+assert_contains "Budget exhausted marker present" "$result" "char budget exhausted at 40000"
 
 # Test 5: deleted file marker
 _repo=$(_setup_collect_repo "5")

--- a/scripts/sw-lib-compound-audit-test.sh
+++ b/scripts/sw-lib-compound-audit-test.sh
@@ -89,6 +89,34 @@ assert_contains "Do NOT flag guard present in prompt" "$result" "Do NOT flag"
 result=$(compound_audit_build_prompt "logic" "diff" "plan" "[]" "95 PASS | 0 FAIL")
 assert_contains "Output Format section present after evidence" "$result" "Output Format"
 
+# Test: Current File State section absent when file_contents is empty
+result=$(compound_audit_build_prompt "logic" "diff" "plan" "[]" "" "")
+if echo "$result" | grep -q "Current File State"; then
+    assert_fail "No Current File State section when file_contents is empty"
+else
+    assert_pass "No Current File State section when file_contents is empty"
+fi
+
+# Test: Current File State section present when file_contents provided
+result=$(compound_audit_build_prompt "logic" "diff" "plan" "[]" "" "### foo.sh (10 lines)")
+assert_contains "Current File State section present" "$result" "Current File State"
+
+# Test: VERIFICATION RULE injected with file_contents
+assert_contains "VERIFICATION RULE present" "$result" "VERIFICATION RULE"
+
+# Test: file content appears verbatim
+result=$(compound_audit_build_prompt "logic" "diff" "plan" "[]" "" "### foo.sh (3 lines)"$'\n'"import FeedParsing")
+assert_contains "File content included verbatim" "$result" "import FeedParsing"
+
+# Test: Output Format section still present after file_contents injection
+result=$(compound_audit_build_prompt "logic" "diff" "plan" "[]" "" "### foo.sh (3 lines)")
+assert_contains "Output Format still present" "$result" "Output Format"
+
+# Test: 5-arg backward compat (no file_contents)
+result=$(compound_audit_build_prompt "logic" "diff --git a/x.sh" "plan" "[]" "95 PASS | 0 FAIL")
+assert_contains "5-arg caller: diff still present" "$result" "diff --git a/x.sh"
+assert_contains "5-arg caller: test evidence still present" "$result" "Test Evidence"
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # compound_audit_parse_findings
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -446,5 +474,161 @@ if [[ "$test_converged_val" != "true" ]]; then
 else
     assert_eq "false should allow loop re-entry" "pass" "fail"
 fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# compound_audit_collect_file_contents
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "compound_audit_collect_file_contents"
+
+_setup_collect_repo() {
+    local dir="$TEST_TEMP_DIR/collect-repo-$1"
+    mkdir -p "$dir"
+    (
+        cd "$dir"
+        git init -q -b main
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+        # Create a feature branch so diff main...HEAD shows changes
+        git checkout -q -b feature
+    )
+    echo "$dir"
+}
+
+# Test 1: empty when no changes
+_repo=$(_setup_collect_repo "1")
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null || true)
+if [[ -z "$result" ]]; then
+    assert_pass "Returns empty when no changed files"
+else
+    assert_fail "Returns empty when no changed files" "got: $result"
+fi
+
+# Test 2: fenced block with content
+_repo=$(_setup_collect_repo "2")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n# line 2\n' > foo.sh
+    git add foo.sh
+    git -c user.email=t@t -c user.name=t commit -q -m add
+    echo "# line 3" >> foo.sh
+    git add foo.sh
+    git -c user.email=t@t -c user.name=t commit -q -m modify
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+assert_contains "Fenced block header present" "$result" "### foo.sh"
+assert_contains "Fenced block content present" "$result" "import FeedParsing"
+
+# Test 3: 800-line skip marker
+_repo=$(_setup_collect_repo "3")
+(
+    cd "$_repo"
+    seq 1 801 | awk '{print "line " $1}' > big.sh
+    git add big.sh
+    git -c user.email=t@t -c user.name=t commit -q -m add
+    echo "# change" >> big.sh
+    git add big.sh
+    git -c user.email=t@t -c user.name=t commit -q -m modify
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+assert_contains "800-line skip marker present" "$result" "exceeds 800-line limit"
+
+# Test 4: 40k char budget exhausted
+_repo=$(_setup_collect_repo "4")
+(
+    cd "$_repo"
+    python3 -c "print('x' * 30000)" > a.sh
+    python3 -c "print('y' * 30000)" > b.sh
+    git add a.sh b.sh
+    git -c user.email=t@t -c user.name=t commit -q -m add
+    echo "# change" >> a.sh && echo "# change" >> b.sh
+    git add a.sh b.sh
+    git -c user.email=t@t -c user.name=t commit -q -m modify
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+assert_contains "Budget exhausted marker present" "$result" "budget exhausted"
+
+# Test 5: deleted file marker
+_repo=$(_setup_collect_repo "5")
+(
+    cd "$_repo"
+    # On main: add a file
+    git checkout -q main
+    echo "content" > del.sh
+    git add del.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "add on main"
+    # On feature: create the file from main then delete it (simulating removal)
+    git checkout -q feature
+    git pull -q origin main 2>/dev/null || git merge -q main 2>/dev/null || {
+        # Manual merge if automated merge fails
+        git reset -q --hard main
+    }
+    git rm -q del.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "delete on feature"
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+assert_contains "Deleted file marker present" "$result" "(deleted)"
+
+# Test 6: real newlines in output (not literal \n)
+_repo=$(_setup_collect_repo "6")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n' > foo.sh
+    git add foo.sh
+    git -c user.email=t@t -c user.name=t commit -q -m add
+    echo "# change" >> foo.sh
+    git add foo.sh
+    git -c user.email=t@t -c user.name=t commit -q -m modify
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+if printf '%s' "$result" | grep -q '^### foo.sh'; then
+    assert_pass "Output contains real newlines"
+else
+    assert_fail "Output contains real newlines" "first line: $(printf '%s' "$result" | head -1)"
+fi
+
+# Test 7: renamed files handled via --no-renames (delete+add pair)
+_repo=$(_setup_collect_repo "7")
+(
+    cd "$_repo"
+    # On main: add the original file
+    git checkout -q main
+    echo "content" > old.sh
+    git add old.sh
+    git -c user.email=t@t -c user.name=t commit -q -m "add old.sh on main"
+    # On feature: sync from main then rename
+    git checkout -q feature
+    git reset -q --hard main
+    git mv old.sh new.sh
+    git -c user.email=t@t -c user.name=t commit -q -m rename
+)
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 40000 2>/dev/null)
+assert_contains "Renamed file: old path marked deleted" "$result" "old.sh (deleted)"
+assert_contains "Renamed file: new path has content" "$result" "### new.sh"
+
+# Test 8: files beyond the 5000-line diff cap are still enumerated
+# This is the headline regression test for issue #341: proves the collector uses
+# git --numstat (not the truncated $_cascade_diff) so later files are covered.
+_repo=$(_setup_collect_repo "8")
+(
+    cd "$_repo"
+    i=1
+    while [[ $i -le 20 ]]; do
+        seq 1 300 | awk -v n="$i" '{print "file " n " line " $1}' > "file-${i}.sh"
+        i=$((i + 1))
+    done
+    git add .
+    git -c user.email=t@t -c user.name=t commit -q -m add-all
+    i=1
+    while [[ $i -le 20 ]]; do
+        echo "# modified" >> "file-${i}.sh"
+        i=$((i + 1))
+    done
+    git add .
+    git -c user.email=t@t -c user.name=t commit -q -m modify-all
+)
+# 20 × 300-line files = 6000+ lines combined diff (beyond 5000-line head cap).
+# With a generous budget all files should be enumerated, including file-20.sh.
+result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 200000 2>/dev/null)
+assert_contains "Many-file coverage: first file present" "$result" "### file-1.sh"
+assert_contains "Many-file coverage: 20th file still present" "$result" "### file-20.sh"
 
 print_test_results


### PR DESCRIPTION
## Summary

Fixes #341: Compound audit agents now receive complete file content for all changed files, not just truncated diffs, enabling accurate import/symbol verification.

**Problem:** `compound_audit_build_prompt()` only provided git diffs to agents. A diff shows ~3 lines of context around hunks, so unchanged code (e.g., `import FeedParsing` at line 1) is invisible when the nearest edit is 160+ lines away. This caused false "missing import" findings.

**Solution:** 
- New `compound_audit_collect_file_contents()` function collects full current-file content (with 800-line and 40k-char budgets)
- `build_prompt()` now injects a "Current File State" section with explicit verification rule: "Before reporting a missing import/symbol, search the Current File State section first"
- File contents collected before cascade loop and refreshed after code rebuild

## Test Plan

- All 74 existing compound-audit tests pass
- 6 new `build_prompt` tests (6-arg backward compat, Current File State section presence/absence, VERIFICATION RULE injection)
- 8 new `collect_file_contents` tests:
  1. Empty when no changed files
  2. Fenced block with real content
  3. 800-line skip marker
  4. 40k-char budget exhaustion
  5. Deleted file marker
  6. Real newlines (not literal \n)
  7. Renamed files (--no-renames shows delete+add pair)
  8. Many-file coverage (20 files × 300 lines each — proves collector uses git --numstat, not truncated diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)