### PR TITLE
fix(loop): correct inverted return values in check_fatal_error

### DIFF
--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -213,7 +213,7 @@ check_fatal_error() {
         local match
         match=$(grep -iE "$fatal_patterns" "$log_file" 2>/dev/null | head -1 | cut -c1-120)
         error "Fatal CLI error: $match"
-        return 1  # fatal error detected
+        return 0  # fatal error detected — abort loop
     fi
 
     # Non-zero exit + tiny output = likely CLI crash
@@ -225,7 +225,7 @@ check_fatal_error() {
             local content
             content=$(head -3 "$log_file" 2>/dev/null | cut -c1-120)
             error "CLI exited $cli_exit_code with minimal output: $content"
-            return 0
+            return 1  # not conclusively fatal — let circuit breaker handle retries
         fi
     fi
 


### PR DESCRIPTION
## Summary

- `check_fatal_error` in `scripts/lib/loop-restart.sh` had two return values swapped relative to bash convention
- The caller (`sw-loop.sh:2555`) uses `if check_fatal_error ...; then abort` — meaning return 0 = abort, return 1 = continue
- **Bug 1 (line 216):** Fatal API patterns (auth failure, invalid key, rate limit, network error) returned `1` → loop silently continued wasting iterations against a dead API
- **Bug 2 (line 228):** Non-zero exit with <3 lines of output returned `0` → loop aborted prematurely on any sparse crash log, even transient ones
- Fix: fatal patterns now return `0` (abort); sparse-output crashes now return `1` (let circuit breaker handle after `CIRCUIT_BREAKER_THRESHOLD` consecutive failures)

## Test plan

- [ ] All three branches of `check_fatal_error` verified via direct sourcing (fatal aborts, sparse crash continues, normal continues)
- [ ] `npm test` passes
- [ ] No regressions

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)