### PR TITLE
fix(pipeline): make heartbeat and stage-marker comments visible in GitHub

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -599,10 +599,15 @@ jobs:
             PIPELINE_ARGS+=(--completed-stages "$COMPLETED_STAGES")
           fi
 
-          # Heartbeat: post progress marker every 10 minutes so watchdog knows we're alive
+          # Heartbeat: post progress marker every 10 minutes so watchdog knows we're alive.
+          # Visible body first so subscribers see content; HTML comment retained for
+          # watchdog parsing (shipwright-watchdog.yml uses `contains("SHIPWRIGHT-HEARTBEAT")`).
           (while true; do
             sleep 600
-            gh issue comment "$ISSUE_NUMBER" --body "<!-- SHIPWRIGHT-HEARTBEAT: $(date -u +%Y-%m-%dT%H:%M:%SZ):running -->" 2>/dev/null || true
+            _HB_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            _HB_DISPLAY=$(date -u '+%H:%M UTC')
+            gh issue comment "$ISSUE_NUMBER" --body "⏳ Pipeline still running — last heartbeat ${_HB_DISPLAY}
+<!-- SHIPWRIGHT-HEARTBEAT: ${_HB_TS}:running -->" 2>/dev/null || true
           done) &
           HEARTBEAT_PID=$!
 

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -1979,8 +1979,10 @@ test_ci_post_stage_event_visible_body() {
     local fns result visible
     fns=$(_load_ci_post_stage_event)
     result=$(_ci_capture_body "$fns" "build" "complete" "45s")
-    visible=$(printf '%s' "$result" | grep -v '^<!--' | tr -d '[:space:]')
+    visible=$(printf '%s\n' "$result" | grep -Ev '^[[:space:]]*<!--' | tr -d '[:space:]')
     [[ -n "$visible" ]] || { echo "Expected visible comment body, got only HTML comments: $result"; return 1; }
+    printf '%s\n' "$result" | grep -Ev '^[[:space:]]*<!--' | grep -Eq 'Pipeline update|build' \
+        || { echo "Expected human-readable pipeline update text in comment body; got: $result"; return 1; }
 }
 
 test_ci_post_stage_event_retains_marker() {

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -1925,6 +1925,102 @@ test_fresh_start_cleans_stale_checkpoints() {
     )
 }
 
+# ──────────────────────────────────────────────────────────────────────────────
+# ci_post_stage_event — comment format tests (issue #258)
+# ──────────────────────────────────────────────────────────────────────────────
+
+_load_ci_post_stage_event() {
+    # Extract ci_post_stage_event into an isolated sourcing script so we can
+    # call it without the full pipeline environment.
+    local fns="$TEST_TEMP_DIR/ci-post-fns.sh"
+    cat > "$fns" <<'FEOF'
+#!/usr/bin/env bash
+set -uo pipefail
+emit_event() { true; }
+info() { true; }
+warn() { true; }
+_timeout() { local _t="$1"; shift; "$@"; }
+_config_get_int() { echo "${3:-30}"; }
+FEOF
+    sed -n '/^ci_post_stage_event()/,/^}/p' "$REAL_PIPELINE_SCRIPT" >> "$fns"
+    echo "$fns"
+}
+
+_ci_capture_body() {
+    # Helper: run ci_post_stage_event with a gh() stub that writes --body arg to
+    # a temp file (avoids >/dev/null suppression in the real function).
+    local fns="$1" stage="$2" status="$3" elapsed="$4"
+    local capture_file="$TEST_TEMP_DIR/ci-body-capture-$$.txt"
+    rm -f "$capture_file"
+    (
+        # shellcheck disable=SC1090
+        source "$fns" 2>/dev/null
+        CI_MODE=true
+        ISSUE_NUMBER=123
+        GH_AVAILABLE=true
+        gh() {
+            local prev=""
+            for arg in "$@"; do
+                if [[ "$prev" == "--body" ]]; then
+                    printf '%s' "$arg" > "$capture_file"
+                    return 0
+                fi
+                prev="$arg"
+            done
+        }
+        ci_post_stage_event "$stage" "$status" "$elapsed"
+    ) 2>/dev/null || true
+    cat "$capture_file" 2>/dev/null || true
+    rm -f "$capture_file"
+}
+
+test_ci_post_stage_event_visible_body() {
+    # Comment body must contain human-readable text (not just HTML comment)
+    local fns result visible
+    fns=$(_load_ci_post_stage_event)
+    result=$(_ci_capture_body "$fns" "build" "complete" "45s")
+    visible=$(printf '%s' "$result" | grep -v '^<!--' | tr -d '[:space:]')
+    [[ -n "$visible" ]] || { echo "Expected visible comment body, got only HTML comments: $result"; return 1; }
+}
+
+test_ci_post_stage_event_retains_marker() {
+    # HTML marker must be present for watchdog parsing
+    local fns result
+    fns=$(_load_ci_post_stage_event)
+    result=$(_ci_capture_body "$fns" "test" "complete" "2m10s")
+    printf '%s' "$result" | grep -q 'SHIPWRIGHT-STAGE' \
+        || { echo "HTML marker SHIPWRIGHT-STAGE missing from comment body"; return 1; }
+    printf '%s' "$result" | grep -q 'test:complete:2m10s' \
+        || { echo "Stage/status/elapsed missing from marker; got: $result"; return 1; }
+}
+
+test_ci_post_stage_event_failed_emoji() {
+    # Failed status should use the failure emoji
+    local fns result
+    fns=$(_load_ci_post_stage_event)
+    result=$(_ci_capture_body "$fns" "review" "failed" "1m5s")
+    printf '%s' "$result" | grep -q '❌' \
+        || { echo "Expected failure emoji in comment body; got: $result"; return 1; }
+}
+
+test_ci_post_stage_event_noop_outside_ci() {
+    # Must be a no-op when CI_MODE != true
+    local fns capture_file
+    fns=$(_load_ci_post_stage_event)
+    capture_file="$TEST_TEMP_DIR/ci-noop-$$.txt"
+    rm -f "$capture_file"
+    (
+        # shellcheck disable=SC1090
+        source "$fns" 2>/dev/null
+        CI_MODE=false
+        ISSUE_NUMBER=123
+        GH_AVAILABLE=true
+        gh() { printf 'called' > "$capture_file"; }
+        ci_post_stage_event "build" "complete" "1s"
+    ) 2>/dev/null || true
+    [[ ! -f "$capture_file" ]] || { echo "ci_post_stage_event should be no-op when CI_MODE=false"; return 1; }
+}
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2018,6 +2114,10 @@ main() {
         "test_verify_artifacts_design_needs_plan:Durable: verify_stage_artifacts design requires plan.md"
         "test_mark_complete_persists_plan:Durable: mark_stage_complete wires persist for plan stage"
         "test_fresh_start_cleans_stale_checkpoints:Cleanup: stale checkpoints/ removed on fresh pipeline start"
+        "test_ci_post_stage_event_visible_body:CI: ci_post_stage_event posts visible comment body"
+        "test_ci_post_stage_event_retains_marker:CI: ci_post_stage_event retains SHIPWRIGHT-STAGE marker for watchdog"
+        "test_ci_post_stage_event_failed_emoji:CI: ci_post_stage_event uses failure emoji for failed status"
+        "test_ci_post_stage_event_noop_outside_ci:CI: ci_post_stage_event is no-op outside CI mode"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -678,7 +678,18 @@ ci_post_stage_event() {
     [[ "${GH_AVAILABLE:-false}" != "true" ]] && return 0
 
     local stage="$1" status="$2" elapsed="${3:-0s}"
-    local comment="<!-- SHIPWRIGHT-STAGE: ${stage}:${status}:${elapsed} -->"
+    local emoji
+    case "$status" in
+        complete) emoji="✅" ;;
+        failed)   emoji="❌" ;;
+        skipped)  emoji="⏭️" ;;
+        *)        emoji="🔄" ;;
+    esac
+    # Visible body first so readers see content; HTML comment retained for
+    # watchdog parsing (shipwright-watchdog.yml uses `contains("SHIPWRIGHT-STAGE")`).
+    local comment
+    comment="${emoji} Pipeline update — \`${stage}\` stage **${status}** (${elapsed})
+<!-- SHIPWRIGHT-STAGE: ${stage}:${status}:${elapsed} -->"
     _timeout "$(_config_get_int "network.gh_timeout" 30 2>/dev/null || echo 30)" gh issue comment "$ISSUE_NUMBER" --body "$comment" >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
## Summary

Fixes #258. Both `ci_post_stage_event()` and the workflow heartbeat loop posted bare HTML comments that render as blank in GitHub — subscribers received notifications but saw empty comment bodies.

- **`scripts/sw-pipeline.sh`**: `ci_post_stage_event()` now prepends a visible human-readable line (emoji + stage/status/elapsed) before the HTML marker. The `<!-- SHIPWRIGHT-STAGE: ... -->` marker is retained so `shipwright-watchdog.yml`'s `contains("SHIPWRIGHT-STAGE")` query continues to work.
- **`.github/workflows/shipwright-pipeline.yml`**: heartbeat comment now includes `⏳ Pipeline still running — last heartbeat HH:MM UTC` before the HTML marker.

Example comment body after this fix:
```
✅ Pipeline update — `build` stage **complete** (45s)
<!-- SHIPWRIGHT-STAGE: build:complete:45s -->
```

## Test plan

- [ ] `bash scripts/sw-pipeline-test.sh test_ci_post_stage_event_visible_body` — visible text is present
- [ ] `bash scripts/sw-pipeline-test.sh test_ci_post_stage_event_retains_marker` — SHIPWRIGHT-STAGE marker retained
- [ ] `bash scripts/sw-pipeline-test.sh test_ci_post_stage_event_failed_emoji` — ❌ emoji on failure
- [ ] `bash scripts/sw-pipeline-test.sh test_ci_post_stage_event_noop_outside_ci` — no-op outside CI
- [ ] Heartbeat format verified by code inspection of `shipwright-pipeline.yml:605`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)