### PR TITLE
fix(ruflo): address PR #407 review comments on test_first stage

### DIFF
--- a/docs/ADR_326_test_first_ruflo_enrichment.md
+++ b/docs/ADR_326_test_first_ruflo_enrichment.md
@@ -26,10 +26,11 @@ This leads to **reinvention of test patterns** on each pipeline run and **lost i
 
 ## Context & Constraints
 
-### Technology Stack
-- **Language**: TypeScript / Node.js
-- **Test Framework**: Vitest (`*.test.js` pattern)
-- **Source Directory**: `src/`
+### Stage Contract
+- **Stage Contract**: `test_first` is repo-agnostic and follows project conventions for language, test framework, and file layout
+- **Current Repository Example**: TypeScript / Node.js
+- **Current Test Convention Example**: Vitest (`*.test.js` pattern)
+- **Current Source Layout Example**: `src/`
 - **Pipeline Framework**: Shipwright (shell-based orchestration)
 - **Memory System**: Ruflo (semantic recall via shell functions)
 

--- a/docs/PLAN_326_test_first_ruflo_enrichment.md
+++ b/docs/PLAN_326_test_first_ruflo_enrichment.md
@@ -10,9 +10,9 @@
 ## Verification of Assumptions (Completed)
 
 ### ✅ File Structure Verified
-- **`stage_test_first()` location**: `/Volumes/zHardDrive/code/shipwright/scripts/lib/pipeline-stages-build.sh` lines 6–114
-- **Reference pattern (`stage_plan()`)**: `/Volumes/zHardDrive/code/shipwright/scripts/lib/pipeline-stages-intake.sh` lines 118–202
-- **Ruflo adapter location**: `/Volumes/zHardDrive/code/shipwright/scripts/lib/ruflo-adapter.sh` (functions verified below)
+- **`stage_test_first()` location**: `scripts/lib/pipeline-stages-build.sh` lines 6–114
+- **Reference pattern (`stage_plan()`)**: `scripts/lib/pipeline-stages-intake.sh` lines 118–202
+- **Ruflo adapter location**: `scripts/lib/ruflo-adapter.sh` (functions verified below)
 
 ### ✅ Ruflo Functions Verified
 All three functions exist and are accessible:
@@ -29,8 +29,8 @@ All variables are exported by `pipeline-stages.sh` (lines 17–31) and inherited
 
 | Variable | Set In | Value | Usage in Plan |
 |----------|--------|-------|---------------|
-| `GOAL` | pipeline-stages-intake.sh line 51 / pipeline-stages.sh line 29 | Issue title or explicit goal | Query input for recall |
-| `ISSUE_LABELS` | pipeline-stages-intake.sh line 20 / pipeline-stages.sh line 27 | Comma-separated label list | Second param to `ruflo_recall_similar_outcomes()` |
+| `GOAL` | pipeline-stages-intake.sh line 51 / pipeline-stages.sh line 29 | Issue title or explicit goal | Included via requirements snippet in second param to `ruflo_recall_similar_outcomes()` |
+| `ISSUE_LABELS` | pipeline-stages-intake.sh line 20 / pipeline-stages.sh line 27 | Comma-separated label list | Part of composite second param to `ruflo_recall_similar_outcomes()` |
 | `TASK_TYPE` | pipeline-stages-intake.sh line 51 / pipeline-stages.sh line 30 | Result of `detect_task_type()` or default "feature" | First param to `ruflo_recall_similar_outcomes()` |
 | `INTELLIGENCE_ISSUE_TYPE` | pipeline-stages.sh line 31 (default: "backend") | Detected issue type or "backend" | Not used directly; TASK_TYPE is the correct param |
 | `SHIPWRIGHT_PIPELINE_ID` | sw-pipeline.sh line 534 | Format: `pipeline-$$-${ISSUE_NUMBER}` | Namespace for `ruflo_store()` |

--- a/docs/PLAN_326_test_first_ruflo_enrichment.md
+++ b/docs/PLAN_326_test_first_ruflo_enrichment.md
@@ -33,7 +33,7 @@ All variables are exported by `pipeline-stages.sh` (lines 17–31) and inherited
 | `ISSUE_LABELS` | pipeline-stages-intake.sh line 20 / pipeline-stages.sh line 27 | Comma-separated label list | Part of composite second param to `ruflo_recall_similar_outcomes()` |
 | `TASK_TYPE` | pipeline-stages-intake.sh line 51 / pipeline-stages.sh line 30 | Result of `detect_task_type()` or default "feature" | First param to `ruflo_recall_similar_outcomes()` |
 | `INTELLIGENCE_ISSUE_TYPE` | pipeline-stages.sh line 31 (default: "backend") | Detected issue type or "backend" | Not used directly; TASK_TYPE is the correct param |
-| `SHIPWRIGHT_PIPELINE_ID` | sw-pipeline.sh line 534 | Format: `pipeline-$$-${ISSUE_NUMBER}` | Namespace for `ruflo_store()` |
+| `SHIPWRIGHT_PIPELINE_ID` | sw-pipeline.sh line 534 | Format: `pipeline-$$-${ISSUE_NUMBER}` | Used in the `ruflo_store()` key; storage namespace is `learning-<repo_hash>` |
 | `ARTIFACTS_DIR` | pipeline-stages.sh line 17 | Default: `.claude/pipeline-artifacts` | Already used in `stage_test_first()` |
 
 ### ✅ Ruflo-Adapter Is Available to `stage_test_first()`

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -20,14 +20,15 @@ stage_test_first() {
 
     # ── Semantic recall: find similar past TDD test generations ──────────────
     local tdd_context=""
-    if ruflo_available; then
-        tdd_context=$(ruflo_recall_similar_outcomes "${TASK_TYPE:-feature}" "${ISSUE_LABELS:-}" 2>/dev/null) || true
-        if [[ -n "$tdd_context" && "$tdd_context" != *'"results":[]'* ]]; then
-            tdd_context=$(printf '%s' "$tdd_context" | jq -r '.results[]? | "- \(.)"' 2>/dev/null | head -5 || true)
-            tdd_context=$(printf '%.2000s' "$tdd_context")
-        else
-            tdd_context=""
-        fi
+    if declare -f ruflo_recall_similar_outcomes >/dev/null 2>&1 && \
+       declare -f ruflo_available >/dev/null 2>&1 && \
+       ruflo_available; then
+        local _recall_requirements _recall_query
+        _recall_requirements=$(printf '%s' "$requirements" | tr '\n' ' ' | cut -c1-800 2>/dev/null || true)
+        _recall_query="${ISSUE_LABELS:-}"
+        [[ -n "$_recall_requirements" ]] && _recall_query="${_recall_query:+${_recall_query}; }requirements: ${_recall_requirements}"
+        tdd_context=$(ruflo_recall_similar_outcomes "${TASK_TYPE:-feature}" "$_recall_query" 2>/dev/null) || true
+        tdd_context=$(printf '%.2000s' "${tdd_context:-}")
     fi
 
     local tdd_prompt="You are writing tests BEFORE implementation (TDD).
@@ -70,6 +71,7 @@ ${tdd_context}"
 
     # Parse output: extract fenced code blocks and write to files
     local wrote_any=false
+    local written_files=""
     local block_path="" in_block=false block_content=""
     while IFS= read -r line; do
         if [[ "$line" =~ ^\`\`\`([a-zA-Z0-9_/\.\-]+)$ ]]; then
@@ -80,6 +82,7 @@ ${tdd_context}"
                 mkdir -p "$out_dir" 2>/dev/null || true
                 if echo "$block_content" > "$out_file" 2>/dev/null; then
                     wrote_any=true
+                    written_files="${written_files:+${written_files},}${block_path}"
                     info "  Wrote: $block_path"
                 fi
             fi
@@ -94,6 +97,7 @@ ${tdd_context}"
                 mkdir -p "$out_dir" 2>/dev/null || true
                 if echo "$block_content" > "$out_file" 2>/dev/null; then
                     wrote_any=true
+                    written_files="${written_files:+${written_files},}${block_path}"
                     info "  Wrote: $block_path"
                 fi
             fi
@@ -114,6 +118,7 @@ ${tdd_context}"
         mkdir -p "$out_dir" 2>/dev/null || true
         if echo "$block_content" > "$out_file" 2>/dev/null; then
             wrote_any=true
+            written_files="${written_files:+${written_files},}${block_path}"
             info "  Wrote: $block_path"
         fi
     fi
@@ -130,18 +135,27 @@ ${tdd_context}"
     fi
 
     # ── Store TDD generation outcome for future recall ────────────────────────
-    if ruflo_available && [[ "$wrote_any" == "true" ]]; then
+    # Uses the learning-<repo_hash> namespace so future ruflo_recall_similar_outcomes
+    # calls (which query that namespace) can retrieve these stored outcomes.
+    if declare -f ruflo_store >/dev/null 2>&1 && \
+       declare -f ruflo_available >/dev/null 2>&1 && \
+       declare -f _ruflo_resolve_repo_hash >/dev/null 2>&1 && \
+       ruflo_available && [[ "$wrote_any" == "true" ]]; then
         if [[ -z "${SHIPWRIGHT_PIPELINE_ID:-}" ]]; then
             warn "SHIPWRIGHT_PIPELINE_ID unset — skipping TDD outcome storage to prevent key collision"
         else
-            local tdd_key="test_first-${SHIPWRIGHT_PIPELINE_ID}-$(date +%s)"
-            local tdd_outcome
-            tdd_outcome=$(jq -n --arg goal "${GOAL:-}" --arg task "${TASK_TYPE:-feature}" \
-                --arg wrote "$wrote_any" \
-                '{goal: $goal, task_type: $task, tests_generated: ($wrote == "true")}' 2>/dev/null || echo '{}')
-            ruflo_store "$tdd_key" "$tdd_outcome" \
-                "pipeline-${SHIPWRIGHT_PIPELINE_ID}" \
-                "tdd,test_first,${TASK_TYPE:-feature}" 2>/dev/null || true
+            local _tdd_ns_hash
+            _tdd_ns_hash=$(_ruflo_resolve_repo_hash 2>/dev/null) || true
+            if [[ -n "$_tdd_ns_hash" ]]; then
+                local tdd_key="test_first-${SHIPWRIGHT_PIPELINE_ID}-$(date +%s)"
+                local tdd_outcome
+                tdd_outcome=$(jq -n --arg goal "${GOAL:-}" --arg task "${TASK_TYPE:-feature}" \
+                    --arg files "${written_files:-}" \
+                    '{goal: $goal, task_type: $task, tests_generated: true, files_written: $files}' 2>/dev/null || echo '{}')
+                ruflo_store "$tdd_key" "$tdd_outcome" \
+                    "learning-${_tdd_ns_hash}" \
+                    "tdd,test_first,${TASK_TYPE:-feature}" 2>/dev/null || true
+            fi
         fi
     fi
 

--- a/scripts/sw-lib-pipeline-stages-test.sh
+++ b/scripts/sw-lib-pipeline-stages-test.sh
@@ -1017,7 +1017,7 @@ set -e
 # Test: integration — tdd_prompt contains injected recall results when available
 ruflo_available() { return 0; }
 ruflo_recall_similar_outcomes() {
-    printf '{"results":["Use describe/it blocks for JWT tests","Mock authService for unit tests"]}\n'
+    printf 'Use describe/it blocks for JWT tests\nMock authService for unit tests\n'
 }
 ruflo_store() { return 0; }
 
@@ -1043,7 +1043,7 @@ fi
 
 # Test: empty recall results — tdd_prompt must NOT contain recall section
 ruflo_recall_similar_outcomes() {
-    printf '{"results":[]}\n'
+    printf ''
 }
 
 cat > "$TEST_TEMP_DIR/bin/claude" <<CMOCK
@@ -1071,7 +1071,7 @@ fi
 
 # Test: SHIPWRIGHT_PIPELINE_ID unset — stage returns 0 and skips storage (no key collision)
 ruflo_available() { return 0; }
-ruflo_recall_similar_outcomes() { printf '{"results":[]}\n'; }
+ruflo_recall_similar_outcomes() { printf ''; }
 _ruflo_store_called=false
 ruflo_store() { _ruflo_store_called=true; return 0; }
 cat > "$TEST_TEMP_DIR/bin/claude" <<CMOCK

--- a/scripts/sw-ruflo-adapter-test.sh
+++ b/scripts/sw-ruflo-adapter-test.sh
@@ -2414,30 +2414,27 @@ print_test_section "stage_test_first — ruflo recall happy path"
 unset _RUFLO_ADAPTER_LOADED
 source "$SCRIPT_DIR/lib/ruflo-adapter.sh"
 
-# Mock ruflo_recall_similar_outcomes to return a fake result
+# Mock ruflo_recall_similar_outcomes to return plain-text recall output,
+# matching the adapter contract (raw CLI output, not JSON).
 ruflo_recall_similar_outcomes() {
-    echo '{"results":["- Past TDD pattern: use vitest describe blocks","- Past TDD pattern: mock external deps"]}'
+    printf 'Past TDD pattern: use vitest describe blocks\nPast TDD pattern: mock external deps\n'
 }
 ruflo_store() { return 0; }
 RUFLO_AVAILABLE=true
 
 _recall_result=$(ruflo_recall_similar_outcomes "feature" "tdd,backend" 2>/dev/null || true)
-_tdd_context=""
-if [[ -n "$_recall_result" && "$_recall_result" != *'"results":[]'* ]]; then
-    _tdd_context=$(printf '%s' "$_recall_result" | jq -r '.results[]? | "- \(.)"' 2>/dev/null | head -5 || true)
-    _tdd_context=$(printf '%.2000s' "$_tdd_context")
-fi
+_tdd_context=$(printf '%.2000s' "${_recall_result:-}")
 
 if [[ -n "$_tdd_context" ]]; then
     assert_pass "stage_test_first recall: tdd_context populated from ruflo results"
 else
-    assert_fail "stage_test_first recall: tdd_context populated from ruflo results" "got empty context"
+    assert_fail "stage_test_first recall: tdd_context populated from ruflo results" "got empty recall output"
 fi
 
 if printf '%s\n' "$_tdd_context" | grep -q "vitest"; then
-    assert_pass "stage_test_first recall: extracted result lines contain expected content"
+    assert_pass "stage_test_first recall: raw recall output contains expected content"
 else
-    assert_fail "stage_test_first recall: extracted result lines contain expected content" "got: $_tdd_context"
+    assert_fail "stage_test_first recall: raw recall output contains expected content" "got: $_tdd_context"
 fi
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -2466,20 +2463,27 @@ ruflo_store() {
     echo "KEY=$1 NS=$3 TAGS=$4" >> "$_store_call_log"
     return 0
 }
+# Provide a deterministic repo hash for the test
+_ruflo_resolve_repo_hash() { echo "testhash123"; }
 
 RUFLO_AVAILABLE=true
 SHIPWRIGHT_PIPELINE_ID="pipeline-99-42"
 GOAL="add authentication"
 TASK_TYPE="feature"
+written_files="tests/auth.test.js"
 
 wrote_any=true
 if ruflo_available && [[ "$wrote_any" == "true" ]]; then
-    _tdd_key="test_first-${SHIPWRIGHT_PIPELINE_ID:-unknown}-$(date +%s)"
-    _tdd_outcome=$(jq -n --arg goal "${GOAL:-}" --arg task "${TASK_TYPE:-feature}" \
-        '{goal: $goal, task_type: $task, tests_generated: true}' 2>/dev/null || echo '{}')
-    ruflo_store "$_tdd_key" "$_tdd_outcome" \
-        "pipeline-${SHIPWRIGHT_PIPELINE_ID:-unknown}" \
-        "tdd,test_first,${TASK_TYPE:-feature}" 2>/dev/null || true
+    _tdd_ns_hash=$(_ruflo_resolve_repo_hash 2>/dev/null) || true
+    if [[ -n "$_tdd_ns_hash" ]]; then
+        _tdd_key="test_first-${SHIPWRIGHT_PIPELINE_ID:-unknown}-$(date +%s)"
+        _tdd_outcome=$(jq -n --arg goal "${GOAL:-}" --arg task "${TASK_TYPE:-feature}" \
+            --arg files "${written_files:-}" \
+            '{goal: $goal, task_type: $task, tests_generated: true, files_written: $files}' 2>/dev/null || echo '{}')
+        ruflo_store "$_tdd_key" "$_tdd_outcome" \
+            "learning-${_tdd_ns_hash}" \
+            "tdd,test_first,${TASK_TYPE:-feature}" 2>/dev/null || true
+    fi
 fi
 
 if [[ -f "$_store_call_log" ]]; then
@@ -2488,10 +2492,10 @@ else
     assert_fail "stage_test_first store: ruflo_store called when wrote_any=true" "store log not created"
 fi
 
-if grep -q "NS=pipeline-pipeline-99-42" "$_store_call_log" 2>/dev/null; then
-    assert_pass "stage_test_first store: namespace contains pipeline ID"
+if grep -q "NS=learning-testhash123" "$_store_call_log" 2>/dev/null; then
+    assert_pass "stage_test_first store: namespace uses learning- prefix for future recall"
 else
-    assert_fail "stage_test_first store: namespace contains pipeline ID" "got: $(cat "$_store_call_log" 2>/dev/null)"
+    assert_fail "stage_test_first store: namespace uses learning- prefix for future recall" "got: $(cat "$_store_call_log" 2>/dev/null)"
 fi
 
 if grep -q "TAGS=tdd,test_first,feature" "$_store_call_log" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Addresses all actionable review comments from Copilot/Codex review of PR #407 (merged).

- **Guard ruflo calls with `declare -f`** — matches pattern used by `stage_plan` and `stage_design`; prevents `command not found` noise when adapter isn't sourced
- **Fix recall query to include requirements/GOAL** — builds composite query with task type, labels, and a 800-char requirements snippet so semantic recall is more relevant
- **Fix JSON parsing bug** — `ruflo_recall_similar_outcomes` returns raw CLI text, not JSON; removed `jq -r '.results[]?'` parsing and `'"results":[]'` check; now treats output as plain text
- **Fix store namespace** — was storing to `pipeline-<PIPELINE_ID>` but `ruflo_recall_similar_outcomes` queries `learning-<repo_hash>`; now stores to `learning-<repo_hash>` so TDD outcomes are retrievable in future runs (fixes the broken semantic feedback loop)
- **Track written file paths** — stored outcome now includes `files_written` field with comma-separated test file paths
- **Fix test mocks** — updated all mocks in `sw-lib-pipeline-stages-test.sh` and `sw-ruflo-adapter-test.sh` to return plain text instead of fabricated JSON
- **Docs** — fix machine-specific absolute paths to repo-relative; update PLAN to reflect actual recall query inputs; fix ADR tech-stack section to be repo-agnostic

## Test Results

- `sw-lib-pipeline-stages-test.sh`: All 74 tests pass
- `sw-ruflo-adapter-test.sh`: All 149 tests pass

Closes review comments on #407.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)