### PR TITLE
fix(test): rm symlink before mv restore in pipeline-detection-test

### DIFF
--- a/scripts/sw-lib-pipeline-detection-test.sh
+++ b/scripts/sw-lib-pipeline-detection-test.sh
@@ -491,7 +491,7 @@ _PIPELINE_DETECT_HELPER_CAPS_CACHE=""
 
 # Restore mock git
 if [[ -f "$TEST_TEMP_DIR/bin/git.mock" ]]; then
-    mv "$TEST_TEMP_DIR/bin/git.mock" "$TEST_TEMP_DIR/bin/git"
+    rm -f "$TEST_TEMP_DIR/bin/git" && mv "$TEST_TEMP_DIR/bin/git.mock" "$TEST_TEMP_DIR/bin/git"
 fi
 
 print_test_results


### PR DESCRIPTION
## Summary

- `sw-lib-pipeline-detection-test.sh:494` used `mv git.mock git` to restore a mock binary after temporarily symlinking to the real system git
- On macOS, BSD `mv` calls `access(dest, W_OK)` which follows symlinks — the real git target (`/usr/bin/git`) is root-owned and unwritable, so `mv` prompts for interactive override
- In a non-interactive pipeline (no stdin), this blocks or exits non-zero under `set -euo pipefail`, killing the entire `npm test` run before newer test suites even execute
- Fix: add `rm -f "$TEST_TEMP_DIR/bin/git" &&` before `mv` — `rm -f` removes the symlink inode without following to the target, so `mv` then restores the mock cleanly

Pre-existing bug; not introduced by any feature branch.

## Test plan

- [ ] `npm test` exits 0
- [ ] `sw-lib-pipeline-detection-test.sh` completes without interactive prompt or hang
- [ ] No regressions in other test suites

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)