### PR TITLE
feat(compound): drop hallucinated missing-symbol findings via structural verification (#342)

### DIFF
--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -222,13 +222,20 @@ compound_audit_verify_findings() {
     local findings="$1"
     [[ -z "$findings" || "$findings" == "[]" ]] && { echo "[]"; return 0; }
 
-    # Unambiguous absence phrasings. Intentionally excludes bare "missing" /
-    # "not defined" which match too much prose (e.g. "Missing null check for
-    # import stream" must not be matched).
+    # Unambiguous absence phrasings. Excludes standalone "missing" and plain
+    # "not defined" which match too much prose; "is not defined" is retained
+    # because it is a specific compiler/runtime diagnostic phrase.
+    # (e.g. "Missing null check for import stream" does NOT match — no
+    # "missing import" substring — while "X is not defined" does match.)
     local absence_pattern='missing import|not imported|undefined (symbol|reference|identifier)|undefined:|undeclared (identifier|type)|use of unresolved|use of undeclared|unresolved reference|cannot find .* in scope|cannot find name|no such (module|type|identifier)|is not defined'
 
     local count
-    count=$(echo "$findings" | jq 'length' 2>/dev/null || echo "0")
+    # Fail-open: if jq can't parse or count the array, return original findings
+    # unchanged rather than silently dropping everything.
+    if ! count=$(echo "$findings" | jq -e 'if type == "array" then length else error("expected array") end' 2>/dev/null); then
+        echo "$findings"
+        return 0
+    fi
     [[ "$count" -eq 0 ]] && { echo "[]"; return 0; }
 
     # Collect indices of findings to keep. Build the final array in one
@@ -247,6 +254,15 @@ compound_audit_verify_findings() {
         # Normalize path: strip leading ./ and collapse //
         file="${file#./}"
         while [[ "$file" == *//* ]]; do file="${file//\/\//\/}"; done
+
+        # Safety: reject absolute paths and directory traversal from the
+        # LLM-supplied file field before using it in git show / cat.
+        # Fail-open: unsafe paths are kept, not dropped.
+        if [[ "$file" == /* || "$file" == *../* || "$file" == */.. ]]; then
+            keep_indices="${keep_indices}${keep_indices:+,}${i}"
+            i=$((i + 1))
+            continue
+        fi
 
         if [[ -n "$file" ]] && echo "$combined" | grep -qiE "$absence_pattern" 2>/dev/null; then
             symbol=""

--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -190,6 +190,124 @@ compound_audit_dedup_structural() {
     ' 2>/dev/null || echo "$findings"
 }
 
+# ─── compound_audit_verify_findings ────────────────────────────────────────
+# Layer 2 hallucination filter. Drops findings where the LLM claims a symbol
+# is missing but structural verification proves the symbol is actually present
+# in the cited file. Complements the Layer 1 full-file-context prompt (#341).
+#
+# Ground truth: git show HEAD:<file> → cat <file>. This mirrors
+# compound_audit_collect_file_contents (line 239) so the verifier inspects
+# exactly the bytes the model saw in its prompt.
+#
+# Fail-open rules (any of these → keep the finding, never drop):
+#   1. Description + evidence doesn't match the absence pattern
+#   2. No symbol could be extracted from description + evidence
+#   3. File field is empty
+#   4. File is unreadable via both git show and cat
+#   5. grep exits non-zero (symbol genuinely not in file)
+#
+# Symbol extraction covers real-world LLM phrasings observed in practice:
+#   - "import X"                        (Swift, Go, TS, Python)
+#   - "cannot find 'X' in scope"        (Swift)
+#   - "Cannot find name 'X'"            (TypeScript)
+#   - "undefined: X"                    (Go)
+#   - "'X' is not defined"              (Python / plain English)
+# Identifiers may be lowercase. Surrounding quotes are stripped.
+# Multi-symbol claims: only the first symbol is verified. If present, drop —
+# Layer 1 full-file context is the right place for comprehensive analysis.
+#
+# Usage: compound_audit_verify_findings "$findings_json_array"
+# Output: Filtered JSON array on stdout.
+compound_audit_verify_findings() {
+    local findings="$1"
+    [[ -z "$findings" || "$findings" == "[]" ]] && { echo "[]"; return 0; }
+
+    # Unambiguous absence phrasings. Intentionally excludes bare "missing" /
+    # "not defined" which match too much prose (e.g. "Missing null check for
+    # import stream" must not be matched).
+    local absence_pattern='missing import|not imported|undefined (symbol|reference|identifier)|undefined:|undeclared (identifier|type)|use of unresolved|use of undeclared|unresolved reference|cannot find .* in scope|cannot find name|no such (module|type|identifier)|is not defined'
+
+    local count
+    count=$(echo "$findings" | jq 'length' 2>/dev/null || echo "0")
+    [[ "$count" -eq 0 ]] && { echo "[]"; return 0; }
+
+    # Collect indices of findings to keep. Build the final array in one
+    # jq pass at the end to avoid spawning a jq process per kept finding.
+    local keep_indices=""
+    local i=0
+    while [[ "$i" -lt "$count" ]]; do
+        local finding desc evidence file combined symbol keep
+        keep=1
+        finding=$(echo "$findings" | jq -c ".[$i]" 2>/dev/null)
+        desc=$(echo "$finding" | jq -r '.description // ""' 2>/dev/null)
+        evidence=$(echo "$finding" | jq -r '.evidence // ""' 2>/dev/null)
+        file=$(echo "$finding" | jq -r '.file // ""' 2>/dev/null)
+        combined="$desc $evidence"
+
+        # Normalize path: strip leading ./ and collapse //
+        file="${file#./}"
+        while [[ "$file" == *//* ]]; do file="${file//\/\//\/}"; done
+
+        if [[ -n "$file" ]] && echo "$combined" | grep -qiE "$absence_pattern" 2>/dev/null; then
+            symbol=""
+
+            # Priority 1: "import X" or "import {X}"
+            symbol=$(echo "$combined" | grep -oE "import[[:space:]]+\{?[A-Za-z_][A-Za-z0-9_]*" \
+                | grep -oE "[A-Za-z_][A-Za-z0-9_]*$" | grep -v '^import$' | head -1 || true)
+
+            # Priority 2: quoted symbol after "find" / "find name"
+            if [[ -z "$symbol" ]]; then
+                symbol=$(echo "$combined" | grep -oE "find( name)?[[:space:]]+['\"\`]?[A-Za-z_][A-Za-z0-9_]*" \
+                    | grep -oE "[A-Za-z_][A-Za-z0-9_]*$" | head -1 || true)
+            fi
+
+            # Priority 3: Go-style "undefined: X"
+            if [[ -z "$symbol" ]]; then
+                symbol=$(echo "$combined" | grep -oE "undefined:[[:space:]]*[A-Za-z_][A-Za-z0-9_]*" \
+                    | grep -oE "[A-Za-z_][A-Za-z0-9_]*$" | head -1 || true)
+            fi
+
+            # Priority 4: Python / plain English "'X' is not defined"
+            if [[ -z "$symbol" ]]; then
+                symbol=$(echo "$combined" \
+                    | grep -oE "['\"\`][A-Za-z_][A-Za-z0-9_]*['\"\`][[:space:]]+is not defined" \
+                    | grep -oE "[A-Za-z_][A-Za-z0-9_]*" | head -1 || true)
+            fi
+
+            if [[ -n "$symbol" ]]; then
+                # Fetch content the same way the prompt collector does:
+                # git show HEAD:file first, fall back to worktree cat.
+                local content=""
+                content=$(git show "HEAD:${file}" 2>/dev/null) \
+                    || content=$(cat "$file" 2>/dev/null) \
+                    || content=""
+
+                if [[ -n "$content" ]] && printf '%s' "$content" | grep -qwF -- "$symbol" 2>/dev/null; then
+                    # Symbol present → finding is a hallucination → drop it.
+                    keep=0
+                    type audit_emit >/dev/null 2>&1 && \
+                        audit_emit "compound.false_positive_dropped" \
+                            "symbol=$symbol" "file=$file" "description=$desc" || true
+                fi
+                # Empty content or grep miss → fall through to keep=1.
+            fi
+        fi
+
+        if [[ "$keep" -eq 1 ]]; then
+            keep_indices="${keep_indices}${keep_indices:+,}${i}"
+        fi
+        i=$((i + 1))
+    done
+
+    if [[ -z "$keep_indices" ]]; then
+        echo "[]"
+        return 0
+    fi
+
+    # Single jq pass to materialize the kept subset.
+    echo "$findings" | jq --argjson ks "[$keep_indices]" '[.[$ks[]]]' 2>/dev/null || echo "$findings"
+}
+
 # ─── Escalation trigger keywords ──────────────────────────────────────────
 _COMPOUND_TRIGGERS_security="injection|auth|secret|credential|permission|bypass|xss|csrf|traversal|sanitiz"
 _COMPOUND_TRIGGERS_error_handling="catch|swallow|silent|ignore.*error|missing.*error|unchecked|unhandled"
@@ -412,6 +530,10 @@ compound_audit_run_cycle() {
         if [[ -f "$agent_file" ]]; then
             local agent_findings
             agent_findings=$(compound_audit_parse_findings "$(cat "$agent_file")")
+
+            # Layer 2: drop LLM-hallucinated "missing symbol" findings before
+            # stamping, emitting, or merging into the accumulated set. (#342)
+            agent_findings=$(compound_audit_verify_findings "$agent_findings") || true
 
             # Stamp each finding with the commit it was discovered at
             if [[ -n "$current_commit" ]]; then

--- a/scripts/sw-lib-compound-audit-test.sh
+++ b/scripts/sw-lib-compound-audit-test.sh
@@ -631,4 +631,165 @@ result=$(cd "$_repo" && BASE_BRANCH=main compound_audit_collect_file_contents 20
 assert_contains "Many-file coverage: first file present" "$result" "### file-1.sh"
 assert_contains "Many-file coverage: 20th file still present" "$result" "### file-20.sh"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# compound_audit_verify_findings
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "compound_audit_verify_findings"
+
+# Helper: create a minimal git repo for verify_findings tests
+_setup_vf_repo() {
+    local dir="$TEST_TEMP_DIR/vf-repo-$1"
+    mkdir -p "$dir"
+    (
+        cd "$dir"
+        git init -q -b main
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    )
+    echo "$dir"
+}
+
+# Test 1 — Positive drop: capitalized import exists in cited file → drop
+_repo=$(_setup_vf_repo "1")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n# other code\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"foo.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Positive drop: hallucinated import finding removed" "0" "$count"
+
+# Test 2 — Wrong-file scope: symbol in bar.swift but finding cites foo.swift → keep
+_repo=$(_setup_vf_repo "2")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n' > bar.swift
+    printf '# unrelated\n' > foo.swift
+    git add bar.swift foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"foo.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Wrong-file scope: finding kept when symbol absent from cited file" "1" "$count"
+
+# Test 3 — Word-boundary safety: FooBarManager exists, not Foo → keep
+_repo=$(_setup_vf_repo "3")
+(
+    cd "$_repo"
+    printf 'class FooBarManager {}\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"high","category":"logic","file":"foo.swift","line":1,"description":"cannot find Foo in scope","evidence":"","suggestion":"import it"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Word boundary: FooBarManager does not satisfy missing Foo claim" "1" "$count"
+
+# Test 4 — Lowercase quoted Swift drop: func fetchFeed exists, finding says cannot find 'fetchFeed' → drop
+_repo=$(_setup_vf_repo "4")
+(
+    cd "$_repo"
+    printf 'func fetchFeed() { return [] }\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"foo.swift","line":1,"description":"cannot find '\''fetchFeed'\'' in scope","evidence":"","suggestion":"define it"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Lowercase quoted Swift: hallucinated find-quote finding dropped" "0" "$count"
+
+# Test 5 — Go-style undefined: drop: func parseBody exists → drop
+_repo=$(_setup_vf_repo "5")
+(
+    cd "$_repo"
+    printf 'func parseBody() error { return nil }\n' > foo.go
+    git add foo.go
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"foo.go","line":1,"description":"undefined: parseBody","evidence":"","suggestion":"define it"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Go-style undefined: hallucinated finding dropped" "0" "$count"
+
+# Test 6 — Lowercase no-symbol pass-through: "missing function parseXML" doesn't match absence pattern
+_findings='[{"severity":"medium","category":"logic","file":"foo.sh","line":5,"description":"missing function parseXML","evidence":"","suggestion":"add it"}]'
+result=$(compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "No-symbol pass-through: absence pattern does not match 'missing function'" "1" "$count"
+
+# Test 7 — Tight absence pattern: "Missing null check for import stream" must NOT be treated as symbol-absence
+_findings='[{"severity":"high","category":"logic","file":"foo.sh","line":10,"description":"Missing null check for import stream","evidence":"","suggestion":"add null check"}]'
+result=$(compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Tight pattern: 'Missing null check for import stream' is kept (not a symbol claim)" "1" "$count"
+
+# Test 8 — Path normalization: ./foo.swift normalizes to foo.swift → drop
+_repo=$(_setup_vf_repo "8")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"./foo.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Path normalization: ./foo.swift strips to foo.swift and drops correctly" "0" "$count"
+
+# Test 9 — Fail-open on unreadable file: nonexistent.swift → keep
+_repo=$(_setup_vf_repo "9")
+_findings='[{"severity":"critical","category":"integration","file":"nonexistent.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Fail-open: unreadable file keeps finding" "1" "$count"
+
+# Test 10 — Mixed array: 3 findings, 1 drop, 2 keep; accumulator correct
+_repo=$(_setup_vf_repo "10")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[
+  {"severity":"high","category":"logic","file":"bar.sh","line":5,"description":"off-by-one error in loop","evidence":"i <= len","suggestion":"use <"},
+  {"severity":"critical","category":"integration","file":"foo.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"},
+  {"severity":"medium","category":"completeness","file":"baz.sh","line":20,"description":"spec requirement unimplemented","evidence":"TODO","suggestion":"implement"}
+]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings")
+count=$(echo "$result" | jq 'length')
+assert_eq "Mixed array: 2 of 3 findings survive after drop" "2" "$count"
+assert_contains "Mixed array: first real finding preserved" "$result" "off-by-one"
+assert_contains "Mixed array: third real finding preserved" "$result" "spec requirement"
+
+# Test 11 — Regex metachar safety: $foo symbol must not crash verifier
+_repo=$(_setup_vf_repo "11")
+(
+    cd "$_repo"
+    printf 'some code\n' > foo.sh
+    git add foo.sh
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"high","category":"logic","file":"foo.sh","line":1,"description":"cannot find $foo in scope","evidence":"","suggestion":"fix"}]'
+result=$(cd "$_repo" && compound_audit_verify_findings "$_findings" 2>/dev/null)
+count=$(echo "$result" | jq 'length')
+assert_eq "Metachar safety: \$foo in description does not crash verifier" "1" "$count"
+
+# Test 12 — Audit event payload: drop event emitted with symbol= and file= fields
+_repo=$(_setup_vf_repo "12")
+(
+    cd "$_repo"
+    printf 'import FeedParsing\n' > foo.swift
+    git add foo.swift
+    git -c user.email=t@t -c user.name=t commit -q -m add
+)
+_findings='[{"severity":"critical","category":"integration","file":"foo.swift","line":1,"description":"missing import FeedParsing","evidence":"","suggestion":"add import"}]'
+(cd "$_repo" && compound_audit_verify_findings "$_findings") >/dev/null
+_event_line=$(grep "false_positive_dropped" "$ARTIFACTS_DIR/pipeline-audit.jsonl" 2>/dev/null | tail -1 || true)
+assert_contains "Audit event payload: symbol field present" "$_event_line" '"symbol":"FeedParsing"'
+assert_contains "Audit event payload: file field present" "$_event_line" '"file":"foo.swift"'
+
 print_test_results


### PR DESCRIPTION
## Summary

- Adds `compound_audit_verify_findings()` to `scripts/lib/compound-audit.sh` as a cheap **Layer 2 hallucination filter** that runs after each audit agent's findings are parsed, before commit-stamping and merging
- For findings matching tight absence phrases (`missing import`, `undefined:`, `cannot find X in scope`, etc.), extracts the cited symbol via a 4-priority chain (Swift/Go/TS/Python) and verifies it against the cited file using `git show HEAD:file || cat file` + `grep -wF`
- Drops the finding and emits `compound.false_positive_dropped` if the symbol is present; **fail-open** on any ambiguity
- Hooks into `compound_audit_run_cycle()` immediately after `compound_audit_parse_findings` so dropped hallucinations never reach dedup, escalation, convergence, or event emission as `compound.finding`
- 12 new test cases covering: positive drop, wrong-file scope, word-boundary safety, lowercase quoted Swift (`find 'X' in scope`), Go-style `undefined: X`, no-symbol pass-through, tight pattern regression (`Missing null check for import stream` must NOT match), path normalization (`./foo.swift`), fail-open on untracked file, mixed array accumulator integrity, regex metachar safety, audit event payload validation

## Test plan

- [x] `./scripts/sw-lib-compound-audit-test.sh` — 89/89 pass (74 pre-existing + 15 new assertions)
- [x] `npm test` — all suites pass; 2 pre-existing unrelated failures (`Feature flag disabled`, `PATH install`) unchanged
- [x] Code review via agent: zero high-confidence bugs found
- [ ] CI green on push

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)