### PR TITLE
fix(pipeline): prevent GOAL mutation from leaking into persisted state

### DIFF
--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -73,6 +73,20 @@ resume_state() {
         fi
     done < "$STATE_FILE"
 
+    # Backward compat: strip mutation-injected content from legacy polluted state files.
+    # Uses %% to strip from first sentinel to end (bash 3.2 safe, no regex, no subshell).
+    if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
+    if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
+    if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
+    # KNOWN FIX is prepended — strip from start through first blank line
+    if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+    # Set ORIGINAL_GOAL so write_state uses it immediately on next call
+    ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
+
     # CLI --max-iterations overrides state file
     if $MAX_ITERATIONS_EXPLICIT; then
         MAX_ITERATIONS="$cli_max_iterations"
@@ -130,7 +144,8 @@ write_state() {
     local tmp_state="${STATE_FILE}.tmp.$$"
     # Encode GOAL: escape backslashes first, then newlines, so that a literal \n
     # in the goal is stored as \\n (unambiguous) while a real newline becomes \n.
-    local _goal_esc="${GOAL//\\/\\\\}"
+    local _write_goal="${ORIGINAL_GOAL:-$GOAL}"
+    local _goal_esc="${_write_goal//\\/\\\\}"
     _goal_esc="${_goal_esc//$'\n'/\\n}"
     # Use printf instead of heredoc to avoid delimiter injection from GOAL
     {

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -977,6 +977,7 @@ ${arch_lines}"
 
     # Augment goal with architecture context for re-run
     local original_goal="$GOAL"
+    trap '{ GOAL="$original_goal"; trap - RETURN; }' RETURN
     if [[ -n "$arch_context" ]]; then
         GOAL="$GOAL
 

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -593,7 +593,8 @@ write_state() {
     # Encode GOAL: escape backslashes first, then newlines, so that a literal \n
     # in the goal is stored as \\n (unambiguous) while a real newline becomes \n.
     local tmp_state="${STATE_FILE}.tmp.$$"
-    local _goal_esc="${GOAL//\\/\\\\}"
+    local _write_goal="${ORIGINAL_GOAL:-$GOAL}"
+    local _goal_esc="${_write_goal//\\/\\\\}"
     _goal_esc="${_goal_esc//$'\n'/\\n}"
     {
         printf -- '---\n'
@@ -679,6 +680,20 @@ ${sid}:${sst}"
             esac
         fi
     done < "$STATE_FILE"
+
+    # Backward compat: strip mutation-injected content from legacy polluted state files.
+    # Uses %% to strip from first sentinel to end (bash 3.2 safe, no regex, no subshell).
+    if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
+    if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
+    if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
+    if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
+    # KNOWN FIX is prepended — strip from start through first blank line
+    if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+    # Set ORIGINAL_GOAL so write_state uses it immediately on next call
+    ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
 
     # Backward compat: old state files won't have pipeline_run_epoch.
     # Derive epoch from the started_at timestamp already parsed above — this is the

--- a/scripts/sw-lib-goal-mutation-test.sh
+++ b/scripts/sw-lib-goal-mutation-test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║  GOAL mutation RETURN trap tests — issue #362                            ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+
+print_test_header "GOAL mutation RETURN trap tests (issue #362)"
+setup_test_env "sw-lib-goal-mutation-test"
+_test_cleanup_hook() { cleanup_test_env; }
+
+# ── Simulate a mutation function with RETURN trap (the fixed pattern) ────────
+
+mutating_function_with_trap() {
+    local original_goal="$GOAL"
+    trap '{ GOAL="$original_goal"; trap - RETURN; }' RETURN
+    GOAL="$GOAL
+
+BLOCKING ISSUES — something to fix"
+    return "${1:-0}"
+}
+
+mutating_function_without_trap() {
+    local original_goal="$GOAL"
+    GOAL="$GOAL
+
+BLOCKING ISSUES — something to fix"
+    # Manual restore only at normal exit path
+    local rc=0
+    inner_call() { return "${1:-0}"; }
+    if inner_call "${1:-0}"; then
+        GOAL="$original_goal"
+        return 0
+    else
+        GOAL="$original_goal"
+        return 1
+    fi
+}
+
+print_test_section "RETURN trap restores GOAL on success"
+GOAL="Original goal"
+mutating_function_with_trap 0 || true
+assert_eq "RETURN trap restores GOAL after success" "Original goal" "$GOAL"
+
+print_test_section "RETURN trap restores GOAL on failure"
+GOAL="Original goal"
+mutating_function_with_trap 1 || true
+assert_eq "RETURN trap restores GOAL after failure" "Original goal" "$GOAL"
+
+print_test_section "RETURN trap restores GOAL even when subshell exits under set -e"
+GOAL="Original goal"
+# Verify the trap fires even when the function is called in a conditional
+if mutating_function_with_trap 0; then
+    :
+fi
+assert_eq "RETURN trap fires when function called in if-branch" "Original goal" "$GOAL"
+
+print_test_section "Without trap: GOAL restored on normal exit"
+GOAL="Original goal"
+mutating_function_without_trap 0 || true
+assert_eq "Manual restore works on success path" "Original goal" "$GOAL"
+
+print_test_section "Without trap: GOAL restored on failure exit"
+GOAL="Original goal"
+mutating_function_without_trap 1 || true
+assert_eq "Manual restore works on failure path" "Original goal" "$GOAL"
+
+print_test_results

--- a/scripts/sw-lib-loop-restart-test.sh
+++ b/scripts/sw-lib-loop-restart-test.sh
@@ -59,7 +59,7 @@ source "$SCRIPT_DIR/lib/loop-restart.sh"
 print_test_section "write_state / resume_state multi-line GOAL round-trip"
 
 # --- Test 1: single-line goal round-trip (regression guard) ---
-GOAL="simple loop goal"
+GOAL="simple loop goal" ORIGINAL_GOAL=""
 write_state
 GOAL=""
 resume_state 2>/dev/null
@@ -70,7 +70,7 @@ else
 fi
 
 # --- Test 2: multi-line goal write — goal value must be escaped (contains literal \n not real newlines) ---
-GOAL="$(printf 'Fix loop tests\n\nKNOWN FIX: check src/foo.sh\nRun: npm test')"
+GOAL="$(printf 'Fix loop tests\n\nKNOWN FIX: check src/foo.sh\nRun: npm test')" ORIGINAL_GOAL=""
 write_state
 _goal_line=$(grep '^goal:' "$STATE_FILE" | sed 's/^goal: *"//;s/" *$//')
 # With the fix, newlines in GOAL are encoded as the two-char sequence \n in the file.
@@ -92,13 +92,13 @@ else
 fi
 
 # --- Test 4: empty goal write — no crash ---
-GOAL=""
+GOAL="" ORIGINAL_GOAL=""
 write_state
 assert_pass "empty loop goal write does not crash"
 
 # --- Test 5: goal containing a literal \n (two chars: backslash + n) ---
 # Full backslash-escaping scheme: literal \n is stored as \\n and round-trips correctly.
-GOAL=$'Contains a literal \\n backslash-n and a real\nnewline'
+GOAL=$'Contains a literal \\n backslash-n and a real\nnewline' ORIGINAL_GOAL=""
 write_state
 GOAL=""
 resume_state 2>/dev/null
@@ -108,16 +108,92 @@ else
     assert_fail "literal \\n in loop goal round-trips correctly" "got: $(printf '%s' "$GOAL" | head -c 80)"
 fi
 
-# --- Test 7: goal with injection-style content (compound quality feedback pattern) ---
-GOAL="$(printf 'Original goal\n\nBLOCKING ISSUES — fix all of these before merge:\n- test_auth_flow fails\n\nFull review context:\nSee audit log for details')"
+# --- Test 7: legacy polluted goal with injection-style content is cleaned on resume ---
+# When a state file contains a goal with compound_quality injection content (from a previous
+# run bug), resume_state should strip the pollution and restore the original goal.
+GOAL="$(printf 'Original goal\n\nBLOCKING ISSUES — fix all of these before merge:\n- test_auth_flow fails\n\nFull review context:\nSee audit log for details')" ORIGINAL_GOAL=""
 write_state
 GOAL=""
 resume_state 2>/dev/null
-_expected="$(printf 'Original goal\n\nBLOCKING ISSUES — fix all of these before merge:\n- test_auth_flow fails\n\nFull review context:\nSee audit log for details')"
+# After resume, the goal should be stripped of the injection content
+_expected="Original goal"
 if [[ "$GOAL" == "$_expected" ]]; then
-    assert_pass "compound quality feedback injection round-trip"
+    assert_pass "resume_state strips legacy polluted BLOCKING ISSUES injection"
 else
-    assert_fail "compound quality feedback injection round-trip" "first 80 chars: $(printf '%s' "$GOAL" | head -c 80)"
+    assert_fail "resume_state strips legacy polluted BLOCKING ISSUES injection" "got: $(printf '%s' "$GOAL" | head -c 80)"
 fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# write_state — ORIGINAL_GOAL protection (issue #362)
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "write_state ORIGINAL_GOAL protection (issue #362)"
+
+# Reload the real write_state — do NOT re-source loop-restart.sh; use fresh module guard
+unset -f write_state
+unset -f resume_state
+_LOOP_RESTART_LOADED=""
+source "$SCRIPT_DIR/lib/loop-restart.sh"
+
+# Test A: write_state uses ORIGINAL_GOAL when GOAL is mutated
+GOAL="Original pipeline goal"
+ORIGINAL_GOAL="Original pipeline goal"
+GOAL="$(printf 'Original pipeline goal\n\nBLOCKING ISSUES — fix all of these before merge: tests fail')"
+write_state
+_saved=$(grep '^goal:' "$STATE_FILE" | sed 's/^goal: *"//;s/" *$//')
+assert_contains "write_state writes ORIGINAL_GOAL not mutated GOAL" "$_saved" "Original pipeline goal"
+_blocking_count=$(echo "$_saved" | grep -c 'BLOCKING ISSUES' || true)
+assert_eq "write_state does not write BLOCKING ISSUES" "0" "$_blocking_count"
+
+# Test B: ORIGINAL_GOAL empty → falls back to GOAL (no regression)
+GOAL="Fallback goal"
+ORIGINAL_GOAL=""
+write_state
+GOAL=""
+resume_state 2>/dev/null
+assert_eq "write_state falls back to GOAL when ORIGINAL_GOAL empty" "Fallback goal" "$GOAL"
+
+# Test C: resume_state strips BLOCKING ISSUES from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'Clean goal\n\nBLOCKING ISSUES — fix all: test fails\n\nFull feedback...')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips BLOCKING ISSUES on load" "Clean goal" "$GOAL"
+assert_eq "resume_state sets ORIGINAL_GOAL after strip" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test D: resume_state strips HUMAN FEEDBACK from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'Clean goal\n\nHUMAN FEEDBACK (received after iteration 3): fix the auth bug')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips HUMAN FEEDBACK on load" "Clean goal" "$GOAL"
+
+# Test E: resume_state strips KNOWN FIX prefix from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'KNOWN FIX (from past success): retry logic\n\nClean goal')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips KNOWN FIX prefix on load" "Clean goal" "$GOAL"
+
+# Test F: no unbounded growth across 2 compound_quality cycles
+GOAL="Original"
+ORIGINAL_GOAL="Original"
+GOAL="$(printf 'Original\n\nBLOCKING ISSUES — something: fail')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+ORIGINAL_GOAL="$GOAL"
+GOAL="$(printf '%s\n\nBLOCKING ISSUES — something else: fail' "$GOAL")"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "no unbounded growth across 2 compound_quality cycles" "Original" "$GOAL"
 
 print_test_results

--- a/scripts/sw-lib-pipeline-state-test.sh
+++ b/scripts/sw-lib-pipeline-state-test.sh
@@ -494,7 +494,7 @@ check_disk_space() { return 0; }   # stub — disk space not relevant in tests
 source "$SCRIPT_DIR/lib/pipeline-state.sh"
 
 # Reset all state vars to a known baseline.
-GOAL="" CURRENT_STAGE="build" PIPELINE_STATUS="interrupted"
+GOAL="" ORIGINAL_GOAL="" CURRENT_STAGE="build" PIPELINE_STATUS="interrupted"
 STAGE_STATUSES="intake:complete" LOG_ENTRIES=""
 PIPELINE_NAME="test-pipeline" GITHUB_ISSUE="" GIT_BRANCH=""
 PR_NUMBER="" PROGRESS_COMMENT_ID="" PIPELINE_START_EPOCH=""
@@ -512,6 +512,7 @@ fi
 
 # --- Test 2: multi-line goal write — goal value must be escaped (contains literal \n not real newlines) ---
 GOAL="$(printf 'Fix issue 348\n\nBLOCKING: tests fail\nFocus on src/foo.sh')"
+ORIGINAL_GOAL=""
 write_state
 _goal_line=$(grep '^goal:' "$STATE_FILE" | sed 's/^goal: *"//;s/" *$//')
 # With the fix, newlines in GOAL are encoded as the two-char sequence \n in the file.
@@ -534,7 +535,7 @@ else
 fi
 
 # --- Test 4: empty goal write — no crash ---
-GOAL="" PIPELINE_STATUS="running"
+GOAL="" ORIGINAL_GOAL="" PIPELINE_STATUS="running"
 write_state
 assert_pass "empty goal write does not crash"
 
@@ -542,6 +543,7 @@ assert_pass "empty goal write does not crash"
 # This was an ambiguous case with the simpler fix; the full backslash-escaping
 # scheme encodes literal \n as \\n so it round-trips correctly.
 GOAL=$'Contains a literal \\n backslash-n and a real\nnewline'
+ORIGINAL_GOAL=""
 write_state
 GOAL=""
 resume_state 2>/dev/null
@@ -553,6 +555,7 @@ fi
 
 # --- Test 6: goal with YAML-special chars preserved ---
 GOAL='Goal with colon: here and #hash and "quotes"'
+ORIGINAL_GOAL=""
 write_state
 GOAL=""
 resume_state 2>/dev/null
@@ -574,5 +577,84 @@ echo "content" > "$ARTIFACTS_DIR/plan.md"
 # Should be no-op when CI_MODE=false
 persist_artifacts "plan" "plan.md" 2>/dev/null
 assert_pass "persist_artifacts is no-op outside CI"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# write_state — ORIGINAL_GOAL protection (issue #362)
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "write_state ORIGINAL_GOAL protection (issue #362)"
+
+# Reload the real write_state (clear the module guard to force re-source)
+_PIPELINE_STATE_LOADED=""
+# Provide any missing stubs that pipeline-state.sh needs
+check_disk_space()         { return 0; }
+get_stage_description()    { echo ""; }
+build_stage_progress()     { echo ""; }
+update_pipeline_status()   { :; }
+db_available()             { return 1; }
+PIPELINE_RUN_EPOCH=""
+PIPELINE_START_EPOCH=""
+source "$SCRIPT_DIR/lib/pipeline-state.sh"
+
+# Test A: write_state uses ORIGINAL_GOAL when GOAL is mutated
+GOAL="Original pipeline goal"
+ORIGINAL_GOAL="Original pipeline goal"
+GOAL="$(printf 'Original pipeline goal\n\nBLOCKING ISSUES — fix all of these before merge: tests fail')"
+write_state
+_saved=$(grep '^goal:' "$STATE_FILE" | sed 's/^goal: *"//;s/" *$//')
+assert_contains "write_state writes ORIGINAL_GOAL not mutated GOAL" "$_saved" "Original pipeline goal"
+_blocking_count=$(echo "$_saved" | grep -c 'BLOCKING ISSUES' || true)
+assert_eq "write_state does not write BLOCKING ISSUES" "0" "$_blocking_count"
+
+# Test B: ORIGINAL_GOAL empty → falls back to GOAL (no regression)
+GOAL="Fallback goal"
+ORIGINAL_GOAL=""
+write_state
+GOAL=""
+resume_state 2>/dev/null
+assert_eq "write_state falls back to GOAL when ORIGINAL_GOAL empty" "Fallback goal" "$GOAL"
+
+# Test C: resume_state strips BLOCKING ISSUES from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'Clean goal\n\nBLOCKING ISSUES — fix all: test fails\n\nFull feedback...')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips BLOCKING ISSUES on load" "Clean goal" "$GOAL"
+assert_eq "resume_state sets ORIGINAL_GOAL after strip" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test D: resume_state strips HUMAN FEEDBACK from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'Clean goal\n\nHUMAN FEEDBACK (received after iteration 3): fix the auth bug')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips HUMAN FEEDBACK on load" "Clean goal" "$GOAL"
+
+# Test E: resume_state strips KNOWN FIX prefix from legacy polluted state
+ORIGINAL_GOAL=""
+GOAL="$(printf 'KNOWN FIX (from past success): retry logic\n\nClean goal')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips KNOWN FIX prefix on load" "Clean goal" "$GOAL"
+
+# Test F: no unbounded growth across 2 compound_quality cycles
+GOAL="Original"
+ORIGINAL_GOAL="Original"
+GOAL="$(printf 'Original\n\nBLOCKING ISSUES — something: fail')"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+ORIGINAL_GOAL="$GOAL"
+GOAL="$(printf '%s\n\nBLOCKING ISSUES — something else: fail' "$GOAL")"
+write_state
+GOAL=""
+ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "no unbounded growth across 2 compound_quality cycles" "Original" "$GOAL"
 
 print_test_results

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -279,6 +279,7 @@ estimate_pipeline_cost() {
 
 # ─── Defaults ───────────────────────────────────────────────────────────────
 GOAL=""
+ORIGINAL_GOAL=""   # Clean goal — guards against mutation leak into write_state()
 ISSUE_NUMBER=""
 PIPELINE_NAME="standard"
 PIPELINE_CONFIG=""
@@ -1271,6 +1272,7 @@ self_healing_build_test() {
 
             # Temporarily augment the goal with error context
             local original_goal="$GOAL"
+            trap '{ GOAL="$original_goal"; trap - RETURN; }' RETURN
             GOAL="$GOAL
 
 ${memory_prefix}IMPORTANT — Previous build attempt failed tests. Fix these errors:
@@ -1496,6 +1498,7 @@ self_healing_review_build_test() {
 
         # Inject review blockers into goal for the build loop
         local original_goal="$GOAL"
+        trap '{ GOAL="$original_goal"; trap - RETURN; }' RETURN
         GOAL="$GOAL
 
 IMPORTANT — Code review found critical/security issues that MUST be fixed:
@@ -2612,6 +2615,9 @@ pipeline_start() {
         fi
         write_state 2>/dev/null || true
     fi
+
+    # Capture clean goal before any stage mutations — mirrors sw-loop.sh:415
+    ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
 
     echo ""
     echo -e "${PURPLE}${BOLD}╔═══════════════════════════════════════════════════════════════════╗${RESET}"


### PR DESCRIPTION
## Problem

Fixes #362.

During every `compound_quality → self-healing build cycle`, `write_state()` is called inside the GOAL mutation window (via `mark_stage_complete()`), writing the bloated GOAL to disk before any restoration occurs. This causes unbounded GOAL growth across cycles and corrupts pipeline state on resume.

## Changes

- **`write_state()` in both `pipeline-state.sh` and `loop-restart.sh`**: Use `${ORIGINAL_GOAL:-$GOAL}` instead of raw `$GOAL` — clean goal always persisted
- **`resume_state()` in both files**: Strip 8 known mutation sentinel patterns from legacy polluted state files; set `ORIGINAL_GOAL` so subsequent writes are immediately clean
- **`sw-pipeline.sh`**: Declare and initialize `ORIGINAL_GOAL` in pipeline context (mirrors `sw-loop.sh:415`); add RETURN traps to `self_healing_build_test()` and `self_healing_review_build_test()`
- **`pipeline-intelligence.sh`**: Add RETURN trap to `pipeline_backtrack_to_stage()` (previously manual-restore only)

## Tests

- New test section in `sw-lib-pipeline-state-test.sh` (6 tests, TDD)
- New test section in `sw-lib-loop-restart-test.sh` (6 tests, TDD)
- New `sw-lib-goal-mutation-test.sh` (5 tests for RETURN trap behavior)
- All existing tests pass including issue #348 multi-line GOAL round-trips

## Verification

After `mark_stage_complete("build")` during compound_quality, `pipeline-state.md` `goal:` field contains only the original goal. Kill mid-cycle + resume: goal is clean. Two consecutive compound_quality cycles: goal does not grow.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)