### PR TITLE
fix(pipeline): derive model from loop-state.md instead of hardcoding opus

### DIFF
--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -526,3 +526,31 @@ safe_git_stage() {
     fi
 }
 
+# ─── Model Resolution Helpers ────────────────────────────────────
+# get_pipeline_model: for pre-loop sites (startup, dry-run, pipeline.started).
+# Loop-state.md does not exist yet at these call sites.
+# Priority: $MODEL (CLI flag) → pipeline config .defaults.model → "opus"
+get_pipeline_model() {
+    if [[ -n "${MODEL:-}" ]]; then echo "$MODEL"; return; fi
+    if [[ -n "${PIPELINE_CONFIG:-}" && -f "${PIPELINE_CONFIG:-/dev/null}" ]]; then
+        local _m
+        _m=$(jq -r '.defaults.model // ""' "$PIPELINE_CONFIG" 2>/dev/null || echo "")
+        if [[ -n "$_m" && "$_m" != "null" ]]; then echo "$_m"; return; fi
+    fi
+    echo "opus"
+}
+
+# get_effective_model: for post-stage / telemetry sites.
+# Reads loop-state.md when present so recorded model matches what actually ran.
+# Priority: loop-state.md model: → $CLAUDE_MODEL → $MODEL → pipeline config → "opus"
+get_effective_model() {
+    local _loop_state="${STATE_DIR:-.claude}/loop-state.md"
+    if [[ -f "$_loop_state" ]]; then
+        local _m
+        _m=$(grep -m1 '^model: ' "$_loop_state" 2>/dev/null | sed 's/^model: //' | tr -d '"')
+        if [[ -n "$_m" && "$_m" != "null" ]]; then echo "$_m"; return; fi
+    fi
+    if [[ -n "${CLAUDE_MODEL:-}" ]]; then echo "$CLAUDE_MODEL"; return; fi
+    get_pipeline_model
+}
+

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -633,6 +633,7 @@ write_state() {
         printf 'elapsed: %s\n' "${total_dur:-0s}"
         printf 'test_cmd: "%s"\n' "${TEST_CMD:-}"
         printf 'pr_number: %s\n' "${PR_NUMBER:-}"
+        printf 'model: %s\n' "$(get_effective_model)"
         printf 'progress_comment_id: %s\n' "${PROGRESS_COMMENT_ID:-}"
         printf 'stages:\n'
         printf '%s' "${stages_yaml}"

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -633,7 +633,7 @@ write_state() {
         printf 'elapsed: %s\n' "${total_dur:-0s}"
         printf 'test_cmd: "%s"\n' "${TEST_CMD:-}"
         printf 'pr_number: %s\n' "${PR_NUMBER:-}"
-        printf 'model: %s\n' "$(get_effective_model)"
+        type get_effective_model >/dev/null 2>&1 && printf 'model: %s\n' "$(get_effective_model)" || true
         printf 'progress_comment_id: %s\n' "${PROGRESS_COMMENT_ID:-}"
         printf 'stages:\n'
         printf '%s' "${stages_yaml}"

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -2040,6 +2040,62 @@ test_ci_post_stage_event_noop_outside_ci() {
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Model resolution: CLI flag (MODEL=sonnet) wins over config default
+# ──────────────────────────────────────────────────────────────────────────────
+test_model_resolution() {
+    # Write a loop-state.md as if the loop chose haiku (post-stage context)
+    mkdir -p "$TEST_TEMP_DIR/project/.claude"
+    cat > "$TEST_TEMP_DIR/project/.claude/loop-state.md" <<'LSEOF'
+model: haiku
+iteration: 2
+LSEOF
+
+    # Run dry-run with --model sonnet — get_pipeline_model() must honor the CLI flag
+    invoke_pipeline start --goal "test model resolution" --model sonnet --dry-run
+
+    assert_exit_code 0 "dry-run with --model sonnet should succeed" &&
+    assert_output_contains "sonnet" "CLI flag --model sonnet should appear in dry-run output" &&
+    assert_output_not_contains "^opus$" "opus should not appear as the selected model when sonnet is specified"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Model resolution: no CLI flag falls back to pipeline config default
+# ──────────────────────────────────────────────────────────────────────────────
+test_model_resolution_no_flag() {
+    # Override standard template so defaults.model is "sonnet"
+    cat > "$TEST_TEMP_DIR/templates/pipelines/standard.json" <<'TMPL'
+{
+  "name": "standard",
+  "description": "Test pipeline with sonnet default model",
+  "defaults": { "test_cmd": "npm test", "model": "sonnet", "agents": 1 },
+  "stages": [
+    { "id": "intake",   "enabled": true,  "gate": "auto", "config": {} },
+    { "id": "plan",     "enabled": true,  "gate": "auto", "config": {} },
+    { "id": "build",    "enabled": true,  "gate": "auto", "config": { "max_iterations": 20 } },
+    { "id": "test",     "enabled": true,  "gate": "auto", "config": { "coverage_min": 0 } },
+    { "id": "review",   "enabled": true,  "gate": "auto", "config": {} },
+    { "id": "pr",       "enabled": true,  "gate": "auto", "config": { "wait_ci": false } },
+    { "id": "deploy",   "enabled": false, "gate": "auto", "config": {} },
+    { "id": "validate", "enabled": false, "gate": "auto", "config": {} }
+  ]
+}
+TMPL
+
+    # Write loop-state.md showing the loop chose sonnet (get_effective_model reads this)
+    mkdir -p "$TEST_TEMP_DIR/project/.claude"
+    cat > "$TEST_TEMP_DIR/project/.claude/loop-state.md" <<'LSEOF'
+model: sonnet
+iteration: 1
+LSEOF
+
+    # Run dry-run with no MODEL env var — get_pipeline_model() should read config default
+    invoke_pipeline start --goal "test model resolution no flag" --dry-run
+
+    assert_exit_code 0 "dry-run without MODEL flag should succeed" &&
+    assert_output_contains "sonnet" "pipeline config default model=sonnet should appear in dry-run output"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Guard: run_stage_with_retry fails fast on undefined stage function
 # ──────────────────────────────────────────────────────────────────────────────
 test_run_stage_with_retry_undefined_stage() {
@@ -2238,6 +2294,8 @@ main() {
         "test_ci_post_stage_event_noop_outside_ci:CI: ci_post_stage_event is no-op outside CI mode"
         "test_run_stage_with_retry_undefined_stage:Guard: run_stage_with_retry fails fast on undefined stage function"
         "test_partial_work_push_condition:CI: partial-work push triggers on failure OR cancelled (issue #437)"
+        "test_model_resolution:Model: CLI flag MODEL=sonnet wins over config default in dry-run"
+        "test_model_resolution_no_flag:Model: pipeline config default model used when no CLI flag set"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -2054,8 +2054,8 @@ LSEOF
     invoke_pipeline start --goal "test model resolution" --model sonnet --dry-run
 
     assert_exit_code 0 "dry-run with --model sonnet should succeed" &&
-    assert_output_contains "sonnet" "CLI flag --model sonnet should appear in dry-run output" &&
-    assert_output_not_contains "^opus$" "opus should not appear as the selected model when sonnet is specified"
+    assert_output_contains "sonnet" "CLI --model sonnet should appear in dry-run output" &&
+    assert_output_not_contains "opus" "opus should not appear anywhere in dry-run output when sonnet is specified"
 }
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -1878,8 +1878,10 @@ run_pipeline() {
             audit_emit "stage.start" "stage=$id" || true
         fi
 
-        local stage_model_used="$(get_effective_model)"
+        local stage_model_used=""
         if run_stage_with_retry "$id"; then
+            # Resolve after stage runs so loop-state.md reflects this stage's model
+            stage_model_used="$(get_effective_model)"
             mark_stage_complete "$id"
             completed=$((completed + 1))
             # Capture project pattern after intake (for memory context in later stages)
@@ -1925,9 +1927,10 @@ run_pipeline() {
                 && [[ -s "$ARTIFACTS_DIR/review-blockers.md" ]]; then
                 info "Review blocked — attempting review self-healing rebuild..."
                 if self_healing_review_build_test; then
+                    stage_model_used="$(get_effective_model)"
                     mark_stage_complete "$id"
                     completed=$((completed + 1))
-                    echo "${id}|${stage_model_used:-$(get_effective_model)}|true" >> "${ARTIFACTS_DIR}/model-routing.log"
+                    echo "${id}|${stage_model_used}|true" >> "${ARTIFACTS_DIR}/model-routing.log"
                     continue
                 fi
                 # Self-healing exhausted — fall through to normal failure
@@ -2757,7 +2760,8 @@ pipeline_start() {
     PIPELINE_EXIT_CODE="$exit_code"
 
     # Compute total cost for pipeline.completed (prefer actual from Claude when available)
-    local model_key="${MODEL:-sonnet}"
+    local model_key
+    model_key="$(get_effective_model)"
     local total_cost
     if [[ -n "${TOTAL_COST_USD:-}" && "${TOTAL_COST_USD}" != "0" && "${TOTAL_COST_USD}" != "null" ]]; then
         total_cost="${TOTAL_COST_USD}"
@@ -2988,7 +2992,8 @@ pipeline_start() {
     fi
 
     # Emit cost event — prefer actual cost from Claude CLI when available
-    local model_key="${MODEL:-sonnet}"
+    local model_key
+    model_key="$(get_effective_model)"
     local total_cost
     if [[ -n "${TOTAL_COST_USD:-}" && "${TOTAL_COST_USD}" != "0" && "${TOTAL_COST_USD}" != "null" ]]; then
         total_cost="${TOTAL_COST_USD}"

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -1847,7 +1847,7 @@ run_pipeline() {
                 if [[ "$use_recommended" == "true" ]]; then
                     export CLAUDE_MODEL="$recommended_model"
                 else
-                    export CLAUDE_MODEL="opus"
+                    export CLAUDE_MODEL="opus" # A/B control arm: opus is intentional — do not replace with get_effective_model()
                 fi
 
                 emit_event "intelligence.model_ab" \
@@ -1878,7 +1878,7 @@ run_pipeline() {
             audit_emit "stage.start" "stage=$id" || true
         fi
 
-        local stage_model_used="${CLAUDE_MODEL:-${MODEL:-opus}}"
+        local stage_model_used="$(get_effective_model)"
         if run_stage_with_retry "$id"; then
             mark_stage_complete "$id"
             completed=$((completed + 1))
@@ -1927,7 +1927,7 @@ run_pipeline() {
                 if self_healing_review_build_test; then
                     mark_stage_complete "$id"
                     completed=$((completed + 1))
-                    echo "${id}|${stage_model_used:-opus}|true" >> "${ARTIFACTS_DIR}/model-routing.log"
+                    echo "${id}|${stage_model_used:-$(get_effective_model)}|true" >> "${ARTIFACTS_DIR}/model-routing.log"
                     continue
                 fi
                 # Self-healing exhausted — fall through to normal failure
@@ -2195,7 +2195,7 @@ run_dry_run() {
 
     # Build model (per-stage override or default)
     local default_model stage_model
-    default_model=$(jq -r '.defaults.model // "opus"' "$PIPELINE_CONFIG")
+    default_model=$(get_pipeline_model)
     stage_model="$MODEL"
     [[ -z "$stage_model" ]] && stage_model="$default_model"
 
@@ -2668,7 +2668,7 @@ pipeline_start() {
         echo -e "  ${BOLD}Gates:${RESET}       ${gate_count} approval gate(s)"
     fi
 
-    echo -e "  ${BOLD}Model:${RESET}       ${MODEL:-$(jq -r '.defaults.model // "opus"' "$PIPELINE_CONFIG")}"
+    echo -e "  ${BOLD}Model:${RESET}       $(get_pipeline_model)"
     echo -e "  ${BOLD}Self-heal:${RESET}   ${BUILD_TEST_RETRIES} retry cycle(s)"
 
     if [[ "$GH_AVAILABLE" == "true" ]]; then
@@ -2739,7 +2739,7 @@ pipeline_start() {
         "complexity=${INTELLIGENCE_COMPLEXITY:-0}" \
         "machine=$(hostname 2>/dev/null || echo "unknown")" \
         "pipeline=${PIPELINE_NAME}" \
-        "model=${MODEL:-opus}" \
+        "model=$(get_pipeline_model)" \
         "goal=${GOAL}"
 
     # Record pipeline run in SQLite for dashboard visibility


### PR DESCRIPTION
## Summary

- `sw-pipeline.sh` hardcoded `"opus"` as the model fallback in 6 places, causing cost telemetry and `pipeline-state.md` to diverge from the model `sw-loop.sh` actually used
- Adds `get_pipeline_model()` (pre-loop: CLI flag → config → opus) and `get_effective_model()` (post-stage: loop-state.md → CLAUDE_MODEL → CLI flag → config → opus) to `scripts/lib/helpers.sh`
- Wires both helpers into all affected sites; A/B test control arm at line 1850 intentionally left as `"opus"` with explanatory comment
- `pipeline-state.sh::write_state()` now records `model:` so both state files agree after each stage

## Test plan

- [ ] `npm test` passes (71 tests, up from 69 — 2 new model-resolution cases added)
- [ ] `grep -n '"opus"' scripts/sw-pipeline.sh` returns only lines 616 (cost rates) and 1850 (A/B control, commented)
- [ ] `MODEL=sonnet bash scripts/sw-pipeline.sh --dry-run --goal "test"` shows `Model: sonnet` with no spurious `opus`
- [ ] After a stage completes, both `.claude/loop-state.md` and `.claude/pipeline-state.md` agree on `model:`

Closes #442

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)