### PR TITLE
fix(compound): plateau defers to quality gate, fix double-count scoring (#349)

### DIFF
--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1560,6 +1560,7 @@ ${_cascade_test_tail}"
     local _neg_prev_categories=""
 
     local cycle=0
+    local _cycles_executed=0
     while [[ "$cycle" -lt "$max_cycles" ]]; do
         cycle=$((cycle + 1))
         local all_passed=true
@@ -1936,9 +1937,13 @@ All quality checks clean:
         fi
 
         # Check for plateau: issue count unchanged between cycles.
-        # Use break (not return 1) so the quality gate below makes the final
-        # pass/fail decision — subjective findings that stabilise at a non-zero
-        # count should not hard-fail when the quality score is still acceptable.
+        # When current_issue_count > 0 (subjective/unfixable findings) use break
+        # so the quality gate makes the final pass/fail decision; the score formula
+        # will penalise real issues while allowing acceptable subjective findings to
+        # stabilise (fixes #349).
+        # When current_issue_count == 0 but all_passed=false, some failure is not
+        # tracked in the count (simulation, security-scan, etc.) — hard-fail as
+        # before to preserve the strict guarantee.
         if [[ "$(_compound_should_plateau "$current_issue_count" "$prev_issue_count" "$cycle")" == "plateau" ]]; then
             warn "Convergence: quality plateau — ${current_issue_count} issues unchanged between cycles"
             emit_event "compound.plateau" \
@@ -1946,12 +1951,20 @@ All quality checks clean:
                 "cycle=$cycle" \
                 "issue_count=$current_issue_count"
 
-            if [[ -n "$ISSUE_NUMBER" ]]; then
-                gh_comment_issue "$ISSUE_NUMBER" "⚠️ **Compound quality plateau** — ${current_issue_count} issues unchanged after cycle ${cycle}. Deferring to quality gate." 2>/dev/null || true
+            if [[ "$current_issue_count" -gt 0 ]]; then
+                if [[ -n "$ISSUE_NUMBER" ]]; then
+                    gh_comment_issue "$ISSUE_NUMBER" "⚠️ **Compound quality plateau** — ${current_issue_count} issues unchanged after cycle ${cycle}. Deferring to quality gate." 2>/dev/null || true
+                fi
+                log_stage "compound_quality" "Plateau at cycle ${cycle}/${max_cycles} (${current_issue_count} issues) — deferring to quality gate"
+                _cycles_executed=$cycle
+                break
+            else
+                if [[ -n "$ISSUE_NUMBER" ]]; then
+                    gh_comment_issue "$ISSUE_NUMBER" "⚠️ **Compound quality plateau** — untracked failures persist after cycle ${cycle}. Stopping early." 2>/dev/null || true
+                fi
+                log_stage "compound_quality" "Plateau at cycle ${cycle}/${max_cycles} — untracked failures, hard fail"
+                return 1
             fi
-
-            log_stage "compound_quality" "Plateau at cycle ${cycle}/${max_cycles} (${current_issue_count} issues) — deferring to quality gate"
-            break
         fi
         prev_issue_count="$current_issue_count"
 
@@ -2019,6 +2032,7 @@ All quality checks clean:
             info "Re-running review after rebuild..."
             stage_review 2>/dev/null || true
         fi
+        _cycles_executed=$cycle
     done
 
     # ── Quality Score Computation ──
@@ -2059,6 +2073,27 @@ All quality checks clean:
         local _arch_major
         _arch_major=$(jq '[.[] | select(.severity == "high" or .severity == "major")] | length' "$ARTIFACTS_DIR/compound-architecture-validation.json" 2>/dev/null || echo "0")
         total_major=$((total_major + ${_arch_crit:-0} + ${_arch_major:-0}))
+    fi
+    # Cascade audit findings (compound-audit-findings.json) — not in earlier sections
+    if [[ -f "$ARTIFACTS_DIR/compound-audit-findings.json" ]]; then
+        local _cas_crit
+        _cas_crit=$(jq '[.[] | select(.severity == "critical")] | length' "$ARTIFACTS_DIR/compound-audit-findings.json" 2>/dev/null || echo "0")
+        local _cas_major
+        _cas_major=$(jq '[.[] | select(.severity == "high")] | length' "$ARTIFACTS_DIR/compound-audit-findings.json" 2>/dev/null || echo "0")
+        local _cas_minor
+        _cas_minor=$(jq '[.[] | select(.severity == "medium" or .severity == "low")] | length' "$ARTIFACTS_DIR/compound-audit-findings.json" 2>/dev/null || echo "0")
+        total_critical=$((total_critical + ${_cas_crit:-0}))
+        total_major=$((total_major + ${_cas_major:-0}))
+        total_minor=$((total_minor + ${_cas_minor:-0}))
+    fi
+    # Simulation review findings — set all_passed=false in-loop but not tracked in artifact re-reads above
+    if [[ -f "$ARTIFACTS_DIR/compound-simulation-review.json" ]]; then
+        local _sim_crit
+        _sim_crit=$(jq '[.[] | select(.severity == "critical" or .severity == "high")] | length' "$ARTIFACTS_DIR/compound-simulation-review.json" 2>/dev/null || echo "0")
+        local _sim_minor
+        _sim_minor=$(jq '[.[] | select(.severity == "low" or .severity == "medium")] | length' "$ARTIFACTS_DIR/compound-simulation-review.json" 2>/dev/null || echo "0")
+        total_critical=$((total_critical + ${_sim_crit:-0}))
+        total_minor=$((total_minor + ${_sim_minor:-0}))
     fi
 
     # Apply deductions
@@ -2131,10 +2166,10 @@ All quality checks clean:
 | Minor | ${total_minor} | -$((total_minor * 2)) |
 
 DoD pass rate: ${_dod_pass_rate}%
-Quality issues remain after ${max_cycles} cycles. Check artifacts for details." 2>/dev/null || true
+Quality issues remain after ${_cycles_executed} cycles. Check artifacts for details." 2>/dev/null || true
         fi
 
-        log_stage "compound_quality" "Quality gate failed: ${quality_score}/${min_threshold} after ${max_cycles} cycles"
+        log_stage "compound_quality" "Quality gate failed: ${quality_score}/${min_threshold} after ${_cycles_executed} cycles"
         return 1
     fi
 
@@ -2147,13 +2182,13 @@ Quality issues remain after ${max_cycles} cycles. Check artifacts for details." 
         elif [[ "$quality_score" -ge 70 ]]; then
             success "Compound quality GOOD: ${quality_score}/100"
         else
-            warn "Compound quality ACCEPTABLE: ${quality_score}/${min_threshold} after ${max_cycles} cycles"
+            warn "Compound quality ACCEPTABLE: ${quality_score}/${min_threshold} after ${_cycles_executed} cycles"
         fi
 
         if [[ -n "$ISSUE_NUMBER" ]]; then
             local quality_emoji="✅"
             [[ "$quality_score" -lt 70 ]] && quality_emoji="⚠️"
-            gh_comment_issue "$ISSUE_NUMBER" "${quality_emoji} **Compound quality passed** — score ${quality_score}/${min_threshold} after ${max_cycles} cycles
+            gh_comment_issue "$ISSUE_NUMBER" "${quality_emoji} **Compound quality passed** — score ${quality_score}/${min_threshold} after ${_cycles_executed} cycles
 
 | Finding Type | Count |
 |---|---|
@@ -2164,19 +2199,19 @@ Quality issues remain after ${max_cycles} cycles. Check artifacts for details." 
 DoD pass rate: ${_dod_pass_rate}%" 2>/dev/null || true
         fi
 
-        log_stage "compound_quality" "Passed with score ${quality_score}/${min_threshold} after ${max_cycles} cycles"
+        log_stage "compound_quality" "Passed with score ${quality_score}/${min_threshold} after ${_cycles_executed} cycles"
         return 0
     fi
 
-    error "Compound quality exhausted after ${max_cycles} cycles with insufficient score"
+    error "Compound quality exhausted after ${_cycles_executed} cycles with insufficient score"
 
     if [[ -n "$ISSUE_NUMBER" ]]; then
-        gh_comment_issue "$ISSUE_NUMBER" "❌ **Compound quality failed** after ${max_cycles} cycles
+        gh_comment_issue "$ISSUE_NUMBER" "❌ **Compound quality failed** after ${_cycles_executed} cycles
 
 Quality issues remain. Check artifacts for details." 2>/dev/null || true
     fi
 
-    log_stage "compound_quality" "Failed after ${max_cycles} cycles"
+    log_stage "compound_quality" "Failed after ${_cycles_executed} cycles"
     return 1
 }
 

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1112,6 +1112,25 @@ _extract_blocking_items() {
     # tmp_items and tmp_fps cleaned up by the RETURN trap above.
 }
 
+# _compound_should_plateau <current_count> <prev_count> <cycle>
+# Pure predicate: returns "plateau" when issue-count stagnation is detected,
+# "skip" otherwise. Extracted so plateau logic is unit-testable independently
+# of the compound_quality loop.
+# Plateau conditions (all must be true):
+#   - prev_count >= 0  (at least one real prior cycle, not the sentinel -1)
+#   - current_count == prev_count  (no change)
+#   - cycle > 1        (never fire on the very first cycle)
+_compound_should_plateau() {
+    local current_count="$1" prev_count="$2" cycle="$3"
+    if [[ "$prev_count" -ge 0 \
+       && "$current_count" -eq "$prev_count" \
+       && "$cycle" -gt 1 ]]; then
+        echo "plateau"
+    else
+        echo "skip"
+    fi
+}
+
 # _write_quality_feedback <route> <output_file> [blocking_items]
 # Collects all quality findings into a single markdown file. Extracted from
 # compound_rebuild_with_feedback() to allow direct testing without mocking
@@ -1441,6 +1460,14 @@ stage_compound_quality() {
         warn "Atomic write violations: ${atomic_violations} (state/config file patterns)"
         total_minor=$((total_minor + atomic_violations))
     fi
+
+    # Snapshot pre-loop totals so the post-loop quality gate can restore them
+    # before re-reading artifact files. Without this, in-loop per-cycle
+    # accumulation and post-loop file-reading count the same findings twice
+    # (or more for multi-cycle runs), inflating quality-score penalties.
+    local _preloop_critical=$total_critical
+    local _preloop_major=$total_major
+    local _preloop_minor=$total_minor
 
     # Vitals-driven adaptive cycle limit (preferred)
     # Respect the template's max_cycles as a ceiling — vitals can only reduce, not inflate
@@ -1908,8 +1935,11 @@ All quality checks clean:
             return 0
         fi
 
-        # Check for plateau: issue count unchanged between cycles
-        if [[ "$prev_issue_count" -ge 0 && "$current_issue_count" -eq "$prev_issue_count" && "$cycle" -gt 1 ]]; then
+        # Check for plateau: issue count unchanged between cycles.
+        # Use break (not return 1) so the quality gate below makes the final
+        # pass/fail decision — subjective findings that stabilise at a non-zero
+        # count should not hard-fail when the quality score is still acceptable.
+        if [[ "$(_compound_should_plateau "$current_issue_count" "$prev_issue_count" "$cycle")" == "plateau" ]]; then
             warn "Convergence: quality plateau — ${current_issue_count} issues unchanged between cycles"
             emit_event "compound.plateau" \
                 "issue=${ISSUE_NUMBER:-0}" \
@@ -1917,11 +1947,11 @@ All quality checks clean:
                 "issue_count=$current_issue_count"
 
             if [[ -n "$ISSUE_NUMBER" ]]; then
-                gh_comment_issue "$ISSUE_NUMBER" "⚠️ **Compound quality plateau** — ${current_issue_count} issues unchanged after cycle ${cycle}. Stopping early." 2>/dev/null || true
+                gh_comment_issue "$ISSUE_NUMBER" "⚠️ **Compound quality plateau** — ${current_issue_count} issues unchanged after cycle ${cycle}. Deferring to quality gate." 2>/dev/null || true
             fi
 
-            log_stage "compound_quality" "Plateau at cycle ${cycle}/${max_cycles} (${current_issue_count} issues)"
-            return 1
+            log_stage "compound_quality" "Plateau at cycle ${cycle}/${max_cycles} (${current_issue_count} issues) — deferring to quality gate"
+            break
         fi
         prev_issue_count="$current_issue_count"
 
@@ -1994,6 +2024,14 @@ All quality checks clean:
     # ── Quality Score Computation ──
     # Starting score: 100, deductions based on findings
     local quality_score=100
+
+    # Restore pre-loop totals before reading artifact files.
+    # In-loop accumulation adds findings once per cycle (inflated for multi-cycle
+    # runs); the artifact files reflect the most recent cycle state and are the
+    # authoritative source for the final quality gate count.
+    total_critical=$_preloop_critical
+    total_major=$_preloop_major
+    total_minor=$_preloop_minor
 
     # Count findings from artifact files
     if [[ -f "$ARTIFACTS_DIR/security-source-scan.json" ]]; then

--- a/scripts/sw-lib-pipeline-intelligence-test.sh
+++ b/scripts/sw-lib-pipeline-intelligence-test.sh
@@ -356,6 +356,42 @@ route=$(classify_quality_findings 2>/dev/null || echo "correctness")
 assert_pass "classify_quality_findings returns routing decision"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# _compound_should_plateau (issue #349)
+# Plateau detection helper: returns "plateau" when stagnation is detected,
+# "skip" otherwise. Covers the fix where return 1 was replaced with break so
+# the quality gate makes the final pass/fail decision.
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "_compound_should_plateau"
+
+# Test 1: fires when count is stable across cycles (cycle > 1, prev >= 0)
+result=$(_compound_should_plateau 3 3 2)
+assert_eq "plateau fires: stable count, cycle>1" "plateau" "$result"
+
+# Test 2: skip when count decreases (progress is being made)
+result=$(_compound_should_plateau 2 3 2)
+assert_eq "skip: count decreased" "skip" "$result"
+
+# Test 3: skip when count increases (new findings appeared)
+result=$(_compound_should_plateau 4 3 2)
+assert_eq "skip: count increased" "skip" "$result"
+
+# Test 4: skip on cycle 1 — first cycle never triggers plateau
+result=$(_compound_should_plateau 3 3 1)
+assert_eq "skip: cycle==1 never plateaus" "skip" "$result"
+
+# Test 5: skip when prev_count is sentinel -1 (before any real cycle)
+result=$(_compound_should_plateau 3 -1 2)
+assert_eq "skip: prev=-1 (sentinel)" "skip" "$result"
+
+# Test 6: fires on later cycles with stable count (e.g. cycle 5)
+result=$(_compound_should_plateau 5 5 5)
+assert_eq "plateau fires: stable count on cycle 5" "plateau" "$result"
+
+# Test 7: skip when count is zero and stable (zero issues — not a stagnation problem)
+result=$(_compound_should_plateau 0 0 2)
+assert_eq "plateau fires: zero stable count still triggers plateau detection" "plateau" "$result"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Integration: Full intelligence pipeline
 # ═══════════════════════════════════════════════════════════════════════════════
 print_test_section "Integration: Full intelligence pipeline"

--- a/scripts/sw-lib-pipeline-intelligence-test.sh
+++ b/scripts/sw-lib-pipeline-intelligence-test.sh
@@ -387,9 +387,9 @@ assert_eq "skip: prev=-1 (sentinel)" "skip" "$result"
 result=$(_compound_should_plateau 5 5 5)
 assert_eq "plateau fires: stable count on cycle 5" "plateau" "$result"
 
-# Test 7: skip when count is zero and stable (zero issues — not a stagnation problem)
+# Test 7: zero stable count still fires plateau (allows quality gate to make the call)
 result=$(_compound_should_plateau 0 0 2)
-assert_eq "plateau fires: zero stable count still triggers plateau detection" "plateau" "$result"
+assert_eq "plateau fires: zero stable count triggers plateau" "plateau" "$result"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Integration: Full intelligence pipeline


### PR DESCRIPTION
## Summary

Fixes #349 — `compound_quality` was hard-failing when AI review findings (adversarial/negative prompting) stabilised at a non-zero count between cycles, even when all tests passed and the findings were subjective (naming conventions, style preferences).

Three coordinated changes:

- **`return 1` → `break` at plateau site** — stagnation detection now exits the cycle loop and defers pass/fail to the quality gate (score ≥ 60 threshold). Plateau still warns, emits `compound.plateau` event, and comments on the GitHub issue.

- **Pre-loop snapshot + restore before post-loop scoring** — `total_critical/major/minor` were accumulated in-loop once per cycle AND re-read from artifact files after the loop, causing 2-3× inflation of penalties in multi-cycle runs. Snapshot pre-loop totals, restore them before the post-loop artifact re-read so each finding source is counted exactly once. This also fixes the pre-existing double-counting on the natural-exhaustion path.

- **Extract `_compound_should_plateau()` helper** — pure predicate function extracted from the inline `[[ ]]` condition so plateau logic is unit-testable in isolation without mocking the full compound_quality runtime.

## Root cause analysis

> **Why `! $all_passed` guard (suggested in issue) is a no-op:**
> Line 1889 (`if $all_passed; then return 0`) already exits when `all_passed=true` before the plateau check is ever reached. The plateau check is _only_ reachable when `all_passed=false`. Adding `! $all_passed &&` would evaluate to `! false = true` — no change in behavior.
>
> The real scenario: adversarial/negative review findings set `all_passed=false` AND contribute to `current_issue_count`. Since the code diff doesn't change between compound cycles (no rebuild happened), these findings are identical each cycle → stable count → old plateau → `return 1`.

## Test plan

- [x] 7 new unit tests for `_compound_should_plateau` covering all edge cases
- [x] `bash scripts/sw-lib-pipeline-intelligence-test.sh` — 82/82 pass
- [x] `bash scripts/sw-lib-compound-audit-test.sh` — 89/89 pass
- [x] `bash scripts/sw-lib-helpers-test.sh` — 54/54 pass

## Behavioral contract

| Scenario | Before | After |
|----------|--------|-------|
| Tests pass, subjective findings stable | false plateau → `return 1` | `break` → quality gate → pass (score ≥ 60) |
| Tests fail, real issues stagnant | plateau → `return 1` | `break` → quality gate → fail (low score) |
| Zero issues + all tests pass | success (line 1854) | unchanged |
| Max cycles exhausted | falls to quality gate | unchanged (same path) |
| Multi-cycle run scoring | double/triple counting | single count from final artifacts |

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)