### PR TITLE
fix(detection): use positional args instead of -t flag for ios_xcode targets

### DIFF
--- a/scripts/lib/pipeline-detection.sh
+++ b/scripts/lib/pipeline-detection.sh
@@ -446,7 +446,7 @@ select_test_commands_for_context_json() {
                 if [[ "$pkg_count" -gt 0 ]]; then
                     [[ -n "$all_targets" ]] && all_targets="${all_targets},Packages" || all_targets="Packages"
                 fi
-                [[ -n "$all_targets" ]] && helper_flags="-t ${all_targets}"
+                [[ -n "$all_targets" ]] && helper_flags="${all_targets//,/ }"
             fi
             if [[ -n "$script" ]]; then
                 cmd="bash ./${script}"
@@ -512,7 +512,7 @@ detect_test_cmd_for_loop() {
                         || all_targets="Packages"
                 fi
                 if [[ -n "$all_targets" ]]; then
-                    helper_flags="-t ${all_targets}"
+                    helper_flags="${all_targets//,/ }"
                 else
                     # No specific targets — fall back to syntax check to avoid triggering full regression
                     local syntax_flag

--- a/scripts/sw-lib-pipeline-detection-test.sh
+++ b/scripts/sw-lib-pipeline-detection-test.sh
@@ -444,10 +444,10 @@ if echo "$result" | grep -q ' -s'; then
 else
     assert_fail "Storyboard-only change: syntax fallback (-s) used" "got: $result"
 fi
-if echo "$result" | grep -qE ' -t [^ ]'; then
-    assert_fail "Storyboard-only change: no -t target flag in command"
+if echo "$result" | grep -q ' -t '; then
+    assert_fail "Storyboard-only change: no -t flag in command"
 else
-    assert_pass "Storyboard-only change: no -t target flag in command"
+    assert_pass "Storyboard-only change: no -t flag in command"
 fi
 DTCFL_BASE=$(git -C "$DTCFL_DIR" rev-parse HEAD)
 
@@ -456,15 +456,15 @@ _reset_dtcfl_caches
 echo "class FooTests {}" > "$DTCFL_DIR/Sources/FooTests.swift"
 ( cd "$DTCFL_DIR" && git add "Sources/FooTests.swift" && git commit -q -m "add FooTests" )
 result=$(detect_test_cmd_for_loop "$DTCFL_BASE" 2>/dev/null || true)
-if echo "$result" | grep -qE ' -t [^ ]'; then
-    assert_pass "One Swift file: -t flag present"
+if ! echo "$result" | grep -q ' -t '; then
+    assert_pass "One Swift file: no -t flag (positional args)"
 else
-    assert_fail "One Swift file: -t flag present" "got: $result"
+    assert_fail "One Swift file: no -t flag (positional args)" "got: $result"
 fi
 if echo "$result" | grep -q 'FooTests'; then
-    assert_pass "One Swift file: target class name extracted"
+    assert_pass "One Swift file: target class name present as positional arg"
 else
-    assert_fail "One Swift file: target class name extracted" "got: $result"
+    assert_fail "One Swift file: target class name present as positional arg" "got: $result"
 fi
 DTCFL_BASE=$(git -C "$DTCFL_DIR" rev-parse HEAD)
 
@@ -474,15 +474,15 @@ echo "class BarTests {}" > "$DTCFL_DIR/Sources/BarTests.swift"
 echo "class BazTests {}" > "$DTCFL_DIR/Sources/BazTests.swift"
 ( cd "$DTCFL_DIR" && git add "Sources/BarTests.swift" "Sources/BazTests.swift" && git commit -q -m "add BarTests BazTests" )
 result=$(detect_test_cmd_for_loop "$DTCFL_BASE" 2>/dev/null || true)
-if echo "$result" | grep -qE ' -t [^ ]'; then
-    assert_pass "Multiple Swift files: -t flag present"
+if ! echo "$result" | grep -q ' -t '; then
+    assert_pass "Multiple Swift files: no -t flag (positional args)"
 else
-    assert_fail "Multiple Swift files: -t flag present" "got: $result"
+    assert_fail "Multiple Swift files: no -t flag (positional args)" "got: $result"
 fi
-if echo "$result" | grep -qE ' -t [^,]+,[^ ]'; then
-    assert_pass "Multiple Swift files: comma-separated targets"
+if echo "$result" | grep -qE 'BarTests[[:space:]]BazTests|BazTests[[:space:]]BarTests'; then
+    assert_pass "Multiple Swift files: space-separated positional targets"
 else
-    assert_fail "Multiple Swift files: comma-separated targets" "got: $result"
+    assert_fail "Multiple Swift files: space-separated positional targets" "got: $result"
 fi
 
 export PROJECT_ROOT="$_orig_project_root"


### PR DESCRIPTION
## Summary

- `pipeline-detection.sh` was generating `bash ./scripts/run-xcode-tests.sh -t FooTests` for ios_xcode environments, matching the old script interface
- `run-xcode-tests.sh` was refactored to positional args (no `-t`) but shipwright was never updated — the flag was silently ignored, causing full test suite runs instead of targeted ones
- Fixes both locations that build `helper_flags` for ios_xcode: `select_test_commands_for_context_json` (line 449) and `detect_test_cmd_for_loop` (line 515)
- `"${all_targets//,/ }"` converts comma-separated targets (`FooTests,BarTests`) to space-separated positional args (`FooTests BarTests`)

## Changes

| File | Change |
|------|--------|
| `scripts/lib/pipeline-detection.sh` | Two one-line fixes: `helper_flags="-t ${all_targets}"` → `helper_flags="${all_targets//,/ }"` |
| `scripts/sw-lib-pipeline-detection-test.sh` | Update three assertion blocks to verify `-t` absent and class names present as positional args |

## Test plan

- [x] `./scripts/sw-lib-pipeline-detection-test.sh` — All 79 tests passed
- [x] `npm test` — running (no failures detected)
- Generated command before: `bash ./scripts/run-xcode-tests.sh -t FooTests`
- Generated command after: `bash ./scripts/run-xcode-tests.sh FooTests`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)