### PR TITLE
fix(pipeline): clean checkpoints/ directory on fresh pipeline start

### DIFF
--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -496,7 +496,7 @@ _cleanup_run_artifacts() {
 
     # Per-run subdirectories
     local d
-    for d in "$ARTIFACTS_DIR"/stage-outputs "$ARTIFACTS_DIR"/wiki; do
+    for d in "$ARTIFACTS_DIR"/stage-outputs "$ARTIFACTS_DIR"/wiki "$ARTIFACTS_DIR"/checkpoints; do
         [[ -d "$d" ]] && rm -rf "$d"
     done
 
@@ -536,6 +536,20 @@ _cleanup_stale_artifacts_on_resume() {
         if [[ "$mtime" =~ ^[0-9]+$ && "$mtime" -lt "$epoch" ]]; then
             rm -f "$f"
         fi
+    done
+
+    # Sweep stale files inside per-run subdirectories (e.g. checkpoints/ left by a
+    # different pipeline that previously occupied this worktree).
+    local d
+    for d in "$ARTIFACTS_DIR"/checkpoints; do
+        [[ -d "$d" ]] || continue
+        for f in "$d"/*; do
+            [[ -f "$f" ]] || continue
+            mtime=$(file_mtime "$f")
+            if [[ "$mtime" =~ ^[0-9]+$ && "$mtime" -lt "$epoch" ]]; then
+                rm -f "$f"
+            fi
+        done
     done
 
     return 0

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -1891,6 +1891,40 @@ test_mark_complete_persists_plan() {
         grep -q 'plan.*persist_artifacts.*plan.md.*dod.md.*context-bundle.md'
 }
 
+# ──────────────────────────────────────────────────────────────────────────────
+# 59. Fresh start cleans stale checkpoints/ directory
+# ──────────────────────────────────────────────────────────────────────────────
+test_fresh_start_cleans_stale_checkpoints() {
+    local artifacts="$TEST_TEMP_DIR/project/.claude/pipeline-artifacts"
+    pipeline_config_with_stages "intake" > "$TEST_TEMP_DIR/templates/pipelines/standard.json"
+
+    # Plant stale checkpoint that a prior pipeline run left behind
+    mkdir -p "$artifacts/checkpoints"
+    echo '{"stage":"build","iteration":3}' > "$artifacts/checkpoints/build-checkpoint.json"
+
+    invoke_pipeline start --goal "Fresh start goal" --skip-gates
+
+    assert_exit_code 0 "pipeline should complete" &&
+    # _cleanup_run_artifacts() must remove the checkpoints/ directory entirely,
+    # not just its contents.  pipeline_post_completion_cleanup removes individual
+    # files but leaves the directory — so a surviving directory means Fix 1 is absent.
+    (
+        if [[ ! -d "$artifacts/checkpoints" ]]; then
+            return 0
+        fi
+        local remaining=0
+        for f in "$artifacts/checkpoints"/*-checkpoint.json; do
+            [[ -f "$f" ]] && remaining=$((remaining + 1))
+        done
+        if [[ "$remaining" -gt 0 ]]; then
+            echo -e "    ${RED}✗${RESET} Stale checkpoints survived fresh start: $remaining files remain"
+        else
+            echo -e "    ${RED}✗${RESET} checkpoints/ directory survived fresh start (not removed by _cleanup_run_artifacts)"
+        fi
+        return 1
+    )
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1983,6 +2017,7 @@ main() {
         "test_verify_artifacts_no_requirements:Durable: verify_stage_artifacts passes for stages with no requirements"
         "test_verify_artifacts_design_needs_plan:Durable: verify_stage_artifacts design requires plan.md"
         "test_mark_complete_persists_plan:Durable: mark_stage_complete wires persist for plan stage"
+        "test_fresh_start_cleans_stale_checkpoints:Cleanup: stale checkpoints/ removed on fresh pipeline start"
     )
 
     for entry in "${tests[@]}"; do


### PR DESCRIPTION
## Summary

- **Root cause:** `_cleanup_run_artifacts()` in `scripts/lib/pipeline-state.sh` was missing `checkpoints/` from its per-run subdirectory cleanup loop. Stale checkpoint files from a prior pipeline persisted across fresh starts.
- **Impact:** When `pipeline start --resume` was used (e.g. by daemon auto-retry in worktrees), the checkpoint-loading code at `sw-pipeline.sh:2537-2574` found stale files and pre-populated `COMPLETED_STAGES` with stages from an unrelated pipeline — causing intake/plan/design to be skipped with no context.
- **Corrected failure chain:** Only Path A (`pipeline start --resume`, sets `RESUME_FROM_CHECKPOINT=true`) reads checkpoint files. The `pipeline resume` subcommand is unaffected — it calls `resume_state()` directly and never touches the checkpoint dir.

## Changes

| File | Change |
|------|--------|
| `scripts/lib/pipeline-state.sh` | **Fix 1:** add `"$ARTIFACTS_DIR"/checkpoints` to the `_cleanup_run_artifacts()` subdirectory loop — removes entire dir on every fresh `initialize_state()` call |
| `scripts/lib/pipeline-state.sh` | **Fix 2:** add epoch-based file sweep inside `checkpoints/` to `_cleanup_stale_artifacts_on_resume()` — defensive hardening for the resume path |
| `scripts/sw-pipeline-test.sh` | **Test #59:** `test_fresh_start_cleans_stale_checkpoints` — plants stale checkpoint, runs fresh start, asserts `checkpoints/` directory is removed (not just files, which post-completion cleanup already handles) |

## Test plan

- [x] `test_fresh_start_cleans_stale_checkpoints` fails before Fix 1 (directory survives)
- [x] `test_fresh_start_cleans_stale_checkpoints` passes after Fix 1
- [x] `./scripts/sw-pipeline-test.sh` — All 61 tests passed
- [x] `./scripts/sw-lib-pipeline-state-test.sh` — All 72 tests passed
- [x] `npm test` — no regressions

Closes #363

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)