### PR TITLE
fix(loop): GOAL pollution, circuit-breaker escape hatch, zero-progress blindness (#345)

### DIFF
--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -191,6 +191,22 @@ Fix these specific errors. Each line above is one distinct error from the test o
     local rejection_notice_section
     rejection_notice_section="$(compose_rejection_notice_section)"
 
+    # Zero-progress notice: fire when the previous iteration produced no new commits
+    # AND the quality gate is still failing. Without this, the agent reads passing
+    # tests + the same gate feedback and silently exits in seconds, making no changes.
+    local zero_progress_notice=""
+    if [[ "${PREV_NEW_COMMITS:-0}" -eq 0 ]] && [[ "${QUALITY_GATE_PASSED:-true}" == "false" ]]; then
+        zero_progress_notice="
+## Zero Progress Detected (IMPORTANT)
+Your previous iteration made NO new commits. The working tree is identical to before.
+Quality gates are still failing with the feedback shown above. You MUST either:
+  (a) make concrete code changes and commit them, OR
+  (b) state explicitly why the quality-gate feedback is incorrect, citing
+      specific file:line evidence — do not silently exit.
+Declaring LOOP_COMPLETE or exiting without committing code changes will not satisfy
+the holistic gate and will count toward the circuit-breaker failure limit."
+    fi
+
     # Memory context injection (failure patterns + past learnings)
     local memory_section=""
     if type memory_inject_context >/dev/null 2>&1; then
@@ -463,6 +479,8 @@ ${audit_feedback_section}
 ${holistic_feedback_section}
 
 ${rejection_notice_section}
+
+${zero_progress_notice}
 
 ${stuckness_section}
 

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -2311,12 +2311,19 @@ else
         "Expected ORIGINAL_GOAL:-\$GOAL in sw-loop.sh holistic prompt; got raw \${GOAL}"
 fi
 
-# Verify the fix is specifically inside run_holistic_gate, not elsewhere
-holistic_goal_line=$(grep -n 'ORIGINAL_GOAL:-\$GOAL' "$SCRIPT_DIR/sw-loop.sh" | head -1 || true)
-if [[ -n "$holistic_goal_line" ]]; then
-    assert_pass "Fix 1: ORIGINAL_GOAL:-\$GOAL present in sw-loop.sh"
+# Verify the fix is specifically inside run_holistic_gate (not just anywhere in the file)
+holistic_gate_block=$(
+    awk '
+        /^run_holistic_gate\(\)[[:space:]]*\{/ { in_fn=1 }
+        in_fn { print }
+        in_fn && /^\}/ { exit }
+    ' "$SCRIPT_DIR/sw-loop.sh" || true
+)
+if printf '%s\n' "$holistic_gate_block" | grep -q 'ORIGINAL_GOAL:-\$GOAL'; then
+    assert_pass "Fix 1: ORIGINAL_GOAL:-\$GOAL present inside run_holistic_gate"
 else
-    assert_fail "Fix 1: ORIGINAL_GOAL:-\$GOAL present in sw-loop.sh"
+    assert_fail "Fix 1: ORIGINAL_GOAL:-\$GOAL present inside run_holistic_gate" \
+        "Expected ORIGINAL_GOAL:-\$GOAL inside run_holistic_gate in sw-loop.sh"
 fi
 
 # ─── Fix 2: Circuit breaker escape hatch respects quality gates ──────────────

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -2294,6 +2294,102 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Bug fixes: loop stuckness — GOAL pollution, circuit-breaker escape hatch,
+# zero-progress blindness (#345)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${DIM}  loop stuckness fixes (#345)${RESET}"
+
+# ─── Fix 1: Holistic gate uses ORIGINAL_GOAL, not polluted GOAL ──────────────
+# run_holistic_gate() must inject ${ORIGINAL_GOAL:-$GOAL} so that feedback
+# accumulated in GOAL during a session does not poison the holistic assessment.
+if grep -q 'ORIGINAL_GOAL:-\$GOAL' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "Fix 1: holistic gate uses \${ORIGINAL_GOAL:-\$GOAL}"
+else
+    assert_fail "Fix 1: holistic gate uses \${ORIGINAL_GOAL:-\$GOAL}" \
+        "Expected ORIGINAL_GOAL:-\$GOAL in sw-loop.sh holistic prompt; got raw \${GOAL}"
+fi
+
+# Verify the fix is specifically inside run_holistic_gate, not elsewhere
+holistic_goal_line=$(grep -n 'ORIGINAL_GOAL:-\$GOAL' "$SCRIPT_DIR/sw-loop.sh" | head -1 || true)
+if [[ -n "$holistic_goal_line" ]]; then
+    assert_pass "Fix 1: ORIGINAL_GOAL:-\$GOAL present in sw-loop.sh"
+else
+    assert_fail "Fix 1: ORIGINAL_GOAL:-\$GOAL present in sw-loop.sh"
+fi
+
+# ─── Fix 2: Circuit breaker escape hatch respects quality gates ──────────────
+# The elif branch that resets CONSECUTIVE_FAILURES=0 must also require that
+# QUALITY_GATE_PASSED is true (or quality gates are disabled). Variable is
+# QUALITY_GATE_PASSED (singular), gated by QUALITY_GATES_ENABLED.
+if grep -qE 'QUALITY_GATES_ENABLED.*QUALITY_GATE_PASSED|QUALITY_GATE_PASSED.*QUALITY_GATES_ENABLED' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "Fix 2: circuit breaker escape hatch checks QUALITY_GATE_PASSED"
+else
+    assert_fail "Fix 2: circuit breaker escape hatch checks QUALITY_GATE_PASSED" \
+        "Expected QUALITY_GATES_ENABLED and QUALITY_GATE_PASSED in the elif escape-hatch branch"
+fi
+
+# Verify escape hatch still resets CONSECUTIVE_FAILURES (it should still work when gates pass)
+if grep -A5 'QUALITY_GATES_ENABLED.*QUALITY_GATE_PASSED\|QUALITY_GATE_PASSED.*QUALITY_GATES_ENABLED' \
+    "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null | grep -q 'CONSECUTIVE_FAILURES=0' 2>/dev/null; then
+    assert_pass "Fix 2: CONSECUTIVE_FAILURES still resets when all gates pass"
+else
+    assert_fail "Fix 2: CONSECUTIVE_FAILURES still resets when all gates pass" \
+        "Expected CONSECUTIVE_FAILURES=0 in the escape hatch branch after quality gate guard"
+fi
+
+# ─── Fix 3a: PREV_NEW_COMMITS global initialized and persisted ───────────────
+# PREV_NEW_COMMITS=0 must be initialized in the defaults section.
+if grep -q 'PREV_NEW_COMMITS=0' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "Fix 3a: PREV_NEW_COMMITS initialized to 0 in defaults"
+else
+    assert_fail "Fix 3a: PREV_NEW_COMMITS initialized to 0 in defaults" \
+        "Expected 'PREV_NEW_COMMITS=0' in sw-loop.sh defaults"
+fi
+
+# PREV_NEW_COMMITS must be set to new_commits after the circuit breaker block
+if grep -q 'PREV_NEW_COMMITS="${new_commits' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "Fix 3a: PREV_NEW_COMMITS set from new_commits after circuit breaker"
+else
+    assert_fail "Fix 3a: PREV_NEW_COMMITS set from new_commits after circuit breaker" \
+        "Expected PREV_NEW_COMMITS=\"\${new_commits...}\" assignment in main loop body"
+fi
+
+# ─── Fix 3b: Zero-progress notice in compose_prompt ─────────────────────────
+# compose_prompt() in loop-iteration.sh must check PREV_NEW_COMMITS and
+# QUALITY_GATE_PASSED and inject a zero-progress warning when both indicate stuckness.
+if grep -q 'PREV_NEW_COMMITS' "$SCRIPT_DIR/lib/loop-iteration.sh"; then
+    assert_pass "Fix 3b: loop-iteration.sh references PREV_NEW_COMMITS"
+else
+    assert_fail "Fix 3b: loop-iteration.sh references PREV_NEW_COMMITS" \
+        "Expected PREV_NEW_COMMITS check in loop-iteration.sh compose_prompt()"
+fi
+
+if grep -q 'Zero Progress Detected' "$SCRIPT_DIR/lib/loop-iteration.sh"; then
+    assert_pass "Fix 3b: zero-progress notice text present in loop-iteration.sh"
+else
+    assert_fail "Fix 3b: zero-progress notice text present in loop-iteration.sh" \
+        "Expected 'Zero Progress Detected' string in compose_prompt() notice"
+fi
+
+# Notice must only fire when PREV_NEW_COMMITS==0 AND quality gate failed
+if grep -qE 'PREV_NEW_COMMITS.*-eq 0.*QUALITY_GATE_PASSED|QUALITY_GATE_PASSED.*PREV_NEW_COMMITS.*-eq 0' \
+    "$SCRIPT_DIR/lib/loop-iteration.sh"; then
+    assert_pass "Fix 3b: zero-progress notice gated on PREV_NEW_COMMITS==0 and QUALITY_GATE_PASSED==false"
+else
+    assert_fail "Fix 3b: zero-progress notice gated on PREV_NEW_COMMITS==0 and QUALITY_GATE_PASSED==false" \
+        "Expected both conditions on the same guard in loop-iteration.sh"
+fi
+
+# ─── Fix 3b: compose_prompt includes zero_progress_notice in output ──────────
+if grep -q 'zero_progress_notice' "$SCRIPT_DIR/lib/loop-iteration.sh"; then
+    assert_pass "Fix 3b: zero_progress_notice variable used in compose_prompt output"
+else
+    assert_fail "Fix 3b: zero_progress_notice variable used in compose_prompt output"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # RESULTS
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2686,7 +2686,7 @@ ${GOAL}"
             # implementation is correct — this is not a stuck agent.
             # Clear prior strikes so stale counts don't trip the breaker later.
             CONSECUTIVE_FAILURES=0
-            echo -e "  ${CYAN}▸${RESET} Tests and audit passed — skipping circuit breaker strike"
+            echo -e "  ${CYAN}▸${RESET} Tests, audit, and quality gates passed — skipping circuit breaker strike"
         else
             CONSECUTIVE_FAILURES=$(( CONSECUTIVE_FAILURES + 1 ))
             echo -e "  ${YELLOW}⚠${RESET} Low progress (${CONSECUTIVE_FAILURES}/${CIRCUIT_BREAKER_THRESHOLD} before circuit breaker)"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -124,6 +124,7 @@ AUDIT_RESULT=""
 HOLISTIC_RESULT=""
 COMPLETION_REJECTED=false
 QUALITY_GATE_PASSED=true
+PREV_NEW_COMMITS=0          # Commit count from previous iteration (for zero-progress detection)
 
 # ─── Multi-Test Defaults ──────────────────────────────────────────────────
 ADDITIONAL_TEST_CMDS=()   # Array of extra test commands (from --additional-test-cmds)
@@ -1591,7 +1592,7 @@ run_holistic_gate() {
 You are a final quality gate evaluating whether an autonomous coding agent has FULLY achieved its goal.
 
 ## Original Goal
-${GOAL}
+${ORIGINAL_GOAL:-$GOAL}
 
 ## Project Stats
 - Files in repo: ${file_count}
@@ -2678,9 +2679,11 @@ ${GOAL}"
                 echo -e "  ${CYAN}▸${RESET} Progress detected — continuing"
             fi
         elif [[ "${TEST_PASSED:-}" == "true" ]] && \
-             { ! $AUDIT_AGENT_ENABLED || [[ "${AUDIT_RESULT:-}" == "pass" ]]; }; then
-            # Tests passed AND audit either passed or is disabled.
-            # Implementation is verified — this is not a stuck agent.
+             { ! $AUDIT_AGENT_ENABLED || [[ "${AUDIT_RESULT:-}" == "pass" ]]; } && \
+             { ! $QUALITY_GATES_ENABLED || $QUALITY_GATE_PASSED; }; then
+            # Tests passed AND audit either passed or is disabled AND quality gates
+            # either passed or are disabled. All verification signals agree the
+            # implementation is correct — this is not a stuck agent.
             # Clear prior strikes so stale counts don't trip the breaker later.
             CONSECUTIVE_FAILURES=0
             echo -e "  ${CYAN}▸${RESET} Tests and audit passed — skipping circuit breaker strike"
@@ -2688,6 +2691,10 @@ ${GOAL}"
             CONSECUTIVE_FAILURES=$(( CONSECUTIVE_FAILURES + 1 ))
             echo -e "  ${YELLOW}⚠${RESET} Low progress (${CONSECUTIVE_FAILURES}/${CIRCUIT_BREAKER_THRESHOLD} before circuit breaker)"
         fi
+
+        # Persist commit count so the next iteration's compose_prompt() can detect
+        # zero-progress (agent made no commits but quality gate is still failing).
+        PREV_NEW_COMMITS="${new_commits:-0}"
 
         # Extract summary and update state
         local summary


### PR DESCRIPTION
## Summary

Three confirmed bugs caused build loops to run indefinitely without converging, observed simultaneously in two separate pipeline runs (zpod issue #450, shipwright issue #325):

- **GOAL pollution in holistic gate** — `run_holistic_gate()` injected `${GOAL}` as `## Original Goal`. GOAL is progressively mutated at 4 sites (failure diagnosis, memory fixes, human feedback, session context). The holistic evaluator saw accumulated blocking-issues text as unfulfilled requirements and rejected `LOOP_COMPLETE` forever. Physical evidence: `~/code/zpod/.claude/loop-state.md` had a 327-line `goal:` field (original + quality review dump).
- **Circuit-breaker escape hatch ignored quality gates** — The `elif` branch that skips breaker strikes when tests+audit pass did not check `QUALITY_GATE_PASSED`. When the quality gate failed with zero commits, `CONSECUTIVE_FAILURES` reset every iteration and the breaker (threshold 3) never fired. Physical evidence: shipwright run showed `iteration: 10, total_commits: 0, consecutive_failures: 0`.
- **No zero-progress feedback** — `compose_prompt()` had no notice when the previous iteration produced zero commits but quality gates were still failing. The agent read passing tests, concluded everything was fine, and silently exited in seconds every iteration.

## Changes

| File | What |
|---|---|
| `scripts/sw-loop.sh:1594` | Change `${GOAL}` → `${ORIGINAL_GOAL:-$GOAL}` in holistic gate prompt |
| `scripts/sw-loop.sh:2681` | Add `{ ! $QUALITY_GATES_ENABLED \|\| $QUALITY_GATE_PASSED; }` to circuit-breaker escape hatch |
| `scripts/sw-loop.sh:127` | Initialize `PREV_NEW_COMMITS=0` in defaults |
| `scripts/sw-loop.sh:~2695` | Set `PREV_NEW_COMMITS="${new_commits:-0}"` after circuit-breaker block |
| `scripts/lib/loop-iteration.sh` | Add `zero_progress_notice` to `compose_prompt()` when `PREV_NEW_COMMITS==0 && QUALITY_GATE_PASSED==false` |
| `scripts/sw-loop-test.sh` | 10 new assertions covering all three fixes |

## Test plan

- [ ] `bash scripts/sw-loop-test.sh` — all 232 tests pass (including 10 new assertions)
- [ ] `npm test` — no regressions (2 pre-existing failures in `sw-intelligence-test.sh` unrelated to this change)
- [ ] Resume zpod pipeline after sanitizing `loop-state.md` — holistic gate approves `LOOP_COMPLETE`
- [ ] Resume shipwright pipeline — agent receives zero-progress notice and makes commits, or circuit breaker fires cleanly at 3 strikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)