### PR TITLE
fix(pipeline): validate duration format before jq to prevent partial-float corruption

### DIFF
--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -396,6 +396,17 @@ $tail_output" "haiku" "4" | grep -oE '^[0-9.]+$' | head -1 || true)
         fi
     fi
 
+    # Validate: require at least one leading digit before any decimal point.
+    # Rejects: ".", ".34", "0.", "..." — guards against partial-float extraction
+    # by the [0-9.]+ character-class regex and the AI fallback (issue #398).
+    # Uses grep -qE for Bash 3.2 compatibility (no [[ =~ ]] capture groups).
+    if [[ -n "$duration_ms" ]]; then
+        if ! echo "$duration_ms" | grep -qE '^[0-9]+(\.[0-9]+)?$' || \
+           [[ "$duration_ms" == "0" ]] || [[ "$duration_ms" == "0.0" ]]; then
+            duration_ms=""
+        fi
+    fi
+
     if [[ -z "$duration_ms" ]]; then
         info "Could not extract test duration — skipping perf check"
         echo "Duration not parseable" > "$metrics_log"

--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -396,13 +396,14 @@ $tail_output" "haiku" "4" | grep -oE '^[0-9.]+$' | head -1 || true)
         fi
     fi
 
-    # Validate: require at least one leading digit before any decimal point.
-    # Rejects: ".", ".34", "0.", "..." — guards against partial-float extraction
-    # by the [0-9.]+ character-class regex and the AI fallback (issue #398).
-    # Uses grep -qE for Bash 3.2 compatibility (no [[ =~ ]] capture groups).
+    # Validate: require at least one leading digit before any decimal point,
+    # and require the value to be numerically > 0.
+    # Rejects: ".", ".34", "0.", "...", "0", "0.0", "0.00", "00" — guards
+    # against partial-float extraction by [0-9.]+ and the AI fallback (#398).
+    # Uses printf+grep -qE and awk -v for Bash 3.2 compatibility.
     if [[ -n "$duration_ms" ]]; then
-        if ! echo "$duration_ms" | grep -qE '^[0-9]+(\.[0-9]+)?$' || \
-           [[ "$duration_ms" == "0" ]] || [[ "$duration_ms" == "0.0" ]]; then
+        if ! printf '%s\n' "$duration_ms" | grep -qE '^[0-9]+(\.[0-9]+)?$' || \
+           ! awk -v d="$duration_ms" 'BEGIN { exit !(d > 0) }'; then
             duration_ms=""
         fi
     fi

--- a/scripts/sw-lib-pipeline-quality-checks-test.sh
+++ b/scripts/sw-lib-pipeline-quality-checks-test.sh
@@ -257,58 +257,81 @@ fi
 # Each input uses a framework-realistic prefix to exercise the specific extraction path.
 
 # pytest path (line ~372): ".34" passes jq tonumber but silently corrupts history
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "passed in .34s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression rejects pytest leading-dot float (passed in .34s)"
 else
     assert_fail "quality_check_perf_regression rejects pytest leading-dot float (passed in .34s)"
 fi
+assert_contains "metrics log signals rejection for leading-dot float" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
 
 # pytest path: "0." passes jq tonumber as 0, corrupts history with meaningless zero
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "passed in 0.s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression rejects pytest trailing dot (passed in 0.s)"
 else
     assert_fail "quality_check_perf_regression rejects pytest trailing dot (passed in 0.s)"
 fi
+assert_contains "metrics log signals rejection for trailing-dot float" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
 
 # Jest path (line ~369): lone "." crashes jq (exit 5), leaves history stale
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "Time: . s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression rejects Jest lone dot (Time: . s)"
 else
     assert_fail "quality_check_perf_regression rejects Jest lone dot (Time: . s)"
 fi
+assert_contains "metrics log signals rejection for Jest lone dot" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
 
 # Generic fallback path (line ~378): "..." crashes jq (exit 5)
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "...s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression rejects multiple dots (...s)"
 else
     assert_fail "quality_check_perf_regression rejects multiple dots (...s)"
 fi
+assert_contains "metrics log signals rejection for multiple dots" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
 
 # Zero duration: "0" is syntactically valid for jq but a meaningless baseline
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "passed in 0s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression rejects zero duration (passed in 0s)"
 else
     assert_fail "quality_check_perf_regression rejects zero duration (passed in 0s)"
 fi
+assert_contains "metrics log signals rejection for zero duration" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
+
+# Zero-valued with alternate encoding: "0.00" also numerically zero
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
+echo "passed in 0.00s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects zero-valued 0.00 (passed in 0.00s)"
+else
+    assert_fail "quality_check_perf_regression rejects zero-valued 0.00 (passed in 0.00s)"
+fi
+assert_contains "metrics log signals rejection for 0.00 duration" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Duration not parseable"
 
 # Valid float via Jest pattern: must be accepted and return 0
-rm -f "$ARTIFACTS_DIR/test-results.log"
+rm -f "$ARTIFACTS_DIR/test-results.log" "$ARTIFACTS_DIR/perf-metrics.log"
 echo "Time: 12.34 s" > "$ARTIFACTS_DIR/test-results.log"
 if quality_check_perf_regression 2>/dev/null; then
     assert_pass "quality_check_perf_regression accepts valid float (Time: 12.34 s)"
 else
     assert_fail "quality_check_perf_regression accepts valid float (Time: 12.34 s)"
 fi
+assert_contains "metrics log records accepted duration" \
+    "$(cat "$ARTIFACTS_DIR/perf-metrics.log" 2>/dev/null)" "Test duration: 12.34s"
 
 # Silent-corruption guard: seed 3 valid history entries, feed a malformed duration,
 # assert the history file entry count is unchanged (fix prevents the corrupt append).

--- a/scripts/sw-lib-pipeline-quality-checks-test.sh
+++ b/scripts/sw-lib-pipeline-quality-checks-test.sh
@@ -253,6 +253,81 @@ else
     assert_fail "quality_check_perf_regression"
 fi
 
+# --- Issue #398: partial-float / zero duration validation ---
+# Each input uses a framework-realistic prefix to exercise the specific extraction path.
+
+# pytest path (line ~372): ".34" passes jq tonumber but silently corrupts history
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "passed in .34s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects pytest leading-dot float (passed in .34s)"
+else
+    assert_fail "quality_check_perf_regression rejects pytest leading-dot float (passed in .34s)"
+fi
+
+# pytest path: "0." passes jq tonumber as 0, corrupts history with meaningless zero
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "passed in 0.s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects pytest trailing dot (passed in 0.s)"
+else
+    assert_fail "quality_check_perf_regression rejects pytest trailing dot (passed in 0.s)"
+fi
+
+# Jest path (line ~369): lone "." crashes jq (exit 5), leaves history stale
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "Time: . s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects Jest lone dot (Time: . s)"
+else
+    assert_fail "quality_check_perf_regression rejects Jest lone dot (Time: . s)"
+fi
+
+# Generic fallback path (line ~378): "..." crashes jq (exit 5)
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "...s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects multiple dots (...s)"
+else
+    assert_fail "quality_check_perf_regression rejects multiple dots (...s)"
+fi
+
+# Zero duration: "0" is syntactically valid for jq but a meaningless baseline
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "passed in 0s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression rejects zero duration (passed in 0s)"
+else
+    assert_fail "quality_check_perf_regression rejects zero duration (passed in 0s)"
+fi
+
+# Valid float via Jest pattern: must be accepted and return 0
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "Time: 12.34 s" > "$ARTIFACTS_DIR/test-results.log"
+if quality_check_perf_regression 2>/dev/null; then
+    assert_pass "quality_check_perf_regression accepts valid float (Time: 12.34 s)"
+else
+    assert_fail "quality_check_perf_regression accepts valid float (Time: 12.34 s)"
+fi
+
+# Silent-corruption guard: seed 3 valid history entries, feed a malformed duration,
+# assert the history file entry count is unchanged (fix prevents the corrupt append).
+_perf_hist_dir="${HOME}/.shipwright/baselines/$(echo -n "$PROJECT_ROOT" | shasum -a 256 2>/dev/null | cut -c1-12)"
+_perf_hist_file="${_perf_hist_dir}/perf-history.json"
+mkdir -p "$_perf_hist_dir"
+echo '{"durations":[10.0,11.0,12.0],"updated":"2026-01-01T00:00:00Z"}' > "$_perf_hist_file"
+_orig_count=$(jq '.durations | length' "$_perf_hist_file" 2>/dev/null || echo "0")
+rm -f "$ARTIFACTS_DIR/test-results.log"
+echo "passed in .34s" > "$ARTIFACTS_DIR/test-results.log"
+quality_check_perf_regression 2>/dev/null || true
+_post_count=$(jq '.durations | length' "$_perf_hist_file" 2>/dev/null || echo "0")
+if [[ "$_orig_count" == "$_post_count" ]]; then
+    assert_pass "quality_check_perf_regression does not corrupt perf history on bad duration"
+else
+    assert_fail "quality_check_perf_regression does not corrupt perf history on bad duration"
+fi
+rm -f "$_perf_hist_file"
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # pipeline_test_status / pipeline_test_passed
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Fixes #398.

`quality_check_perf_regression()` in `scripts/lib/pipeline-quality-checks.sh` uses `[0-9.]+` as a character class in its last-resort extraction regex — and as `^[0-9.]+$` in the AI fallback — both of which match a lone `.`. This produced two failure modes:

- **Crash path** (`.`, `...`): `jq tonumber` exits 5, `mv` never runs, perf history silently stale
- **Silent corruption** (`.34`, `0.`): `jq` succeeds but stores the wrong value, poisoning the 10-run rolling history used for future 2σ regression calculations

The only prior guard was `[[ -z "$duration_ms" ]]`, which a lone `.` bypasses.

## Changes

**`scripts/lib/pipeline-quality-checks.sh`** — single validation block inserted after all 6 extraction paths:

```bash
if [[ -n "$duration_ms" ]]; then
    if ! echo "$duration_ms" | grep -qE '^[0-9]+(\.[0-9]+)?$' || \
       [[ "$duration_ms" == "0" ]] || [[ "$duration_ms" == "0.0" ]]; then
        duration_ms=""
    fi
fi
```

- Requires at least one leading digit before any decimal point — rejects `.`, `.34`, `0.`, `...`
- Explicitly rejects zero durations (`0`, `0.0`) — meaningless baseline values
- `grep -qE` used for Bash 3.2 compatibility (no `[[ =~ ]]` capture groups)
- Invalid input falls through to the existing empty-string guard → writes `Duration not parseable`, returns 0

**`scripts/sw-lib-pipeline-quality-checks-test.sh`** — 7 new test cases:

| Input | Extraction path | Failure mode before fix |
|-------|----------------|------------------------|
| `passed in .34s` | pytest (line ~372) | Silent history corruption |
| `passed in 0.s` | pytest | Silent history corruption with zero |
| `Time: . s` | Jest (line ~369) | jq crash (exit 5), history stale |
| `...s` | generic fallback | jq crash, history stale |
| `passed in 0s` | pytest | Meaningless zero baseline |
| `Time: 12.34 s` | Jest | (positive case — must still pass) |
| History corruption guard | seeds 3 entries, feeds `.34s`, asserts count unchanged | Detects silent write corruption end-to-end |

## Test results

```
All 57 tests passed
```

(up from 50 before this PR)

## Notes

- Does **not** change any extraction regex — those remain deliberately liberal
- The `|| echo "[$duration_ms]"` fallback at line ~472 is a secondary latent bug (produces `[.]` string when jq crashes), but is now unreachable with bad values — implicitly covered
- `duration_ms` variable name is a pre-existing misnomer (holds seconds); not changed here

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)