### PR TITLE
fix: address unresolved code review comments from PRs 366 and 368

### DIFF
--- a/scripts/lib/daemon-triage.sh
+++ b/scripts/lib/daemon-triage.sh
@@ -181,7 +181,7 @@ triage_score_issue() {
     local memory_score=0
     if [[ -x "$SCRIPT_DIR/sw-memory.sh" ]]; then
         local memory_result
-        memory_result=$(timeout 5 "$SCRIPT_DIR/sw-memory.sh" search --issue "$issue_num" --json 2>/dev/null || true)
+        memory_result=$(_timeout 5 "$SCRIPT_DIR/sw-memory.sh" search --issue "$issue_num" --json 2>/dev/null || true)
         if [[ -n "$memory_result" ]]; then
             local prior_result
             prior_result=$(echo "$memory_result" | jq -r '.last_result // ""' 2>/dev/null || true)

--- a/scripts/lib/ruflo-adapter.sh
+++ b/scripts/lib/ruflo-adapter.sh
@@ -1046,10 +1046,22 @@ ruflo_execute_audit() {
 
     # Initialize audit hive
     local hive_id=""
-    # Save caller's EXIT trap so we can restore it — overwriting it would skip pipeline
-    # teardown (lock release, stash restore, etc.) if the process exits while we hold the trap.
-    _RUFLO_AUDIT_PREV_EXIT_TRAP=$(trap -p EXIT 2>/dev/null || true)
-    trap '[[ -n "${hive_id:-}" ]] && _ruflo_hive_shutdown "${hive_id}" 2>/dev/null || true; if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi' EXIT
+    # Save caller's EXIT trap so we can restore it and chain it on unexpected exits.
+    # Using local variables avoids leaking state across calls.
+    # _prev_exit_raw: full "trap -- '...' EXIT" string, used to restore on explicit returns.
+    # _prev_exit_body: just the handler body, embedded inline in our chained trap so that
+    # both hive cleanup AND caller teardown (lock release, stash restore, etc.) run if the
+    # process exits unexpectedly (SIGTERM, set -e, etc.) while our trap is installed.
+    local _prev_exit_raw
+    local _prev_exit_body=""
+    _prev_exit_raw=$(trap -p EXIT 2>/dev/null || true)
+    if [[ -n "$_prev_exit_raw" ]]; then
+        # Extract handler body from: trap -- 'body' EXIT
+        _prev_exit_body=$(printf '%s\n' "$_prev_exit_raw" | sed "s/^trap -- '//; s/' EXIT\$//")
+    fi
+    local _chained_trap='[[ -n "${hive_id:-}" ]] && _ruflo_hive_shutdown "${hive_id}" 2>/dev/null || true'
+    [[ -n "$_prev_exit_body" ]] && _chained_trap="${_chained_trap}; ${_prev_exit_body}"
+    trap "$_chained_trap" EXIT
     local _init_exit=0
     local _init_out=""
     if [[ "${RUFLO_USE_NPX:-false}" == "true" ]]; then
@@ -1067,7 +1079,7 @@ ruflo_execute_audit() {
         hive_id=$(printf '%s' "$_init_out" | jq -r '.hive_id // empty' 2>/dev/null || true)
     if [[ $_init_exit -ne 0 || -z "$hive_id" ]]; then
         emit_event "ruflo.audit_failed" "reason=hive_init_failed"
-        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
+        if [[ -n "${_prev_exit_raw:-}" ]]; then eval "${_prev_exit_raw}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1138,7 +1150,7 @@ ruflo_execute_audit() {
         warn "ruflo: orchestration failed with exit $_orch_exit"
         _ruflo_hive_shutdown "$hive_id"
         emit_event "ruflo.audit_failed" "reason=orchestration_failed"
-        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
+        if [[ -n "${_prev_exit_raw:-}" ]]; then eval "${_prev_exit_raw}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1161,7 +1173,7 @@ ruflo_execute_audit() {
     mkdir -p "$(dirname "$artifact_file")" 2>/dev/null || true
     if ! printf '%s\n' "${_findings:-}" > "$artifact_file"; then
         warn "ruflo: failed to write audit artifact: $artifact_file"
-        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
+        if [[ -n "${_prev_exit_raw:-}" ]]; then eval "${_prev_exit_raw}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1172,7 +1184,7 @@ ruflo_execute_audit() {
         "audit,outcome" || true
 
     emit_event "ruflo.audit_complete" "hive_id=$hive_id" "stage=audit"
-    if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
+    if [[ -n "${_prev_exit_raw:-}" ]]; then eval "${_prev_exit_raw}"; else trap - EXIT; fi
     return 0
 }
 

--- a/scripts/lib/ruflo-adapter.sh
+++ b/scripts/lib/ruflo-adapter.sh
@@ -1046,8 +1046,10 @@ ruflo_execute_audit() {
 
     # Initialize audit hive
     local hive_id=""
-    # Trap ensures hive is cleaned up if SIGTERM or unexpected exit interrupts orchestration.
-    trap '[[ -n "${hive_id:-}" ]] && _ruflo_hive_shutdown "${hive_id}" 2>/dev/null || true' EXIT
+    # Save caller's EXIT trap so we can restore it — overwriting it would skip pipeline
+    # teardown (lock release, stash restore, etc.) if the process exits while we hold the trap.
+    _RUFLO_AUDIT_PREV_EXIT_TRAP=$(trap -p EXIT 2>/dev/null || true)
+    trap '[[ -n "${hive_id:-}" ]] && _ruflo_hive_shutdown "${hive_id}" 2>/dev/null || true; if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi' EXIT
     local _init_exit=0
     local _init_out=""
     if [[ "${RUFLO_USE_NPX:-false}" == "true" ]]; then
@@ -1065,6 +1067,7 @@ ruflo_execute_audit() {
         hive_id=$(printf '%s' "$_init_out" | jq -r '.hive_id // empty' 2>/dev/null || true)
     if [[ $_init_exit -ne 0 || -z "$hive_id" ]]; then
         emit_event "ruflo.audit_failed" "reason=hive_init_failed"
+        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1135,6 +1138,7 @@ ruflo_execute_audit() {
         warn "ruflo: orchestration failed with exit $_orch_exit"
         _ruflo_hive_shutdown "$hive_id"
         emit_event "ruflo.audit_failed" "reason=orchestration_failed"
+        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1157,6 +1161,7 @@ ruflo_execute_audit() {
     mkdir -p "$(dirname "$artifact_file")" 2>/dev/null || true
     if ! printf '%s\n' "${_findings:-}" > "$artifact_file"; then
         warn "ruflo: failed to write audit artifact: $artifact_file"
+        if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
         return 1
     fi
 
@@ -1166,8 +1171,8 @@ ruflo_execute_audit() {
         "pipeline-${pipeline_id}" \
         "audit,outcome" || true
 
-    emit_event "ruflo.audit_complete" "hive_id=$hive_id stage=audit"
-    trap - EXIT
+    emit_event "ruflo.audit_complete" "hive_id=$hive_id" "stage=audit"
+    if [[ -n "${_RUFLO_AUDIT_PREV_EXIT_TRAP:-}" ]]; then eval "${_RUFLO_AUDIT_PREV_EXIT_TRAP}"; else trap - EXIT; fi
     return 0
 }
 

--- a/scripts/sw-lib-pipeline-detection-test.sh
+++ b/scripts/sw-lib-pipeline-detection-test.sh
@@ -451,7 +451,7 @@ else
 fi
 DTCFL_BASE=$(git -C "$DTCFL_DIR" rev-parse HEAD)
 
-# --- Test 2: One Swift file changed → -t ClassName
+# --- Test 2: One Swift file changed → ClassName (positional arg)
 _reset_dtcfl_caches
 echo "class FooTests {}" > "$DTCFL_DIR/Sources/FooTests.swift"
 ( cd "$DTCFL_DIR" && git add "Sources/FooTests.swift" && git commit -q -m "add FooTests" )
@@ -468,7 +468,7 @@ else
 fi
 DTCFL_BASE=$(git -C "$DTCFL_DIR" rev-parse HEAD)
 
-# --- Test 3: Multiple Swift files changed → -t Class1,Class2
+# --- Test 3: Multiple Swift files changed → Class1 Class2 (positional args)
 _reset_dtcfl_caches
 echo "class BarTests {}" > "$DTCFL_DIR/Sources/BarTests.swift"
 echo "class BazTests {}" > "$DTCFL_DIR/Sources/BazTests.swift"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -975,17 +975,27 @@ run_test_gate() {
     local combined_output=""
     local test_timeout="${SW_TEST_TIMEOUT:-$(_config_get_int "loop.test_timeout" 900 2>/dev/null || echo 900)}"
     local _max_test_timeout="$(_config_get_int "loop.test_timeout_max" 3600 2>/dev/null || echo 3600)"
-    # Scale proportionally for multi-target commands (e.g. -t FooTests,BarTests,Packages)
+    # Scale proportionally for multi-target commands.
+    # Supports both legacy -t FooTests,BarTests form and the current positional-arg
+    # form used by ios_xcode targets (e.g. run-xcode-tests.sh FooTests BarTests Packages).
+    local _target_count=0
     local _targets_str
     _targets_str=$(echo "$active_test_cmd" | grep -oE '\-t [^ ]+' | head -1 | sed 's/-t //' || true)
     if [[ -n "$_targets_str" ]]; then
-        local _target_count
+        # Legacy -t comma-separated form
         _target_count=$(echo "$_targets_str" | tr ',' '\n' | grep -c '.' || true)
-        if [[ "${_target_count:-1}" -gt 1 ]]; then
-            local _scaled=$(( _target_count * test_timeout ))
-            [[ "$_scaled" -gt "$_max_test_timeout" ]] && _scaled="$_max_test_timeout"
-            test_timeout="$_scaled"
+    elif echo "$active_test_cmd" | grep -qE 'run-xcode-tests\.sh'; then
+        # Positional-arg form: count space-separated words after the script name
+        local _args_after_script
+        _args_after_script=$(echo "$active_test_cmd" | sed 's|.*run-xcode-tests\.sh[[:space:]]*||' || true)
+        if [[ -n "$_args_after_script" ]]; then
+            _target_count=$(echo "$_args_after_script" | wc -w | tr -d '[:space:]' || true)
         fi
+    fi
+    if [[ "${_target_count:-0}" -gt 1 ]]; then
+        local _scaled=$(( _target_count * test_timeout ))
+        [[ "$_scaled" -gt "$_max_test_timeout" ]] && _scaled="$_max_test_timeout"
+        test_timeout="$_scaled"
     fi
 
     # Run primary test command

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -985,9 +985,12 @@ run_test_gate() {
         # Legacy -t comma-separated form
         _target_count=$(echo "$_targets_str" | tr ',' '\n' | grep -c '.' || true)
     elif echo "$active_test_cmd" | grep -qE 'run-xcode-tests\.sh'; then
-        # Positional-arg form: count space-separated words after the script name
+        # Positional-arg form: count words after the script name, stopping at any shell
+        # separator (&&, ||, |, ;) so chained commands are not counted as targets.
         local _args_after_script
-        _args_after_script=$(echo "$active_test_cmd" | sed 's|.*run-xcode-tests\.sh[[:space:]]*||' || true)
+        _args_after_script=$(echo "$active_test_cmd" \
+            | sed 's|.*run-xcode-tests\.sh[[:space:]]*||; s/[[:space:]]*&&.*//; s/[[:space:]]*||.*//; s/[[:space:]]*|.*//; s/[[:space:]]*;.*//' \
+            || true)
         if [[ -n "$_args_after_script" ]]; then
             _target_count=$(echo "$_args_after_script" | wc -w | tr -d '[:space:]' || true)
         fi

--- a/scripts/sw-ruflo-adapter-test.sh
+++ b/scripts/sw-ruflo-adapter-test.sh
@@ -1586,4 +1586,73 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Test: ruflo_execute_audit preserves caller EXIT trap on failure path
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "ruflo_execute_audit — preserves caller EXIT trap on failure"
+
+unset _RUFLO_ADAPTER_LOADED
+_test_tmp=$(mktemp -d "${TMPDIR:-/tmp}/sw-ruflo-adapter-test.XXXXXX")
+_orig_path="$PATH"
+mock_binary "ruflo" 'exit 1'
+source "$SCRIPT_DIR/lib/ruflo-adapter.sh"
+RUFLO_AVAILABLE=true
+RUFLO_USE_NPX=false
+_sentinel_fired=false
+trap '_sentinel_fired=true' EXIT
+_trap_before=$(trap -p EXIT)
+ruflo_execute_audit "diff content here" "$_test_tmp/audit-out.md" 2>/dev/null || true
+_trap_after=$(trap -p EXIT)
+trap - EXIT
+PATH="$_orig_path"
+rm -f "$TEST_TEMP_DIR/bin/ruflo"
+rm -rf "$_test_tmp"
+if [[ "$_trap_before" == "$_trap_after" ]]; then
+    assert_pass "ruflo_execute_audit restores caller EXIT trap on failure"
+else
+    assert_fail "ruflo_execute_audit restores caller EXIT trap on failure" "before: $_trap_before | after: $_trap_after"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test: ruflo_execute_audit preserves caller EXIT trap on success path
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "ruflo_execute_audit — preserves caller EXIT trap on success"
+
+unset _RUFLO_ADAPTER_LOADED
+_test_tmp=$(mktemp -d "${TMPDIR:-/tmp}/sw-ruflo-adapter-test.XXXXXX")
+_call_log="$_test_tmp/ruflo-calls.log"
+cat > "$_test_tmp/ruflo" <<MOCK
+#!/usr/bin/env bash
+subcmd="\${1:-}"
+printf '%s %s %s\\n' "\$subcmd" "\${2:-}" "\${3:-}" >> "$_call_log"
+if [[ "\$subcmd" == "hive-mind" && "\${2:-}" == "init" ]]; then
+    printf '{"hive_id":"trap-test-hive"}\\n'
+    exit 0
+fi
+if [[ "\$subcmd" == "hive-mind" && "\${2:-}" == "memory" ]]; then
+    printf 'finding: none\\n'
+    exit 0
+fi
+exit 0
+MOCK
+chmod +x "$_test_tmp/ruflo"
+_orig_path="$PATH"
+PATH="$_test_tmp:$PATH"
+source "$SCRIPT_DIR/lib/ruflo-adapter.sh"
+RUFLO_AVAILABLE=true
+RUFLO_USE_NPX=false
+_artifact="$_test_tmp/audit-result.md"
+trap '_sentinel_fired=true' EXIT
+_trap_before=$(trap -p EXIT)
+ruflo_execute_audit "diff content here" "$_artifact" 2>/dev/null || true
+_trap_after=$(trap -p EXIT)
+trap - EXIT
+PATH="${PATH#"$_test_tmp:"}"
+rm -rf "$_test_tmp"
+if [[ "$_trap_before" == "$_trap_after" ]]; then
+    assert_pass "ruflo_execute_audit restores caller EXIT trap on success"
+else
+    assert_fail "ruflo_execute_audit restores caller EXIT trap on success" "before: $_trap_before | after: $_trap_after"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
 print_test_results

--- a/scripts/sw-ruflo-adapter-test.sh
+++ b/scripts/sw-ruflo-adapter-test.sh
@@ -1586,9 +1586,9 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Test: ruflo_execute_audit preserves caller EXIT trap on failure path
+# Test: ruflo_execute_audit restores caller EXIT trap on failure path
 # ═══════════════════════════════════════════════════════════════════════════════
-print_test_section "ruflo_execute_audit — preserves caller EXIT trap on failure"
+print_test_section "ruflo_execute_audit — restores caller EXIT trap on failure"
 
 unset _RUFLO_ADAPTER_LOADED
 _test_tmp=$(mktemp -d "${TMPDIR:-/tmp}/sw-ruflo-adapter-test.XXXXXX")
@@ -1611,11 +1611,17 @@ if [[ "$_trap_before" == "$_trap_after" ]]; then
 else
     assert_fail "ruflo_execute_audit restores caller EXIT trap on failure" "before: $_trap_before | after: $_trap_after"
 fi
+# Verify _sentinel_fired remains false (trap was restored, not fired mid-function)
+if [[ "$_sentinel_fired" == "false" ]]; then
+    assert_pass "caller EXIT sentinel did not fire during ruflo_execute_audit failure"
+else
+    assert_fail "caller EXIT sentinel did not fire during ruflo_execute_audit failure" "sentinel fired unexpectedly"
+fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Test: ruflo_execute_audit preserves caller EXIT trap on success path
+# Test: ruflo_execute_audit restores caller EXIT trap on success path
 # ═══════════════════════════════════════════════════════════════════════════════
-print_test_section "ruflo_execute_audit — preserves caller EXIT trap on success"
+print_test_section "ruflo_execute_audit — restores caller EXIT trap on success"
 
 unset _RUFLO_ADAPTER_LOADED
 _test_tmp=$(mktemp -d "${TMPDIR:-/tmp}/sw-ruflo-adapter-test.XXXXXX")
@@ -1641,6 +1647,7 @@ source "$SCRIPT_DIR/lib/ruflo-adapter.sh"
 RUFLO_AVAILABLE=true
 RUFLO_USE_NPX=false
 _artifact="$_test_tmp/audit-result.md"
+_sentinel_fired=false
 trap '_sentinel_fired=true' EXIT
 _trap_before=$(trap -p EXIT)
 ruflo_execute_audit "diff content here" "$_artifact" 2>/dev/null || true
@@ -1653,6 +1660,67 @@ if [[ "$_trap_before" == "$_trap_after" ]]; then
 else
     assert_fail "ruflo_execute_audit restores caller EXIT trap on success" "before: $_trap_before | after: $_trap_after"
 fi
+if [[ "$_sentinel_fired" == "false" ]]; then
+    assert_pass "caller EXIT sentinel did not fire during ruflo_execute_audit success"
+else
+    assert_fail "caller EXIT sentinel did not fire during ruflo_execute_audit success" "sentinel fired unexpectedly"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test: caller's EXIT handler runs when process exits mid-function (unexpected exit)
+# Uses a subprocess: mock ruflo sends SIGTERM to the bash process running
+# ruflo_execute_audit during orchestration, verifying the chained EXIT trap fires
+# both hive cleanup and the caller's sentinel.
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "ruflo_execute_audit — chains caller EXIT handler on unexpected exit"
+
+_test_tmp=$(mktemp -d "${TMPDIR:-/tmp}/sw-ruflo-adapter-test.XXXXXX")
+_sentinel_file="$_test_tmp/sentinel"
+# Mock ruflo: init succeeds, orchestration sends TERM directly to the bash subprocess
+# (via a PID file written before the function call), simulating mid-function process exit.
+cat > "$_test_tmp/ruflo" << MOCK_EOF
+#!/usr/bin/env bash
+case "\${1:-}/\${2:-}" in
+    hive-mind/init)
+        printf '{"hive_id":"term-test-hive"}\n'
+        exit 0
+        ;;
+    coordination/orchestrate)
+        _target=\$(cat '$_test_tmp/subprocess.pid' 2>/dev/null || true)
+        [[ -n "\$_target" ]] && kill -TERM "\$_target" 2>/dev/null || true
+        sleep 3
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK_EOF
+chmod +x "$_test_tmp/ruflo"
+# Run in a subprocess so SIGTERM exits it cleanly without killing the test harness.
+# Writing $$ before the call lets the mock target the right bash PID.
+# A TERM trap calls exit so bash fires the chained EXIT handler on SIGTERM; the
+# chained handler (installed by ruflo_execute_audit) should run both hive cleanup
+# and the caller's sentinel touch.
+bash -c "
+    echo \$\$ > '$_test_tmp/subprocess.pid'
+    export PATH='$_test_tmp:/usr/local/bin:/usr/bin:/bin'
+    unset _RUFLO_ADAPTER_LOADED
+    source '$SCRIPT_DIR/lib/ruflo-adapter.sh'
+    RUFLO_AVAILABLE=true
+    RUFLO_USE_NPX=false
+    trap 'exit 143' TERM
+    trap 'touch \"$_sentinel_file\"' EXIT
+    ruflo_execute_audit 'diff content' '$_test_tmp/out.md' 2>/dev/null || true
+" 2>/dev/null || true
+# Give the subprocess a moment to finish writing the sentinel if TERM raced
+sleep 1
+if [[ -f "$_sentinel_file" ]]; then
+    assert_pass "chained EXIT trap fires caller handler on unexpected SIGTERM during audit"
+else
+    assert_fail "chained EXIT trap fires caller handler on unexpected SIGTERM during audit" "sentinel file not created"
+fi
+rm -rf "$_test_tmp"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 print_test_results


### PR DESCRIPTION
## Summary

Addresses code review comments that were not resolved before PRs #366 and #368 were merged.

**From PR #366 (ruflo audit integration):**
- **P1 — EXIT trap overwrite** (`ruflo-adapter.sh`): `ruflo_execute_audit` now saves the caller's EXIT trap before installing its own cleanup trap, and restores it on all exit paths (hive init failure, orchestration failure, artifact write failure, and success). Previously the pipeline's `cleanup_on_exit` trap was silently overwritten, skipping lock release and stash restore.
- **emit_event split args** (`ruflo-adapter.sh`): `emit_event "ruflo.audit_complete"` was passing `"hive_id=$hive_id stage=audit"` as a single argument — `stage` was swallowed into `hive_id`. Now split into two separate arguments.
- **P2 — timeout portability** (`daemon-triage.sh`): Replaced bare `timeout 5` with `_timeout 5` from `compat.sh` for macOS compatibility (no GNU `timeout` by default).
- **EXIT trap test coverage** (`sw-ruflo-adapter-test.sh`): Added assertions verifying the caller's EXIT trap is unchanged before and after `ruflo_execute_audit` on both failure and success paths.

**From PR #368 (ios_xcode positional args):**
- **Timeout scaling** (`sw-loop.sh`): `run_test_gate` scaled timeouts by counting `-t Foo,Bar` comma-separated targets, which no longer applies now that ios_xcode uses positional args. Updated to count space-separated words after `run-xcode-tests.sh` when `-t` is absent, so multi-target runs get the correct scaled timeout.
- **Test comments** (`sw-lib-pipeline-detection-test.sh`): Updated section comments that still described the old `-t ClassName` / `-t Class1,Class2` interface to reflect the current positional-arg format.

## Test plan
- [x] `bash scripts/sw-ruflo-adapter-test.sh` — all 101 tests pass (includes 2 new EXIT trap preservation tests)
- [ ] Verify `daemon-triage.sh` memory scoring works on macOS without GNU `timeout`
- [ ] Verify multi-target ios_xcode commands in `sw-loop.sh` receive scaled timeouts

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)