### PR TITLE
feat(cost): stage-level cost attribution — architecture hardening (#87)

### DIFF
--- a/scripts/lib/cost/iteration.sh
+++ b/scripts/lib/cost/iteration.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# lib/cost/iteration.sh — per-iteration cost recording for the build loop
+# Canonical location. lib/loop-cost.sh is a backward-compat shim.
+# Sourced by sw-loop.sh. Extracted here for testability (no sw-loop.sh side effects).
+[[ -n "${_LOOP_COST_LOADED:-}" ]] && return 0
+_LOOP_COST_LOADED=1
+
+# record_iteration_cost <iter_num>
+# Appends one JSON line to $ITER_COST_JSONL using deltas from snapshot vars
+# (_ITER_SNAP_INPUT, _ITER_SNAP_OUTPUT, _ITER_SNAP_COST_MC) that must be set
+# immediately before run_claude_iteration.
+record_iteration_cost() {
+    local iter_num="${1:-0}"
+    [[ -z "${ITER_COST_JSONL:-}" ]] && return 0
+    # Snapshot vars must be set by the caller right before run_claude_iteration.
+    # Treat "totally unset" (not just empty) as a programming error so the call site
+    # gets fixed instead of silently recording cumulative-as-delta.
+    if [[ -z "${_ITER_SNAP_INPUT+x}" || -z "${_ITER_SNAP_OUTPUT+x}" || -z "${_ITER_SNAP_COST_MC+x}" ]]; then
+        echo "warn: record_iteration_cost: _ITER_SNAP_* not set; skipping iter=${iter_num}" >&2
+        return 0
+    fi
+    local _delta_in=$(( ${LOOP_INPUT_TOKENS:-0}    - ${_ITER_SNAP_INPUT}    ))
+    local _delta_out=$(( ${LOOP_OUTPUT_TOKENS:-0}   - ${_ITER_SNAP_OUTPUT}   ))
+    local _delta_mc=$((  ${LOOP_COST_MILLICENTS:-0} - ${_ITER_SNAP_COST_MC}  ))
+    local _cost_usd="0"
+    [[ "$_delta_mc" -gt 0 ]] && \
+        _cost_usd=$(awk -v mc="$_delta_mc" 'BEGIN {printf "%.6f", mc/100000}' 2>/dev/null || echo "0")
+    local _ts _ts_epoch
+    _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    _ts_epoch=$(date +%s)
+    jq -cn \
+        --argjson iter "$iter_num" \
+        --argjson input "$_delta_in" \
+        --argjson output "$_delta_out" \
+        --arg cost "$_cost_usd" \
+        --arg ts "$_ts" \
+        --argjson ts_epoch "$_ts_epoch" \
+        --arg issue "${ISSUE_NUMBER:-}" \
+        '{iteration: $iter, input_tokens: $input, output_tokens: $output, cost_usd: ($cost|tonumber), ts: $ts, ts_epoch: $ts_epoch, issue: $issue}' \
+        2>/dev/null >> "$ITER_COST_JSONL" || true
+    # Emit event for parity with cost_record (allows event stream consumers to track iteration cost)
+    if type emit_event >/dev/null 2>&1; then
+        emit_event "cost.iteration_recorded" \
+            "iter=${iter_num}" \
+            "input=${_delta_in}" \
+            "output=${_delta_out}" \
+            "cost_usd=${_cost_usd}" \
+            "issue=${ISSUE_NUMBER:-}" 2>/dev/null || true
+    fi
+}

--- a/scripts/lib/cost/stage.sh
+++ b/scripts/lib/cost/stage.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# lib/cost/stage.sh — per-stage cost recording bracket helpers
+# Canonical location. lib/stage-cost.sh is a backward-compat shim.
+#
+# Usage pattern in each stage function:
+#   record_stage_cost_start "stagename"   ← at function entry
+#   ...stage work...
+#   record_stage_cost_end "stagename"     ← before every return and at natural end
+#
+# Or use the decorator for automatic pairing:
+#   cost_track_stage "stagename" stage_fn_name
+#
+# Notes:
+#   - run_stage_with_retry calls _start/_end once per attempt, so retried stages
+#     get N records in stage-costs.jsonl (one per attempt). cost_generate_breakdown
+#     groups by stage name and reports `count: N` plus aggregated tokens/cost.
+#   - Pipeline resume re-snapshots on the resumed attempt; deltas span only what
+#     the resumed attempt consumed, which is the desired semantic.
+[[ -n "${_STAGE_COST_LOADED:-}" ]] && return 0
+_STAGE_COST_LOADED=1
+
+# record_stage_cost_start <stage_name>
+# Call at the top of each stage function. Snapshots current cumulative token totals.
+# Bash 3.2 safe: eval is used (not declare -A) because stage names are hardcoded constants.
+# Stage name must be a valid bash identifier (letters, digits, underscore; not starting with digit).
+record_stage_cost_start() {
+    local stage="${1:-}"
+    [[ -z "$stage" ]] && return 0
+    [[ "$stage" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 0
+    eval "_STAGE_SNAP_INPUT_${stage}=\${TOTAL_INPUT_TOKENS:-0}"
+    eval "_STAGE_SNAP_OUTPUT_${stage}=\${TOTAL_OUTPUT_TOKENS:-0}"
+    eval "_STAGE_SNAP_MODEL_${stage}=\${MODEL:-sonnet}"
+}
+
+# record_stage_cost_end <stage_name>
+# Call before every return in a stage function and at the natural end.
+# Computes delta vs snapshot, writes to:
+#   1. Global costs.json via cost_record (historical analytics, now with real stage names)
+#   2. $ARTIFACTS_DIR/stage-costs.jsonl (pipeline-local, source of truth for cost-breakdown.json)
+# No-ops silently when both token deltas are zero (stage made no Claude calls).
+record_stage_cost_end() {
+    local stage="${1:-}"
+    [[ -z "$stage" ]] && return 0
+    [[ "$stage" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 0
+    local _vin="_STAGE_SNAP_INPUT_${stage}"
+    local _vout="_STAGE_SNAP_OUTPUT_${stage}"
+    local _vmodel="_STAGE_SNAP_MODEL_${stage}"
+    local _delta_in=$(( ${TOTAL_INPUT_TOKENS:-0}  - ${!_vin:-0} ))
+    local _delta_out=$(( ${TOTAL_OUTPUT_TOKENS:-0} - ${!_vout:-0} ))
+    # No-op when there were no Claude calls in this stage. eq (not le) so that a
+    # negative delta — which signals a counter reset bug — does not get silently
+    # swallowed; it falls through to cost_record where the bad data is visible.
+    [[ "$_delta_in" -eq 0 && "$_delta_out" -eq 0 ]] && return 0
+    # Use snapshotted model so stages that override MODEL locally (e.g. stage_design)
+    # are billed at the rate that was in effect when the stage started.
+    local _model="${!_vmodel:-${MODEL:-sonnet}}"
+    # 1. Global costs.json (historical analytics — real stage names from now on)
+    if type cost_record >/dev/null 2>&1; then
+        cost_record "$_delta_in" "$_delta_out" "$_model" \
+            "$stage" "${ISSUE_NUMBER:-}" 2>/dev/null || true
+    fi
+    # 2. Pipeline-local sidecar (concurrent-pipeline safe; never queries global ledger).
+    # flock-protected so parallel sub-stages (e.g. compound_quality) do not interleave.
+    if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
+        mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
+        local _ts _ts_epoch _cost_usd="0" _sidecar="${ARTIFACTS_DIR}/stage-costs.jsonl"
+        _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        _ts_epoch=$(date +%s)
+        if type cost_calculate >/dev/null 2>&1; then
+            _cost_usd=$(cost_calculate "$_delta_in" "$_delta_out" "$_model" 2>/dev/null || echo "0")
+        fi
+        local _line
+        _line=$(jq -cn \
+            --arg stage "$stage" \
+            --argjson input "$_delta_in" \
+            --argjson output "$_delta_out" \
+            --arg model "$_model" \
+            --arg cost "$_cost_usd" \
+            --arg ts "$_ts" \
+            --argjson ts_epoch "$_ts_epoch" \
+            --arg issue "${ISSUE_NUMBER:-}" \
+            '{stage: $stage, input_tokens: $input, output_tokens: $output, cost_usd: ($cost|tonumber), model: $model, ts: $ts, ts_epoch: $ts_epoch, issue: $issue}' \
+            2>/dev/null) || _line=""
+        if [[ -n "$_line" ]]; then
+            (
+                if command -v flock >/dev/null 2>&1; then
+                    flock -w 5 200 2>/dev/null || true
+                fi
+                echo "$_line" >> "$_sidecar" 2>/dev/null || true
+            ) 200>"${_sidecar}.lock"
+        fi
+    fi
+}
+
+# cost_track_stage <stage_name> <function_name> [args...]
+# Decorator that automatically brackets a stage function with start/end recording.
+# Captures and propagates the wrapped function's exit code.
+#
+# Example:
+#   cost_track_stage "build" stage_build
+#   cost_track_stage "test"  run_tests --fast
+cost_track_stage() {
+    local _stage="${1:-}"
+    local _fn="${2:-}"
+    [[ -z "$_stage" || -z "$_fn" ]] && { echo "usage: cost_track_stage <stage> <fn> [args...]" >&2; return 1; }
+    shift 2
+    record_stage_cost_start "$_stage"
+    local _rc=0
+    "$_fn" "$@" || _rc=$?
+    record_stage_cost_end "$_stage"
+    return $_rc
+}

--- a/scripts/lib/cost/stage.sh
+++ b/scripts/lib/cost/stage.sh
@@ -29,7 +29,8 @@ record_stage_cost_start() {
     [[ "$stage" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 0
     eval "_STAGE_SNAP_INPUT_${stage}=\${TOTAL_INPUT_TOKENS:-0}"
     eval "_STAGE_SNAP_OUTPUT_${stage}=\${TOTAL_OUTPUT_TOKENS:-0}"
-    eval "_STAGE_SNAP_MODEL_${stage}=\${MODEL:-sonnet}"
+    # Prefer CLAUDE_MODEL (set by intelligence routing) over MODEL (--model flag) over default.
+    eval "_STAGE_SNAP_MODEL_${stage}=\${CLAUDE_MODEL:-\${MODEL:-sonnet}}"
 }
 
 # record_stage_cost_end <stage_name>

--- a/scripts/lib/loop-cost.sh
+++ b/scripts/lib/loop-cost.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# loop-cost.sh — per-iteration cost recording for the build loop
+# Sourced by sw-loop.sh. Extracted here for testability (no sw-loop.sh side effects).
+[[ -n "${_LOOP_COST_LOADED:-}" ]] && return 0
+_LOOP_COST_LOADED=1
+
+# record_iteration_cost <iter_num>
+# Appends one JSON line to $ITER_COST_JSONL using deltas from snapshot vars
+# (_ITER_SNAP_INPUT, _ITER_SNAP_OUTPUT, _ITER_SNAP_COST_MC) that must be set
+# immediately before run_claude_iteration.
+record_iteration_cost() {
+    local iter_num="${1:-0}"
+    [[ -z "${ITER_COST_JSONL:-}" ]] && return 0
+    local _delta_in=$(( ${LOOP_INPUT_TOKENS:-0}    - ${_ITER_SNAP_INPUT:-0}    ))
+    local _delta_out=$(( ${LOOP_OUTPUT_TOKENS:-0}   - ${_ITER_SNAP_OUTPUT:-0}   ))
+    local _delta_mc=$((  ${LOOP_COST_MILLICENTS:-0} - ${_ITER_SNAP_COST_MC:-0}  ))
+    local _cost_usd="0"
+    [[ "$_delta_mc" -gt 0 ]] && \
+        _cost_usd=$(awk "BEGIN {printf \"%.6f\", ${_delta_mc}/100000}" 2>/dev/null || echo "0")
+    local _ts
+    _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    jq -cn \
+        --argjson iter "$iter_num" \
+        --argjson input "$_delta_in" \
+        --argjson output "$_delta_out" \
+        --arg cost "$_cost_usd" \
+        --arg ts "$_ts" \
+        '{iteration: $iter, input_tokens: $input, output_tokens: $output, cost_usd: ($cost|tonumber), ts: $ts}' \
+        2>/dev/null >> "$ITER_COST_JSONL" || true
+}

--- a/scripts/lib/loop-cost.sh
+++ b/scripts/lib/loop-cost.sh
@@ -1,30 +1,6 @@
 #!/usr/bin/env bash
-# loop-cost.sh — per-iteration cost recording for the build loop
-# Sourced by sw-loop.sh. Extracted here for testability (no sw-loop.sh side effects).
+# Backward-compat shim — canonical location is lib/cost/iteration.sh
+# Sources the canonical implementation so existing callers continue to work.
 [[ -n "${_LOOP_COST_LOADED:-}" ]] && return 0
-_LOOP_COST_LOADED=1
-
-# record_iteration_cost <iter_num>
-# Appends one JSON line to $ITER_COST_JSONL using deltas from snapshot vars
-# (_ITER_SNAP_INPUT, _ITER_SNAP_OUTPUT, _ITER_SNAP_COST_MC) that must be set
-# immediately before run_claude_iteration.
-record_iteration_cost() {
-    local iter_num="${1:-0}"
-    [[ -z "${ITER_COST_JSONL:-}" ]] && return 0
-    local _delta_in=$(( ${LOOP_INPUT_TOKENS:-0}    - ${_ITER_SNAP_INPUT:-0}    ))
-    local _delta_out=$(( ${LOOP_OUTPUT_TOKENS:-0}   - ${_ITER_SNAP_OUTPUT:-0}   ))
-    local _delta_mc=$((  ${LOOP_COST_MILLICENTS:-0} - ${_ITER_SNAP_COST_MC:-0}  ))
-    local _cost_usd="0"
-    [[ "$_delta_mc" -gt 0 ]] && \
-        _cost_usd=$(awk "BEGIN {printf \"%.6f\", ${_delta_mc}/100000}" 2>/dev/null || echo "0")
-    local _ts
-    _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    jq -cn \
-        --argjson iter "$iter_num" \
-        --argjson input "$_delta_in" \
-        --argjson output "$_delta_out" \
-        --arg cost "$_cost_usd" \
-        --arg ts "$_ts" \
-        '{iteration: $iter, input_tokens: $input, output_tokens: $output, cost_usd: ($cost|tonumber), ts: $ts}' \
-        2>/dev/null >> "$ITER_COST_JSONL" || true
-}
+_shim_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$_shim_dir/cost/iteration.sh" ]] && source "$_shim_dir/cost/iteration.sh"

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -559,6 +559,8 @@ ${_build_recall_ctx}"
 
     local _token_log="${ARTIFACTS_DIR}/.claude-tokens-build.log"
     export PIPELINE_JOB_ID="${PIPELINE_NAME:-pipeline-$$}"
+    # Per-iteration cost sidecar (issue #87) — read by sw-loop.sh's record_iteration_cost.
+    export ITER_COST_JSONL="${ARTIFACTS_DIR}/loop-iteration-costs.jsonl"
     sw loop "${loop_args[@]}" < /dev/null 2>"$_token_log" || {
         local _loop_exit=$?
         parse_claude_tokens "$_token_log"

--- a/scripts/lib/stage-cost.sh
+++ b/scripts/lib/stage-cost.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# stage-cost.sh — per-stage cost recording bracket helpers
+# Sourced by pipeline stage functions. Extracted for testability.
+#
+# Usage pattern in each stage function:
+#   record_stage_cost_start "stagename"   ← at function entry
+#   ...stage work...
+#   record_stage_cost_end "stagename"     ← before every return and at natural end
+#
+# V1 limitations (documented, not blocking):
+#   - MODEL may be approximate: some stages override MODEL locally (e.g. stage_design
+#     uses design_model). We record ${MODEL:-sonnet} which is an approximation.
+#   - Stage-retry snapshot overwrite: on retry the second _start overwrites the
+#     snapshot, so the pipeline-local sidecar captures only the last attempt's delta.
+#     First-attempt cost still lands in global costs.json via cost_record.
+[[ -n "${_STAGE_COST_LOADED:-}" ]] && return 0
+_STAGE_COST_LOADED=1
+
+# record_stage_cost_start <stage_name>
+# Call at the top of each stage function. Snapshots current cumulative token totals.
+# Bash 3.2 safe: eval is used (not declare -A) because stage names are hardcoded constants.
+record_stage_cost_start() {
+    local stage="$1"
+    eval "_STAGE_SNAP_INPUT_${stage}=\${TOTAL_INPUT_TOKENS:-0}"
+    eval "_STAGE_SNAP_OUTPUT_${stage}=\${TOTAL_OUTPUT_TOKENS:-0}"
+}
+
+# record_stage_cost_end <stage_name>
+# Call before every return in a stage function and at the natural end.
+# Computes delta vs snapshot, writes to:
+#   1. Global costs.json via cost_record (historical analytics, now with real stage names)
+#   2. $ARTIFACTS_DIR/stage-costs.jsonl (pipeline-local, source of truth for cost-breakdown.json)
+# No-ops silently when both token deltas are zero (stage made no Claude calls).
+record_stage_cost_end() {
+    local stage="$1"
+    local _vin="_STAGE_SNAP_INPUT_${stage}"
+    local _vout="_STAGE_SNAP_OUTPUT_${stage}"
+    local _delta_in=$(( ${TOTAL_INPUT_TOKENS:-0}  - ${!_vin:-0} ))
+    local _delta_out=$(( ${TOTAL_OUTPUT_TOKENS:-0} - ${!_vout:-0} ))
+    [[ "$_delta_in" -le 0 && "$_delta_out" -le 0 ]] && return 0
+    # 1. Global costs.json (historical analytics — real stage names from now on)
+    if type cost_record >/dev/null 2>&1; then
+        cost_record "$_delta_in" "$_delta_out" "${MODEL:-sonnet}" \
+            "$stage" "${ISSUE_NUMBER:-}" 2>/dev/null || true
+    fi
+    # 2. Pipeline-local sidecar (concurrent-pipeline safe; never queries global ledger)
+    if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
+        mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
+        local _ts
+        _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+        jq -cn \
+            --arg stage "$stage" \
+            --argjson input "$_delta_in" \
+            --argjson output "$_delta_out" \
+            --arg model "${MODEL:-sonnet}" \
+            --arg ts "$_ts" \
+            '{stage: $stage, input_tokens: $input, output_tokens: $output, model: $model, ts: $ts}' \
+            2>/dev/null >> "${ARTIFACTS_DIR}/stage-costs.jsonl" || true
+    fi
+}

--- a/scripts/lib/stage-cost.sh
+++ b/scripts/lib/stage-cost.sh
@@ -1,60 +1,6 @@
 #!/usr/bin/env bash
-# stage-cost.sh — per-stage cost recording bracket helpers
-# Sourced by pipeline stage functions. Extracted for testability.
-#
-# Usage pattern in each stage function:
-#   record_stage_cost_start "stagename"   ← at function entry
-#   ...stage work...
-#   record_stage_cost_end "stagename"     ← before every return and at natural end
-#
-# V1 limitations (documented, not blocking):
-#   - MODEL may be approximate: some stages override MODEL locally (e.g. stage_design
-#     uses design_model). We record ${MODEL:-sonnet} which is an approximation.
-#   - Stage-retry snapshot overwrite: on retry the second _start overwrites the
-#     snapshot, so the pipeline-local sidecar captures only the last attempt's delta.
-#     First-attempt cost still lands in global costs.json via cost_record.
+# Backward-compat shim — canonical location is lib/cost/stage.sh
+# Sources the canonical implementation so existing callers continue to work.
 [[ -n "${_STAGE_COST_LOADED:-}" ]] && return 0
-_STAGE_COST_LOADED=1
-
-# record_stage_cost_start <stage_name>
-# Call at the top of each stage function. Snapshots current cumulative token totals.
-# Bash 3.2 safe: eval is used (not declare -A) because stage names are hardcoded constants.
-record_stage_cost_start() {
-    local stage="$1"
-    eval "_STAGE_SNAP_INPUT_${stage}=\${TOTAL_INPUT_TOKENS:-0}"
-    eval "_STAGE_SNAP_OUTPUT_${stage}=\${TOTAL_OUTPUT_TOKENS:-0}"
-}
-
-# record_stage_cost_end <stage_name>
-# Call before every return in a stage function and at the natural end.
-# Computes delta vs snapshot, writes to:
-#   1. Global costs.json via cost_record (historical analytics, now with real stage names)
-#   2. $ARTIFACTS_DIR/stage-costs.jsonl (pipeline-local, source of truth for cost-breakdown.json)
-# No-ops silently when both token deltas are zero (stage made no Claude calls).
-record_stage_cost_end() {
-    local stage="$1"
-    local _vin="_STAGE_SNAP_INPUT_${stage}"
-    local _vout="_STAGE_SNAP_OUTPUT_${stage}"
-    local _delta_in=$(( ${TOTAL_INPUT_TOKENS:-0}  - ${!_vin:-0} ))
-    local _delta_out=$(( ${TOTAL_OUTPUT_TOKENS:-0} - ${!_vout:-0} ))
-    [[ "$_delta_in" -le 0 && "$_delta_out" -le 0 ]] && return 0
-    # 1. Global costs.json (historical analytics — real stage names from now on)
-    if type cost_record >/dev/null 2>&1; then
-        cost_record "$_delta_in" "$_delta_out" "${MODEL:-sonnet}" \
-            "$stage" "${ISSUE_NUMBER:-}" 2>/dev/null || true
-    fi
-    # 2. Pipeline-local sidecar (concurrent-pipeline safe; never queries global ledger)
-    if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
-        mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
-        local _ts
-        _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        jq -cn \
-            --arg stage "$stage" \
-            --argjson input "$_delta_in" \
-            --argjson output "$_delta_out" \
-            --arg model "${MODEL:-sonnet}" \
-            --arg ts "$_ts" \
-            '{stage: $stage, input_tokens: $input, output_tokens: $output, model: $model, ts: $ts}' \
-            2>/dev/null >> "${ARTIFACTS_DIR}/stage-costs.jsonl" || true
-    fi
-}
+_shim_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[[ -f "$_shim_dir/cost/stage.sh" ]] && source "$_shim_dir/cost/stage.sh"

--- a/scripts/sw-cost-test.sh
+++ b/scripts/sw-cost-test.sh
@@ -40,20 +40,6 @@ MOCKEOF
 
 _test_cleanup_hook() { cleanup_test_env; }
 
-assert_pass() {
-    local desc="$1"
-    echo -e "  ${GREEN}✓${RESET} ${desc}"
-}
-
-assert_fail() {
-    local desc="$1"
-    local detail="${2:-}"
-    FAILURES+=("$desc")
-    echo -e "  ${RED}✗${RESET} ${desc}"
-    [[ -n "$detail" ]] && echo -e "    ${DIM}${detail}${RESET}"
-    return 0
-}
-
 # ═══════════════════════════════════════════════════════════════════════════════
 # TESTS
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -327,7 +313,7 @@ else
 fi
 
 # ── Test 4: record_iteration_cost from lib/loop-cost.sh ───────────────────────
-_loop_cost_lib="$SCRIPT_DIR/lib/loop-cost.sh"
+_loop_cost_lib="$SCRIPT_DIR/lib/cost/iteration.sh"
 if [[ -f "$_loop_cost_lib" ]]; then
     _iter_sidecar="$TEST_TEMP_DIR/test-iter-costs.jsonl"
     (
@@ -370,14 +356,14 @@ if [[ -f "$_loop_cost_lib" ]]; then
         assert_fail "record_iteration_cost: iteration 1 delta input_tokens correct (5000)" "got: ${_iter1_input}"
     fi
 else
-    assert_fail "record_iteration_cost: lib/loop-cost.sh exists" "file not found: $_loop_cost_lib"
+    assert_fail "record_iteration_cost: lib/cost/iteration.sh exists" "file not found: $_loop_cost_lib"
     assert_fail "record_iteration_cost: sidecar has 3 lines"
     assert_fail "record_iteration_cost: iteration numbers are 1/2/3"
     assert_fail "record_iteration_cost: iteration 1 delta input_tokens correct (5000)"
 fi
 
 # ── Test 5: record_stage_cost_start/end from lib/stage-cost.sh ─────────────────
-_stage_cost_lib="$SCRIPT_DIR/lib/stage-cost.sh"
+_stage_cost_lib="$SCRIPT_DIR/lib/cost/stage.sh"
 if [[ -f "$_stage_cost_lib" ]]; then
     _stage_sidecar_dir="$TEST_TEMP_DIR/stage-cost-test"
     mkdir -p "$_stage_sidecar_dir"
@@ -400,6 +386,8 @@ if [[ -f "$_stage_cost_lib" ]]; then
     if [[ -f "$_stage_sidecar_dir/stage-costs.jsonl" ]]; then
         _sc_stage=$(jq -r '.stage' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
         _sc_input=$(jq -r '.input_tokens' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
+        _sc_ts_epoch=$(jq -r '.ts_epoch // empty' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
+        _sc_issue=$(jq -r '.issue // empty' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
         if [[ "$_sc_stage" == "plan" ]]; then
             assert_pass "record_stage_cost_end: stage-costs.jsonl has stage=plan"
         else
@@ -410,14 +398,28 @@ if [[ -f "$_stage_cost_lib" ]]; then
         else
             assert_fail "record_stage_cost_end: input_tokens delta correct (8000)" "got: ${_sc_input}"
         fi
+        if [[ -n "$_sc_ts_epoch" ]] && [[ "$_sc_ts_epoch" =~ ^[0-9]+$ ]]; then
+            assert_pass "record_stage_cost_end: ts_epoch field present and numeric (schema parity)"
+        else
+            assert_fail "record_stage_cost_end: ts_epoch field present and numeric" "got: '${_sc_ts_epoch}'"
+        fi
+        if [[ "$_sc_issue" == "87" ]]; then
+            assert_pass "record_stage_cost_end: issue field propagated from ISSUE_NUMBER"
+        else
+            assert_fail "record_stage_cost_end: issue field propagated from ISSUE_NUMBER" "got: '${_sc_issue}'"
+        fi
     else
         assert_fail "record_stage_cost_end: stage-costs.jsonl has stage=plan" "file not created"
         assert_fail "record_stage_cost_end: input_tokens delta correct (8000)"
+        assert_fail "record_stage_cost_end: ts_epoch field present and numeric"
+        assert_fail "record_stage_cost_end: issue field propagated from ISSUE_NUMBER"
     fi
 else
-    assert_fail "record_stage_cost_end: lib/stage-cost.sh exists" "file not found: $_stage_cost_lib"
+    assert_fail "record_stage_cost_end: lib/cost/stage.sh exists" "file not found: $_stage_cost_lib"
     assert_fail "record_stage_cost_end: stage-costs.jsonl has stage=plan"
     assert_fail "record_stage_cost_end: input_tokens delta correct (8000)"
+    assert_fail "record_stage_cost_end: ts_epoch field present and numeric"
+    assert_fail "record_stage_cost_end: issue field propagated from ISSUE_NUMBER"
 fi
 
 # ── Test 6: AC#1 regression — 4 distinct stages in by_stage ──────────────────
@@ -449,6 +451,259 @@ if [[ -f "$_bd_ac1/cost-breakdown.json" ]]; then
 else
     assert_fail "AC#1 regression: by_stage has 4 distinct stage names"
     assert_fail "AC#1 regression: all 4 stages have non-zero input_tokens"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TESTS: pipeline integration wiring (issue #87)
+# Grep-based — confirm libs are sourced, brackets are inserted, sidecars are wired.
+# Cheap and fast; does not run the pipeline end-to-end.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}Pipeline Integration Wiring${RESET}"
+
+_pipeline_sh="$SCRIPT_DIR/sw-pipeline.sh"
+_loop_sh="$SCRIPT_DIR/sw-loop.sh"
+_build_sh="$SCRIPT_DIR/lib/pipeline-stages-build.sh"
+
+if grep -q 'lib/cost/stage.sh' "$_pipeline_sh"; then
+    assert_pass "sw-pipeline.sh sources lib/cost/stage.sh"
+else
+    assert_fail "sw-pipeline.sh sources lib/cost/stage.sh"
+fi
+
+if grep -q 'record_stage_cost_start "\$stage_id"' "$_pipeline_sh" && \
+   grep -q 'record_stage_cost_end "\$stage_id"' "$_pipeline_sh"; then
+    assert_pass "run_stage_with_retry brackets every stage with start/end"
+else
+    assert_fail "run_stage_with_retry brackets every stage with start/end"
+fi
+
+if grep -q 'cost_generate_breakdown "\$ARTIFACTS_DIR"' "$_pipeline_sh"; then
+    assert_pass "sw-pipeline.sh invokes cost_generate_breakdown at pipeline end"
+else
+    assert_fail "sw-pipeline.sh invokes cost_generate_breakdown at pipeline end"
+fi
+
+if grep -q 'lib/cost/iteration.sh' "$_loop_sh"; then
+    assert_pass "sw-loop.sh sources lib/cost/iteration.sh"
+else
+    assert_fail "sw-loop.sh sources lib/cost/iteration.sh"
+fi
+
+if grep -q '_ITER_SNAP_INPUT=' "$_loop_sh" && \
+   grep -q 'record_iteration_cost "\$ITERATION"' "$_loop_sh"; then
+    assert_pass "sw-loop.sh snapshots and records each iteration's cost"
+else
+    assert_fail "sw-loop.sh snapshots and records each iteration's cost"
+fi
+
+if grep -q 'export ITER_COST_JSONL=' "$_build_sh"; then
+    assert_pass "stage_build exports ITER_COST_JSONL to sw loop subprocess"
+else
+    assert_fail "stage_build exports ITER_COST_JSONL to sw loop subprocess"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TESTS: end-to-end bracket pattern (issue #87 functional verification)
+# Simulates run_stage_with_retry's bracketing using real lib functions and asserts
+# the produced cost-breakdown.json has per-stage cost_usd and a coherent summary.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}End-to-End Bracket Pattern${RESET}"
+
+_e2e_dir="$TEST_TEMP_DIR/e2e-bracket"
+mkdir -p "$_e2e_dir"
+(
+    set +u  # libs may reference unset vars under strict mode in subshell setup
+    ARTIFACTS_DIR="$_e2e_dir"
+    TOTAL_INPUT_TOKENS=0
+    TOTAL_OUTPUT_TOKENS=0
+    MODEL="sonnet"
+    ISSUE_NUMBER="87"
+    SHIPWRIGHT_PIPELINE_ID="e2e-test-pipeline"
+    cost_record() { return 0; }
+    emit_event() { return 0; }
+    # Real cost_calculate from sw-cost.sh would normally be sourced; provide a
+    # cheap stand-in so the sidecar gets a non-zero cost_usd field.
+    cost_calculate() {
+        # sonnet rates: $3/M input, $15/M output → simple linear
+        awk -v it="$1" -v ot="$2" 'BEGIN { printf "%.6f", (it/1000000)*3 + (ot/1000000)*15 }'
+    }
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib/cost/stage.sh"
+
+    # Simulate plan stage: 8000 in, 3000 out
+    record_stage_cost_start "plan"
+    TOTAL_INPUT_TOKENS=$((TOTAL_INPUT_TOKENS + 8000))
+    TOTAL_OUTPUT_TOKENS=$((TOTAL_OUTPUT_TOKENS + 3000))
+    record_stage_cost_end "plan"
+
+    # Simulate design stage: 6000 in, 2500 out
+    record_stage_cost_start "design"
+    TOTAL_INPUT_TOKENS=$((TOTAL_INPUT_TOKENS + 6000))
+    TOTAL_OUTPUT_TOKENS=$((TOTAL_OUTPUT_TOKENS + 2500))
+    record_stage_cost_end "design"
+
+    # Simulate build stage with retry: first attempt 5000/2000, retry 7500/3300
+    record_stage_cost_start "build"
+    TOTAL_INPUT_TOKENS=$((TOTAL_INPUT_TOKENS + 5000))
+    TOTAL_OUTPUT_TOKENS=$((TOTAL_OUTPUT_TOKENS + 2000))
+    record_stage_cost_end "build"  # first attempt failed
+    record_stage_cost_start "build"
+    TOTAL_INPUT_TOKENS=$((TOTAL_INPUT_TOKENS + 7500))
+    TOTAL_OUTPUT_TOKENS=$((TOTAL_OUTPUT_TOKENS + 3300))
+    record_stage_cost_end "build"  # second attempt succeeded
+)
+
+# Also seed iteration sidecar so breakdown is comprehensive
+printf '%s\n' \
+    "{\"iteration\":1,\"input_tokens\":3000,\"output_tokens\":1200,\"cost_usd\":0.027,\"ts\":\"${_now}\"}" \
+    "{\"iteration\":2,\"input_tokens\":4500,\"output_tokens\":2100,\"cost_usd\":0.0455,\"ts\":\"${_now}\"}" \
+    > "$_e2e_dir/loop-iteration-costs.jsonl"
+
+env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" breakdown "$_e2e_dir" "e2e-test-pipeline" "87" >/dev/null 2>&1 || true
+
+if [[ -f "$_e2e_dir/cost-breakdown.json" ]]; then
+    # Three logical stages: plan, design, build. Build has 2 records (retry).
+    _e2e_stages=$(jq '[.by_stage[].stage] | sort | unique | length' "$_e2e_dir/cost-breakdown.json")
+    if [[ "$_e2e_stages" == "3" ]]; then
+        assert_pass "e2e: 3 distinct stages (plan, design, build) recorded"
+    else
+        assert_fail "e2e: 3 distinct stages recorded" "got: ${_e2e_stages}"
+    fi
+
+    # Build's combined input should be 5000 + 7500 = 12500
+    _e2e_build_in=$(jq -r '.by_stage[] | select(.stage=="build") | .input_tokens' "$_e2e_dir/cost-breakdown.json")
+    if [[ "$_e2e_build_in" == "12500" ]]; then
+        assert_pass "e2e: build stage aggregates retry deltas (5000+7500=12500)"
+    else
+        assert_fail "e2e: build stage aggregates retry deltas" "got: ${_e2e_build_in}"
+    fi
+
+    # Each stage must have non-zero cost_usd (AC#1: tokens AND cost)
+    _e2e_cost_count=$(jq '[.by_stage[] | select(.cost_usd > 0)] | length' "$_e2e_dir/cost-breakdown.json")
+    if [[ "$_e2e_cost_count" == "3" ]]; then
+        assert_pass "e2e: every stage has non-zero cost_usd (AC#1)"
+    else
+        assert_fail "e2e: every stage has non-zero cost_usd" "got: ${_e2e_cost_count}"
+    fi
+
+    # Summary total_cost_usd must include both stage and iteration costs
+    _e2e_total_cost=$(jq -r '.summary.total_cost_usd // 0' "$_e2e_dir/cost-breakdown.json")
+    if awk -v t="$_e2e_total_cost" 'BEGIN { exit !(t > 0) }' 2>/dev/null; then
+        assert_pass "e2e: summary.total_cost_usd > 0"
+    else
+        assert_fail "e2e: summary.total_cost_usd > 0" "got: ${_e2e_total_cost}"
+    fi
+
+    # Summary uses stage data as authoritative (iterations are sub-breakdown of build,
+    # so summing both would double-count the build stage).
+    _e2e_total_in=$(jq -r '.summary.total_input_tokens // 0' "$_e2e_dir/cost-breakdown.json")
+    # Stages: 8000 + 6000 + 12500 = 26500.
+    if [[ "$_e2e_total_in" == "26500" ]]; then
+        assert_pass "e2e: summary.total_input_tokens = stage total (no double-count)"
+    else
+        assert_fail "e2e: summary.total_input_tokens = stage total" "got: ${_e2e_total_in}"
+    fi
+
+    # Breakdown stages must carry a models[] array (model attribution preserved after group_by)
+    _e2e_models_count=$(jq '[.by_stage[] | select((.models | type) == "array")] | length' "$_e2e_dir/cost-breakdown.json" 2>/dev/null || echo "0")
+    if [[ "$_e2e_models_count" == "3" ]]; then
+        assert_pass "e2e: every stage has models[] array (model attribution preserved)"
+    else
+        assert_fail "e2e: every stage has models[] array" "got: ${_e2e_models_count} stages with models"
+    fi
+else
+    assert_fail "e2e: cost-breakdown.json produced"
+    assert_fail "e2e: 3 distinct stages recorded"
+    assert_fail "e2e: build stage aggregates retry deltas"
+    assert_fail "e2e: every stage has non-zero cost_usd"
+    assert_fail "e2e: summary.total_cost_usd > 0"
+    assert_fail "e2e: summary.total_input_tokens unions stages + iterations"
+    assert_fail "e2e: every stage has models[] array"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TESTS: malformed-line resilience (jq filters drop bad records gracefully)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}Resilience to Malformed Sidecar Lines${RESET}"
+
+_resil_dir="$TEST_TEMP_DIR/resil"
+mkdir -p "$_resil_dir"
+{
+    echo '{"stage":"plan","input_tokens":1000,"output_tokens":500,"cost_usd":0.001,"model":"sonnet","ts":"'"${_now}"'"}'
+    echo 'this is not valid json'
+    echo '{"input_tokens":999}'  # missing .stage — should be filtered
+    echo '{"stage":"build","input_tokens":2000,"output_tokens":800,"cost_usd":0.005,"model":"sonnet","ts":"'"${_now}"'"}'
+} > "$_resil_dir/stage-costs.jsonl"
+
+{
+    echo '{"iteration":1,"input_tokens":500,"output_tokens":200,"cost_usd":0.001,"ts":"'"${_now}"'"}'
+    echo '{"iteration":"bad","input_tokens":99}'  # iteration not numeric — should be filtered
+    echo '{"iteration":2,"input_tokens":700,"output_tokens":300,"cost_usd":0.0015,"ts":"'"${_now}"'"}'
+} > "$_resil_dir/loop-iteration-costs.jsonl"
+
+env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" breakdown "$_resil_dir" "resil-test" "" >/dev/null 2>&1 || true
+
+if [[ -f "$_resil_dir/cost-breakdown.json" ]]; then
+    _resil_stages=$(jq '.by_stage | length' "$_resil_dir/cost-breakdown.json")
+    _resil_iters=$(jq '.by_iteration | length' "$_resil_dir/cost-breakdown.json")
+    if [[ "$_resil_stages" == "2" ]]; then
+        assert_pass "malformed stage lines filtered (kept 2 of 4)"
+    else
+        assert_fail "malformed stage lines filtered (kept 2 of 4)" "got: ${_resil_stages}"
+    fi
+    if [[ "$_resil_iters" == "2" ]]; then
+        assert_pass "non-numeric iteration filtered (kept 2 of 3)"
+    else
+        assert_fail "non-numeric iteration filtered (kept 2 of 3)" "got: ${_resil_iters}"
+    fi
+else
+    assert_fail "malformed stage lines filtered (kept 2 of 4)"
+    assert_fail "non-numeric iteration filtered (kept 2 of 3)"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TESTS: --by-iteration auto-generates breakdown from sidecars
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}--by-iteration Auto-Regeneration${RESET}"
+
+_auto_dir="$TEST_TEMP_DIR/auto-regen"
+mkdir -p "$_auto_dir"
+# Sidecars present, but cost-breakdown.json absent — show should regenerate it.
+printf '%s\n' \
+    "{\"iteration\":1,\"input_tokens\":1500,\"output_tokens\":600,\"cost_usd\":0.0135,\"ts\":\"${_now}\"}" \
+    > "$_auto_dir/loop-iteration-costs.jsonl"
+
+# Need cost data so the dashboard runs
+cat > "$TEST_TEMP_DIR/home/.shipwright/costs.json" <<COSTEOF
+{"entries":[{"ts":"${_mock_ts}","ts_epoch":${_mock_epoch},"input_tokens":1000,"output_tokens":500,"cost_usd":0.01,"model":"sonnet","stage":"build","issue":"87"}],"summary":{}}
+COSTEOF
+
+_auto_out=$(env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    ARTIFACTS_DIR="$_auto_dir" \
+    bash "$SCRIPT_DIR/sw-cost.sh" show --by-iteration --period 30 2>&1) || true
+
+if [[ -f "$_auto_dir/cost-breakdown.json" ]]; then
+    assert_pass "--by-iteration auto-regenerates cost-breakdown.json from sidecars"
+else
+    assert_fail "--by-iteration auto-regenerates cost-breakdown.json from sidecars" \
+        "no cost-breakdown.json in $_auto_dir"
+fi
+
+if echo "$_auto_out" | grep -qE 'iter +1 +'; then
+    assert_pass "--by-iteration prints iteration row after auto-regen"
+else
+    assert_fail "--by-iteration prints iteration row after auto-regen" \
+        "output tail: $(echo "$_auto_out" | tail -5)"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/sw-cost-test.sh
+++ b/scripts/sw-cost-test.sh
@@ -480,9 +480,9 @@ else
 fi
 
 if grep -q 'cost_generate_breakdown "\$ARTIFACTS_DIR"' "$_pipeline_sh"; then
-    assert_pass "sw-pipeline.sh invokes cost_generate_breakdown at pipeline end"
+    assert_pass "sw-pipeline.sh invokes cost_generate_breakdown from cleanup_on_exit"
 else
-    assert_fail "sw-pipeline.sh invokes cost_generate_breakdown at pipeline end"
+    assert_fail "sw-pipeline.sh invokes cost_generate_breakdown from cleanup_on_exit"
 fi
 
 if grep -q 'lib/cost/iteration.sh' "$_loop_sh"; then

--- a/scripts/sw-cost-test.sh
+++ b/scripts/sw-cost-test.sh
@@ -51,6 +51,7 @@ assert_fail() {
     FAILURES+=("$desc")
     echo -e "  ${RED}✗${RESET} ${desc}"
     [[ -n "$detail" ]] && echo -e "    ${DIM}${detail}${RESET}"
+    return 0
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -229,6 +230,225 @@ if echo "$dash_output" | grep -q "Avg budget used"; then
     assert_pass "Dashboard shows avg budget utilization"
 else
     assert_fail "Dashboard shows avg budget utilization"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# TESTS: per-iteration and stage-level cost attribution (issue #87)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+echo ""
+echo -e "${BOLD}Per-Iteration and Stage-Level Cost Attribution${RESET}"
+
+# ── Test 1: cost_generate_breakdown with sidecar data ──────────────────────────
+_bd_dir="$TEST_TEMP_DIR/breakdown-test"
+mkdir -p "$_bd_dir"
+_now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+printf '%s\n' \
+    "{\"iteration\":1,\"input_tokens\":5000,\"output_tokens\":2000,\"cost_usd\":0.045,\"ts\":\"${_now}\"}" \
+    "{\"iteration\":2,\"input_tokens\":4000,\"output_tokens\":1800,\"cost_usd\":0.039,\"ts\":\"${_now}\"}" \
+    "{\"iteration\":3,\"input_tokens\":3500,\"output_tokens\":1500,\"cost_usd\":0.033,\"ts\":\"${_now}\"}" \
+    > "$_bd_dir/loop-iteration-costs.jsonl"
+printf '%s\n' \
+    "{\"stage\":\"build\",\"input_tokens\":12500,\"output_tokens\":5300,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    "{\"stage\":\"review\",\"input_tokens\":3000,\"output_tokens\":1000,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    > "$_bd_dir/stage-costs.jsonl"
+
+_bd_out=$(env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" breakdown "$_bd_dir" "test-pipeline" "87" 2>&1) || true
+
+if [[ -f "$_bd_dir/cost-breakdown.json" ]]; then
+    assert_pass "cost_generate_breakdown creates cost-breakdown.json"
+    _iter_count=$(jq '.summary.iteration_count' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "")
+    _stage_count=$(jq '.by_stage | length' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "")
+    _iter_len=$(jq '.by_iteration | length' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "")
+    if [[ "$_iter_count" == "3" ]]; then
+        assert_pass "breakdown: summary.iteration_count == 3"
+    else
+        assert_fail "breakdown: summary.iteration_count == 3" "got: ${_iter_count}"
+    fi
+    if [[ "$_stage_count" == "2" ]]; then
+        assert_pass "breakdown: by_stage has 2 entries"
+    else
+        assert_fail "breakdown: by_stage has 2 entries" "got: ${_stage_count}"
+    fi
+    if [[ "$_iter_len" == "3" ]]; then
+        assert_pass "breakdown: by_iteration has 3 entries"
+    else
+        assert_fail "breakdown: by_iteration has 3 entries" "got: ${_iter_len}"
+    fi
+else
+    assert_fail "cost_generate_breakdown creates cost-breakdown.json" "output: $(echo "$_bd_out" | tail -3)"
+    assert_fail "breakdown: summary.iteration_count == 3"
+    assert_fail "breakdown: by_stage has 2 entries"
+    assert_fail "breakdown: by_iteration has 3 entries"
+fi
+
+# ── Test 2: cost_generate_breakdown with no sidecars ───────────────────────────
+_bd_empty="$TEST_TEMP_DIR/breakdown-empty"
+mkdir -p "$_bd_empty"
+env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" breakdown "$_bd_empty" "empty-pipeline" "" 2>&1 || true
+
+if [[ -f "$_bd_empty/cost-breakdown.json" ]]; then
+    _empty_iter=$(jq '.by_iteration | length' "$_bd_empty/cost-breakdown.json" 2>/dev/null || echo "err")
+    _empty_stage=$(jq '.by_stage | length' "$_bd_empty/cost-breakdown.json" 2>/dev/null || echo "err")
+    if [[ "$_empty_iter" == "0" && "$_empty_stage" == "0" ]]; then
+        assert_pass "breakdown with no sidecars produces valid JSON with empty arrays"
+    else
+        assert_fail "breakdown with no sidecars produces valid JSON with empty arrays" \
+            "by_iteration=${_empty_iter} by_stage=${_empty_stage}"
+    fi
+else
+    assert_fail "breakdown with no sidecars produces valid JSON with empty arrays"
+fi
+
+# ── Test 3: --by-iteration flag ─────────────────────────────────────────────────
+_bd_flag_dir="$TEST_TEMP_DIR/breakdown-flag"
+mkdir -p "$_bd_flag_dir"
+printf '%s\n' \
+    "{\"pipeline_id\":\"p1\",\"issue\":\"87\",\"generated_at\":\"${_now}\",\"summary\":{\"total_input_tokens\":12500,\"total_output_tokens\":5300,\"iteration_count\":2,\"stage_count\":1},\"by_stage\":[{\"stage\":\"build\",\"input_tokens\":12500,\"output_tokens\":5300}],\"by_iteration\":[{\"iteration\":1,\"input_tokens\":5000,\"output_tokens\":2000,\"cost_usd\":0.045,\"ts\":\"${_now}\"},{\"iteration\":2,\"input_tokens\":4000,\"output_tokens\":1800,\"cost_usd\":0.039,\"ts\":\"${_now}\"}]}" \
+    > "$_bd_flag_dir/cost-breakdown.json"
+
+_iter_output=$(env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    ARTIFACTS_DIR="$_bd_flag_dir" \
+    bash "$SCRIPT_DIR/sw-cost.sh" show --by-iteration 2>&1) || true
+if echo "$_iter_output" | grep -qi "by iteration\|BY ITERATION"; then
+    assert_pass "--by-iteration flag renders iteration section"
+else
+    assert_fail "--by-iteration flag renders iteration section" "output: $(echo "$_iter_output" | grep -i iter | head -3)"
+fi
+
+_no_iter_output=$(env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" show --by-iteration 2>&1) || true
+if echo "$_no_iter_output" | grep -qi "no iteration data\|no.*iteration\|iteration.*data"; then
+    assert_pass "--by-iteration with no artifact shows graceful message"
+else
+    assert_fail "--by-iteration with no artifact shows graceful message" "output: $(echo "$_no_iter_output" | tail -3)"
+fi
+
+# ── Test 4: record_iteration_cost from lib/loop-cost.sh ───────────────────────
+_loop_cost_lib="$SCRIPT_DIR/lib/loop-cost.sh"
+if [[ -f "$_loop_cost_lib" ]]; then
+    _iter_sidecar="$TEST_TEMP_DIR/test-iter-costs.jsonl"
+    (
+        # Source the lib in a subshell to avoid polluting test environment
+        ITER_COST_JSONL="$_iter_sidecar"
+        LOOP_INPUT_TOKENS=0
+        LOOP_OUTPUT_TOKENS=0
+        LOOP_COST_MILLICENTS=0
+        # shellcheck source=/dev/null
+        source "$_loop_cost_lib"
+        # Iteration 1
+        _ITER_SNAP_INPUT=0; _ITER_SNAP_OUTPUT=0; _ITER_SNAP_COST_MC=0
+        LOOP_INPUT_TOKENS=5000; LOOP_OUTPUT_TOKENS=2000; LOOP_COST_MILLICENTS=450
+        record_iteration_cost 1
+        # Iteration 2
+        _ITER_SNAP_INPUT=5000; _ITER_SNAP_OUTPUT=2000; _ITER_SNAP_COST_MC=450
+        LOOP_INPUT_TOKENS=9000; LOOP_OUTPUT_TOKENS=3800; LOOP_COST_MILLICENTS=840
+        record_iteration_cost 2
+        # Iteration 3
+        _ITER_SNAP_INPUT=9000; _ITER_SNAP_OUTPUT=3800; _ITER_SNAP_COST_MC=840
+        LOOP_INPUT_TOKENS=12500; LOOP_OUTPUT_TOKENS=5300; LOOP_COST_MILLICENTS=1170
+        record_iteration_cost 3
+    )
+    _line_count=$(wc -l < "$_iter_sidecar" 2>/dev/null | tr -d ' ' || echo "0")
+    _iter3_num=$(jq -r 'select(.iteration==3) | .iteration' "$_iter_sidecar" 2>/dev/null | head -1 || echo "")
+    _iter1_input=$(jq -r 'select(.iteration==1) | .input_tokens' "$_iter_sidecar" 2>/dev/null | head -1 || echo "")
+    if [[ "$_line_count" == "3" ]]; then
+        assert_pass "record_iteration_cost: sidecar has 3 lines"
+    else
+        assert_fail "record_iteration_cost: sidecar has 3 lines" "got: ${_line_count}"
+    fi
+    if [[ "$_iter3_num" == "3" ]]; then
+        assert_pass "record_iteration_cost: iteration numbers are 1/2/3"
+    else
+        assert_fail "record_iteration_cost: iteration numbers are 1/2/3" "got iter3: ${_iter3_num}"
+    fi
+    if [[ "$_iter1_input" == "5000" ]]; then
+        assert_pass "record_iteration_cost: iteration 1 delta input_tokens correct (5000)"
+    else
+        assert_fail "record_iteration_cost: iteration 1 delta input_tokens correct (5000)" "got: ${_iter1_input}"
+    fi
+else
+    assert_fail "record_iteration_cost: lib/loop-cost.sh exists" "file not found: $_loop_cost_lib"
+    assert_fail "record_iteration_cost: sidecar has 3 lines"
+    assert_fail "record_iteration_cost: iteration numbers are 1/2/3"
+    assert_fail "record_iteration_cost: iteration 1 delta input_tokens correct (5000)"
+fi
+
+# ── Test 5: record_stage_cost_start/end from lib/stage-cost.sh ─────────────────
+_stage_cost_lib="$SCRIPT_DIR/lib/stage-cost.sh"
+if [[ -f "$_stage_cost_lib" ]]; then
+    _stage_sidecar_dir="$TEST_TEMP_DIR/stage-cost-test"
+    mkdir -p "$_stage_sidecar_dir"
+    (
+        ARTIFACTS_DIR="$_stage_sidecar_dir"
+        TOTAL_INPUT_TOKENS=0
+        TOTAL_OUTPUT_TOKENS=0
+        MODEL="sonnet"
+        ISSUE_NUMBER="87"
+        # Stub cost_record as noop so the lib works without sw-cost.sh loaded
+        cost_record() { return 0; }
+        emit_event() { return 0; }
+        # shellcheck source=/dev/null
+        source "$_stage_cost_lib"
+        record_stage_cost_start "plan"
+        TOTAL_INPUT_TOKENS=8000
+        TOTAL_OUTPUT_TOKENS=3000
+        record_stage_cost_end "plan"
+    )
+    if [[ -f "$_stage_sidecar_dir/stage-costs.jsonl" ]]; then
+        _sc_stage=$(jq -r '.stage' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
+        _sc_input=$(jq -r '.input_tokens' "$_stage_sidecar_dir/stage-costs.jsonl" 2>/dev/null | head -1)
+        if [[ "$_sc_stage" == "plan" ]]; then
+            assert_pass "record_stage_cost_end: stage-costs.jsonl has stage=plan"
+        else
+            assert_fail "record_stage_cost_end: stage-costs.jsonl has stage=plan" "got: ${_sc_stage}"
+        fi
+        if [[ "$_sc_input" == "8000" ]]; then
+            assert_pass "record_stage_cost_end: input_tokens delta correct (8000)"
+        else
+            assert_fail "record_stage_cost_end: input_tokens delta correct (8000)" "got: ${_sc_input}"
+        fi
+    else
+        assert_fail "record_stage_cost_end: stage-costs.jsonl has stage=plan" "file not created"
+        assert_fail "record_stage_cost_end: input_tokens delta correct (8000)"
+    fi
+else
+    assert_fail "record_stage_cost_end: lib/stage-cost.sh exists" "file not found: $_stage_cost_lib"
+    assert_fail "record_stage_cost_end: stage-costs.jsonl has stage=plan"
+    assert_fail "record_stage_cost_end: input_tokens delta correct (8000)"
+fi
+
+# ── Test 6: AC#1 regression — 4 distinct stages in by_stage ──────────────────
+_bd_ac1="$TEST_TEMP_DIR/breakdown-ac1"
+mkdir -p "$_bd_ac1"
+printf '%s\n' \
+    "{\"stage\":\"plan\",\"input_tokens\":8000,\"output_tokens\":3000,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    "{\"stage\":\"design\",\"input_tokens\":6000,\"output_tokens\":2500,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    "{\"stage\":\"build\",\"input_tokens\":12500,\"output_tokens\":5300,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    "{\"stage\":\"review\",\"input_tokens\":3000,\"output_tokens\":1000,\"model\":\"sonnet\",\"ts\":\"${_now}\"}" \
+    > "$_bd_ac1/stage-costs.jsonl"
+
+env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    bash "$SCRIPT_DIR/sw-cost.sh" breakdown "$_bd_ac1" "ac1-test" "87" 2>&1 || true
+
+if [[ -f "$_bd_ac1/cost-breakdown.json" ]]; then
+    _ac1_stages=$(jq '[.by_stage[].stage] | sort | unique | length' "$_bd_ac1/cost-breakdown.json" 2>/dev/null || echo "0")
+    _ac1_all_nonzero=$(jq '[.by_stage[] | select(.input_tokens > 0)] | length' "$_bd_ac1/cost-breakdown.json" 2>/dev/null || echo "0")
+    if [[ "$_ac1_stages" == "4" ]]; then
+        assert_pass "AC#1 regression: by_stage has 4 distinct stage names (not just 'pipeline')"
+    else
+        assert_fail "AC#1 regression: by_stage has 4 distinct stage names" "got: ${_ac1_stages}"
+    fi
+    if [[ "$_ac1_all_nonzero" == "4" ]]; then
+        assert_pass "AC#1 regression: all 4 stages have non-zero input_tokens"
+    else
+        assert_fail "AC#1 regression: all 4 stages have non-zero input_tokens" "got: ${_ac1_all_nonzero}"
+    fi
+else
+    assert_fail "AC#1 regression: by_stage has 4 distinct stage names"
+    assert_fail "AC#1 regression: all 4 stages have non-zero input_tokens"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/sw-cost.sh
+++ b/scripts/sw-cost.sh
@@ -118,7 +118,12 @@ cost_calculate() {
             output_rate="$HAIKU_OUTPUT_PER_M"
             ;;
         *)
-            # Default to sonnet pricing for unknown models
+            # Default to sonnet pricing for unknown models — warn once per process
+            # so operators notice when a new model string is not yet in the case list.
+            if [[ -z "${_COST_CALC_WARN_FIRED:-}" ]]; then
+                _COST_CALC_WARN_FIRED=1
+                echo "warn: cost_calculate: unrecognized model '${model}'; using sonnet pricing (update case list if incorrect)" >&2
+            fi
             input_rate="$SONNET_INPUT_PER_M"
             output_rate="$SONNET_OUTPUT_PER_M"
             ;;
@@ -175,7 +180,7 @@ cost_record() {
                cost_usd: ($cost | tonumber),
                ts: $ts,
                ts_epoch: $epoch
-           }] | .entries = (.entries | .[-1000:])' \
+           }] | .entries = (.entries | .[-10000:])' \
            "$COST_FILE" > "$tmp_file" 2>/dev/null; then
             error "Cost jq transformation failed — entry may be lost"
             rm -f "$tmp_file"
@@ -600,13 +605,20 @@ cost_generate_breakdown() {
 
     local stage_json="[]"
     if [[ -f "$stage_jsonl" ]]; then
-        stage_json=$(jq -s '
+        # Read raw lines and parse each with try/catch so a malformed line in the middle
+        # of the file does not poison the whole aggregation. Filter records missing .stage.
+        stage_json=$(jq -Rcs '
+            split("\n") |
+            map(select(length > 0) | . as $line | try ($line|fromjson) catch empty) |
+            map(select(.stage != null)) |
             group_by(.stage) |
             map({
                 stage: .[0].stage,
-                input_tokens: ([.[].input_tokens] | add // 0),
-                output_tokens: ([.[].output_tokens] | add // 0),
-                count: length
+                input_tokens: ([.[].input_tokens // 0] | add),
+                output_tokens: ([.[].output_tokens // 0] | add),
+                cost_usd: ([.[].cost_usd // 0] | add | . * 1000000 | round / 1000000),
+                count: length,
+                models: ([.[].model // "unknown"] | unique | sort)
             }) |
             sort_by(-.input_tokens)
         ' "$stage_jsonl" 2>/dev/null) || stage_json="[]"
@@ -614,14 +626,33 @@ cost_generate_breakdown() {
 
     local iter_json="[]"
     if [[ -f "$iter_jsonl" ]]; then
-        iter_json=$(jq -s 'sort_by(.iteration)' "$iter_jsonl" 2>/dev/null) || iter_json="[]"
+        iter_json=$(jq -Rcs '
+            split("\n") |
+            map(select(length > 0) | . as $line | try ($line|fromjson) catch empty) |
+            map(select(.iteration|type=="number")) |
+            sort_by(.iteration)
+        ' "$iter_jsonl" 2>/dev/null) || iter_json="[]"
     fi
 
-    local iter_count stage_count total_input total_output
-    iter_count=$(echo "$iter_json"  | jq 'length'              2>/dev/null || echo "0")
-    stage_count=$(echo "$stage_json" | jq 'length'              2>/dev/null || echo "0")
-    total_input=$(echo "$stage_json" | jq '[.[].input_tokens]  | add // 0' 2>/dev/null || echo "0")
-    total_output=$(echo "$stage_json" | jq '[.[].output_tokens] | add // 0' 2>/dev/null || echo "0")
+    local iter_count stage_count total_input total_output total_cost
+    iter_count=$(echo "$iter_json"  | jq 'length' 2>/dev/null || echo "0")
+    stage_count=$(echo "$stage_json" | jq 'length' 2>/dev/null || echo "0")
+    # Roll-up rule: stage data is authoritative because it covers the whole pipeline.
+    # Iteration data is a sub-breakdown of the build stage and would double-count if
+    # added on top. We fall back to iteration-only totals only when no stage data
+    # exists at all (e.g. a standalone `sw loop` outside the pipeline).
+    if [[ "$stage_count" -gt 0 ]]; then
+        total_input=$(echo "$stage_json"  | jq '[.[].input_tokens  // 0] | add // 0' 2>/dev/null || echo "0")
+        total_output=$(echo "$stage_json" | jq '[.[].output_tokens // 0] | add // 0' 2>/dev/null || echo "0")
+        total_cost=$(echo "$stage_json"   | jq '[.[].cost_usd // 0] | add // 0 | . * 1000000 | round / 1000000' 2>/dev/null || echo "0")
+    else
+        total_input=$(echo "$iter_json"   | jq '[.[].input_tokens  // 0] | add // 0' 2>/dev/null || echo "0")
+        total_output=$(echo "$iter_json"  | jq '[.[].output_tokens // 0] | add // 0' 2>/dev/null || echo "0")
+        total_cost=$(echo "$iter_json"    | jq '[.[].cost_usd // 0] | add // 0 | . * 1000000 | round / 1000000' 2>/dev/null || echo "0")
+    fi
+    # Defensive numeric coercion — empty strings would break --argjson below.
+    : "${total_input:=0}" "${total_output:=0}" "${total_cost:=0}"
+    : "${iter_count:=0}" "${stage_count:=0}"
 
     jq -n \
         --arg pipeline_id "$pipeline_id" \
@@ -633,6 +664,7 @@ cost_generate_breakdown() {
         --argjson stage_count "$stage_count" \
         --argjson total_input "$total_input" \
         --argjson total_output "$total_output" \
+        --argjson total_cost "$total_cost" \
         '{
             pipeline_id: $pipeline_id,
             issue: $issue,
@@ -640,6 +672,7 @@ cost_generate_breakdown() {
             summary: {
                 total_input_tokens: $total_input,
                 total_output_tokens: $total_output,
+                total_cost_usd: $total_cost,
                 iteration_count: $iter_count,
                 stage_count: $stage_count
             },
@@ -847,6 +880,12 @@ cost_dashboard() {
     # Iteration breakdown — reads pipeline-local artifact, NOT historical aggregation
     if [[ "$by_iteration" == "true" ]]; then
         local breakdown_file="${artifacts_dir}/cost-breakdown.json"
+        # If breakdown is absent but raw sidecars exist, regenerate on demand so users
+        # who skip the explicit `breakdown` invocation still see iteration data.
+        if [[ ! -f "$breakdown_file" ]] && \
+           { [[ -f "${artifacts_dir}/loop-iteration-costs.jsonl" ]] || [[ -f "${artifacts_dir}/stage-costs.jsonl" ]]; }; then
+            cost_generate_breakdown "$artifacts_dir" "${SHIPWRIGHT_PIPELINE_ID:-unknown}" "${ISSUE_NUMBER:-}" >/dev/null 2>&1 || true
+        fi
         if [[ -f "$breakdown_file" ]]; then
             local iter_data
             iter_data=$(jq '.by_iteration' "$breakdown_file" 2>/dev/null || echo "[]")
@@ -860,11 +899,12 @@ cost_dashboard() {
                     done
                 echo ""
             else
-                echo -e "${DIM}  no iteration data (run a pipeline with cost tracking first)${RESET}"
+                echo -e "${DIM}  no iteration data in ${breakdown_file}${RESET}"
                 echo ""
             fi
         else
-            echo -e "${DIM}  no iteration data (run a pipeline with cost tracking first)${RESET}"
+            echo -e "${DIM}  no iteration data — checked ${artifacts_dir}/cost-breakdown.json${RESET}"
+            echo -e "${DIM}  run a pipeline first, or pass --artifacts-dir <dir>${RESET}"
             echo ""
         fi
     fi

--- a/scripts/sw-cost.sh
+++ b/scripts/sw-cost.sh
@@ -601,7 +601,10 @@ cost_generate_breakdown() {
     local iter_jsonl="${artifacts_dir}/loop-iteration-costs.jsonl"
     local out_file="${artifacts_dir}/cost-breakdown.json"
     local tmp_file
-    tmp_file=$(mktemp "${out_file}.XXXXXX")
+    if ! tmp_file=$(mktemp "${out_file}.XXXXXX" 2>/dev/null) || [[ -z "$tmp_file" ]]; then
+        warn "cost_generate_breakdown: failed to create temporary file for ${out_file}"
+        return 1
+    fi
 
     local stage_json="[]"
     if [[ -f "$stage_jsonl" ]]; then
@@ -611,6 +614,7 @@ cost_generate_breakdown() {
             split("\n") |
             map(select(length > 0) | . as $line | try ($line|fromjson) catch empty) |
             map(select(.stage != null)) |
+            sort_by(.stage) |
             group_by(.stage) |
             map({
                 stage: .[0].stage,
@@ -618,7 +622,7 @@ cost_generate_breakdown() {
                 output_tokens: ([.[].output_tokens // 0] | add),
                 cost_usd: ([.[].cost_usd // 0] | add | . * 1000000 | round / 1000000),
                 count: length,
-                models: ([.[].model // "unknown"] | unique | sort)
+                models: ([.[].model // "unknown"] | sort | unique)
             }) |
             sort_by(-.input_tokens)
         ' "$stage_jsonl" 2>/dev/null) || stage_json="[]"

--- a/scripts/sw-cost.sh
+++ b/scripts/sw-cost.sh
@@ -575,6 +575,89 @@ cost_update_pricing() {
     emit_event "cost.pricing_updated" "model=$model" "input_per_m=$input_price" "output_per_m=$output_price"
 }
 
+# ─── Breakdown Artifact ─────────────────────────────────────────────────────
+
+# cost_generate_breakdown <artifacts_dir> [pipeline_id] [issue]
+# Generates cost-breakdown.json from pipeline-local sidecars only.
+# Reads:  <artifacts_dir>/stage-costs.jsonl       — per-stage token deltas
+#         <artifacts_dir>/loop-iteration-costs.jsonl — per-iteration deltas
+# Writes: <artifacts_dir>/cost-breakdown.json     (atomic via tmp+mv)
+#
+# Never queries global costs.json — sidecars are pipeline-isolated, avoiding
+# concurrent-pipeline cross-contamination and resume-epoch drift issues.
+cost_generate_breakdown() {
+    local artifacts_dir="${1:-}"
+    local pipeline_id="${2:-unknown}"
+    local issue="${3:-}"
+    [[ -z "$artifacts_dir" ]] && { warn "cost_generate_breakdown: missing artifacts_dir"; return 1; }
+    mkdir -p "$artifacts_dir" 2>/dev/null || true
+
+    local stage_jsonl="${artifacts_dir}/stage-costs.jsonl"
+    local iter_jsonl="${artifacts_dir}/loop-iteration-costs.jsonl"
+    local out_file="${artifacts_dir}/cost-breakdown.json"
+    local tmp_file
+    tmp_file=$(mktemp "${out_file}.XXXXXX")
+
+    local stage_json="[]"
+    if [[ -f "$stage_jsonl" ]]; then
+        stage_json=$(jq -s '
+            group_by(.stage) |
+            map({
+                stage: .[0].stage,
+                input_tokens: ([.[].input_tokens] | add // 0),
+                output_tokens: ([.[].output_tokens] | add // 0),
+                count: length
+            }) |
+            sort_by(-.input_tokens)
+        ' "$stage_jsonl" 2>/dev/null) || stage_json="[]"
+    fi
+
+    local iter_json="[]"
+    if [[ -f "$iter_jsonl" ]]; then
+        iter_json=$(jq -s 'sort_by(.iteration)' "$iter_jsonl" 2>/dev/null) || iter_json="[]"
+    fi
+
+    local iter_count stage_count total_input total_output
+    iter_count=$(echo "$iter_json"  | jq 'length'              2>/dev/null || echo "0")
+    stage_count=$(echo "$stage_json" | jq 'length'              2>/dev/null || echo "0")
+    total_input=$(echo "$stage_json" | jq '[.[].input_tokens]  | add // 0' 2>/dev/null || echo "0")
+    total_output=$(echo "$stage_json" | jq '[.[].output_tokens] | add // 0' 2>/dev/null || echo "0")
+
+    jq -n \
+        --arg pipeline_id "$pipeline_id" \
+        --arg issue "$issue" \
+        --arg ts "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        --argjson by_stage "$stage_json" \
+        --argjson by_iteration "$iter_json" \
+        --argjson iter_count "$iter_count" \
+        --argjson stage_count "$stage_count" \
+        --argjson total_input "$total_input" \
+        --argjson total_output "$total_output" \
+        '{
+            pipeline_id: $pipeline_id,
+            issue: $issue,
+            generated_at: $ts,
+            summary: {
+                total_input_tokens: $total_input,
+                total_output_tokens: $total_output,
+                iteration_count: $iter_count,
+                stage_count: $stage_count
+            },
+            by_stage: $by_stage,
+            by_iteration: $by_iteration
+        }' > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$out_file" || {
+        warn "cost_generate_breakdown: failed to write ${out_file}"
+        rm -f "$tmp_file" 2>/dev/null || true
+        return 1
+    }
+    success "cost-breakdown.json written (${stage_count} stages, ${iter_count} iterations)"
+    emit_event "cost.breakdown_generated" \
+        "pipeline_id=${pipeline_id}" \
+        "issue=${issue}" \
+        "stages=${stage_count}" \
+        "iterations=${iter_count}" 2>/dev/null || true
+}
+
 # ─── Dashboard ─────────────────────────────────────────────────────────────
 
 cost_dashboard() {
@@ -582,15 +665,19 @@ cost_dashboard() {
     local json_output=false
     local by_stage=false
     local by_issue=false
+    local by_iteration=false
+    local artifacts_dir="${ARTIFACTS_DIR:-.claude/pipeline-artifacts}"
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --period)  period_days="${2:-7}"; shift 2 ;;
-            --period=*) period_days="${1#--period=}"; shift ;;
-            --json)    json_output=true; shift ;;
-            --by-stage) by_stage=true; shift ;;
-            --by-issue) by_issue=true; shift ;;
-            *)         shift ;;
+            --period)       period_days="${2:-7}"; shift 2 ;;
+            --period=*)     period_days="${1#--period=}"; shift ;;
+            --json)         json_output=true; shift ;;
+            --by-stage)     by_stage=true; shift ;;
+            --by-issue)     by_issue=true; shift ;;
+            --by-iteration) by_iteration=true; shift ;;
+            --artifacts-dir) artifacts_dir="${2:-}"; shift 2 ;;
+            *)              shift ;;
         esac
     done
 
@@ -755,6 +842,31 @@ cost_dashboard() {
                 printf "    %-20s %-12s %s\n" "$issue" "$cost" "$count"
             done
         echo ""
+    fi
+
+    # Iteration breakdown — reads pipeline-local artifact, NOT historical aggregation
+    if [[ "$by_iteration" == "true" ]]; then
+        local breakdown_file="${artifacts_dir}/cost-breakdown.json"
+        if [[ -f "$breakdown_file" ]]; then
+            local iter_data
+            iter_data=$(jq '.by_iteration' "$breakdown_file" 2>/dev/null || echo "[]")
+            local iter_len
+            iter_len=$(echo "$iter_data" | jq 'length' 2>/dev/null || echo "0")
+            if [[ "$iter_len" -gt 0 ]]; then
+                echo -e "${BOLD}  BY ITERATION${RESET}  ${DIM}(most-recent pipeline run — not historical aggregation)${RESET}"
+                echo "$iter_data" | jq -r '.[] | "\(.iteration)\t\(.input_tokens)\t\(.output_tokens)\t\(.cost_usd)"' 2>/dev/null | \
+                    while IFS=$'\t' read -r iter input output cost; do
+                        printf "    iter %-4s  in: %-8s out: %-8s cost: \$%s\n" "$iter" "$input" "$output" "$cost"
+                    done
+                echo ""
+            else
+                echo -e "${DIM}  no iteration data (run a pipeline with cost tracking first)${RESET}"
+                echo ""
+            fi
+        else
+            echo -e "${DIM}  no iteration data (run a pipeline with cost tracking first)${RESET}"
+            echo ""
+        fi
     fi
 
     # Budget
@@ -931,6 +1043,8 @@ show_help() {
     echo -e "  ${CYAN}show${RESET} --json                   JSON output"
     echo -e "  ${CYAN}show${RESET} --by-stage               Breakdown by pipeline stage"
     echo -e "  ${CYAN}show${RESET} --by-issue               Breakdown by issue"
+    echo -e "  ${CYAN}show${RESET} --by-iteration           Per-iteration breakdown (most-recent pipeline artifact)"
+    echo -e "  ${CYAN}breakdown${RESET} <artifacts_dir> [pipeline_id] [issue]  Generate cost-breakdown.json artifact"
     echo -e "  ${CYAN}budget set${RESET} <amount>            Set daily budget (USD)"
     echo -e "  ${CYAN}budget show${RESET}                    Show current budget/usage"
     echo ""
@@ -1000,6 +1114,9 @@ case "$SUBCOMMAND" in
         ;;
     update-pricing)
         cost_update_pricing "$@"
+        ;;
+    breakdown)
+        cost_generate_breakdown "$@"
         ;;
     help|--help|-h)
         show_help

--- a/scripts/sw-doctor.sh
+++ b/scripts/sw-doctor.sh
@@ -936,7 +936,62 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 11. Remote Machines
+# 11. Cost Intelligence
+# ═════════════════════════════════════════════════════════════════════════════
+echo ""
+echo -e "${PURPLE}${BOLD}  COST INTELLIGENCE${RESET}"
+echo -e "${DIM}  ──────────────────────────────────────────${RESET}"
+
+# Cost data files
+_cost_json="${HOME}/.shipwright/costs.json"
+if [[ -f "$_cost_json" ]]; then
+    if jq -e '.entries | type == "array"' "$_cost_json" >/dev/null 2>&1; then
+        _cost_count=$(jq '.entries | length' "$_cost_json" 2>/dev/null || echo "0")
+        check_pass "Cost ledger: ${_cost_count} entries"
+    else
+        check_fail "Cost ledger: invalid schema (missing .entries array)"
+    fi
+else
+    info "  Cost ledger not found ${DIM}(created after first pipeline run)${RESET}"
+fi
+
+# cost-breakdown.json schema validation — look for the most recent one
+_bd_dir=".claude/pipeline-artifacts"
+if [[ -f "$_bd_dir/cost-breakdown.json" ]] && command -v jq >/dev/null 2>&1; then
+    _bd_valid=true
+    # Required top-level fields
+    for _bd_field in pipeline_id generated_at summary by_stage by_iteration; do
+        if ! jq -e ".${_bd_field}" "$_bd_dir/cost-breakdown.json" >/dev/null 2>&1; then
+            check_fail "cost-breakdown.json: missing required field '.${_bd_field}'"
+            _bd_valid=false
+        fi
+    done
+    # Required summary sub-fields
+    for _bd_sum_field in total_input_tokens total_output_tokens total_cost_usd; do
+        if ! jq -e ".summary.${_bd_sum_field} | numbers" "$_bd_dir/cost-breakdown.json" >/dev/null 2>&1; then
+            check_warn "cost-breakdown.json: .summary.${_bd_sum_field} is not a number"
+            _bd_valid=false
+        fi
+    done
+    # Totals should be non-negative
+    _bd_cost=$(jq -r '.summary.total_cost_usd // -1' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "-1")
+    if awk -v v="$_bd_cost" 'BEGIN { exit !(v >= 0) }' 2>/dev/null; then
+        : # ok
+    else
+        check_warn "cost-breakdown.json: .summary.total_cost_usd is negative (${_bd_cost})"
+        _bd_valid=false
+    fi
+    if [[ "$_bd_valid" == "true" ]]; then
+        _bd_stages=$(jq '.summary.stage_count // 0' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "0")
+        _bd_iters=$(jq '.summary.iteration_count // 0' "$_bd_dir/cost-breakdown.json" 2>/dev/null || echo "0")
+        check_pass "cost-breakdown.json: valid schema (${_bd_stages} stages, ${_bd_iters} iterations)"
+    fi
+else
+    info "  No cost-breakdown.json ${DIM}(generated after each pipeline run)${RESET}"
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 12. Remote Machines
 # ═════════════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${PURPLE}${BOLD}  REMOTE MACHINES${RESET}"
@@ -975,7 +1030,7 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 12. Team Connectivity
+# 13. Team Connectivity
 # ═════════════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${PURPLE}${BOLD}  TEAM CONNECTIVITY${RESET}"
@@ -1046,7 +1101,7 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 13. GitHub Integration
+# 14. GitHub Integration
 # ═════════════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${PURPLE}${BOLD}  GITHUB INTEGRATION${RESET}"
@@ -1127,7 +1182,7 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 14. Dashboard & Dependencies
+# 15. Dashboard & Dependencies
 # ═════════════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${PURPLE}${BOLD}  DASHBOARD & DEPENDENCIES${RESET}"
@@ -1185,7 +1240,7 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 15. Database Health
+# 16. Database Health
 # ═════════════════════════════════════════════════════════════════════════════
 echo ""
 echo -e "${PURPLE}${BOLD}  DATABASE HEALTH${RESET}"
@@ -1239,7 +1294,7 @@ echo ""
 doctor_check_intelligence
 
 # ═════════════════════════════════════════════════════════════════════════════
-# 14. Platform health (AGI-level self-improvement)
+# 17. Platform health (AGI-level self-improvement)
 # ═════════════════════════════════════════════════════════════════════════════
 echo -e "${PURPLE}${BOLD}  PLATFORM HEALTH${RESET}"
 echo -e "${DIM}  ──────────────────────────────────────────${RESET}"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2560,8 +2560,8 @@ ${GOAL}"
         commits_before="$(git_commit_count)"
 
         # Snapshot token counters for per-iteration cost attribution (issue #87).
-        # Set even when ITER_COST_JSONL is unset — record_iteration_cost short-circuits
-        # in that case but expects the snapshot vars to be defined (loud-fail check).
+        # These snapshots are only needed when ITER_COST_JSONL is set, because
+        # record_iteration_cost returns early when that sidecar path is unset.
         _ITER_SNAP_INPUT="${LOOP_INPUT_TOKENS:-0}"
         _ITER_SNAP_OUTPUT="${LOOP_OUTPUT_TOKENS:-0}"
         _ITER_SNAP_COST_MC="${LOOP_COST_MILLICENTS:-0}"
@@ -2572,6 +2572,9 @@ ${GOAL}"
 
         # Record per-iteration delta to the pipeline's loop-iteration-costs.jsonl sidecar.
         # No-ops silently when ITER_COST_JSONL is not exported (e.g. standalone `sw loop`).
+        # Note: this path is only reached in single-agent mode. Multi-agent runs go through
+        # launch_multi_agent and do not currently record per-iteration iteration costs to
+        # the sidecar. Iteration attribution for --agents>1 is a future enhancement.
         if type record_iteration_cost >/dev/null 2>&1; then
             record_iteration_cost "$ITERATION" 2>/dev/null || true
         fi

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -40,6 +40,9 @@ fi
 [[ -f "$SCRIPT_DIR/lib/loop-convergence.sh" ]] && source "$SCRIPT_DIR/lib/loop-convergence.sh"
 [[ -f "$SCRIPT_DIR/lib/loop-restart.sh" ]] && source "$SCRIPT_DIR/lib/loop-restart.sh"
 [[ -f "$SCRIPT_DIR/lib/loop-progress.sh" ]] && source "$SCRIPT_DIR/lib/loop-progress.sh"
+# Per-iteration cost recording (issue #87) — record_iteration_cost reads $ITER_COST_JSONL
+# which is exported by the pipeline before invoking `sw loop`.
+[[ -f "$SCRIPT_DIR/lib/cost/iteration.sh" ]] && source "$SCRIPT_DIR/lib/cost/iteration.sh"
 # RuFlo adapter — compatibility layer for ruflo health checks and timeout recovery
 [[ -f "$SCRIPT_DIR/lib/ruflo-adapter.sh" ]] && source "$SCRIPT_DIR/lib/ruflo-adapter.sh" 2>/dev/null || true
 # Context exhaustion prevention — proactive summarization before Claude hits context limits
@@ -2556,9 +2559,22 @@ ${GOAL}"
         local commits_before
         commits_before="$(git_commit_count)"
 
+        # Snapshot token counters for per-iteration cost attribution (issue #87).
+        # Set even when ITER_COST_JSONL is unset — record_iteration_cost short-circuits
+        # in that case but expects the snapshot vars to be defined (loud-fail check).
+        _ITER_SNAP_INPUT="${LOOP_INPUT_TOKENS:-0}"
+        _ITER_SNAP_OUTPUT="${LOOP_OUTPUT_TOKENS:-0}"
+        _ITER_SNAP_COST_MC="${LOOP_COST_MILLICENTS:-0}"
+
         # Run Claude
         local exit_code=0
         run_claude_iteration || exit_code=$?
+
+        # Record per-iteration delta to the pipeline's loop-iteration-costs.jsonl sidecar.
+        # No-ops silently when ITER_COST_JSONL is not exported (e.g. standalone `sw loop`).
+        if type record_iteration_cost >/dev/null 2>&1; then
+            record_iteration_cost "$ITERATION" 2>/dev/null || true
+        fi
 
         local log_file="$LOG_DIR/iteration-${ITERATION}.log"
 

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -3036,8 +3036,11 @@ pipeline_start() {
         "model=$model_key" \
         "cost_usd=$total_cost"
 
-    # Persist cost entry to costs.json + SQLite (was missing — tokens accumulated but never written)
-    if type cost_record >/dev/null 2>&1; then
+    # Persist a pipeline-level cost entry only when stage attribution is NOT active.
+    # When record_stage_cost_end is loaded, each stage delta is already written to
+    # costs.json individually, so writing a pipeline total here would double-count
+    # every token in budget checks and dashboard aggregations.
+    if type cost_record >/dev/null 2>&1 && ! type record_stage_cost_end >/dev/null 2>&1; then
         cost_record "$TOTAL_INPUT_TOKENS" "$TOTAL_OUTPUT_TOKENS" "$model_key" "pipeline" "${ISSUE_NUMBER:-}" 2>/dev/null || true
     fi
     # cost_generate_breakdown runs from cleanup_on_exit so it fires on every exit path.

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -118,6 +118,10 @@ fi
 # shellcheck source=sw-cost.sh
 # for cost_record persistence to costs.json + DB
 [[ -f "$SCRIPT_DIR/sw-cost.sh" ]] && source "$SCRIPT_DIR/sw-cost.sh"
+# shellcheck source=lib/cost/stage.sh
+# Per-stage cost attribution helpers (issue #87). Must source AFTER sw-cost.sh
+# so that cost_calculate / cost_record are available when stages bracket themselves.
+[[ -f "$SCRIPT_DIR/lib/cost/stage.sh" ]] && source "$SCRIPT_DIR/lib/cost/stage.sh"
 # shellcheck source=lib/skill-registry.sh
 # for skill_analyze_outcome (AI outcome learning)
 [[ -f "$SCRIPT_DIR/lib/skill-registry.sh" ]] && source "$SCRIPT_DIR/lib/skill-registry.sh"
@@ -697,6 +701,14 @@ cleanup_on_exit() {
     [[ "${_cleanup_done:-}" == "true" ]] && return 0
     _cleanup_done=true
 
+    # Generate cost-breakdown.json from sidecars on every exit path (issue #87 AC#4).
+    # Doing this here (rather than only after the success block at line ~3038) means
+    # an aborted/interrupted pipeline still produces an artifact for forensics.
+    if type cost_generate_breakdown >/dev/null 2>&1 && [[ -n "${ARTIFACTS_DIR:-}" ]] && [[ -d "$ARTIFACTS_DIR" ]]; then
+        local _bd_pid="${SHIPWRIGHT_PIPELINE_ID:-pipeline-$$-${ISSUE_NUMBER:-0}}"
+        cost_generate_breakdown "$ARTIFACTS_DIR" "$_bd_pid" "${ISSUE_NUMBER:-}" >/dev/null 2>&1 || true
+    fi
+
     # Cleanup ruflo MCP server
     if type ruflo_cleanup >/dev/null 2>&1; then
         ruflo_cleanup || true
@@ -1040,8 +1052,21 @@ run_stage_with_retry() {
     local attempt=0
     local prev_error_class=""
     while true; do
+        # Bracket every stage attempt for per-stage cost attribution (issue #87).
+        # _start snapshots token totals; _end records the delta to stage-costs.jsonl
+        # and the global cost ledger. Re-snapshotting on retry is intentional —
+        # each attempt's delta is the cost incurred during that attempt.
+        if type record_stage_cost_start >/dev/null 2>&1; then
+            record_stage_cost_start "$stage_id"
+        fi
         if "stage_${stage_id}"; then
+            if type record_stage_cost_end >/dev/null 2>&1; then
+                record_stage_cost_end "$stage_id"
+            fi
             return 0
+        fi
+        if type record_stage_cost_end >/dev/null 2>&1; then
+            record_stage_cost_end "$stage_id"
         fi
 
         # Capture error_class and error snippet for stage.failed / pipeline.completed events
@@ -3015,6 +3040,7 @@ pipeline_start() {
     if type cost_record >/dev/null 2>&1; then
         cost_record "$TOTAL_INPUT_TOKENS" "$TOTAL_OUTPUT_TOKENS" "$model_key" "pipeline" "${ISSUE_NUMBER:-}" 2>/dev/null || true
     fi
+    # cost_generate_breakdown runs from cleanup_on_exit so it fires on every exit path.
 
     # Record pipeline outcome for Thompson sampling / outcome-based learning
     if type db_record_outcome >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- **DDD consolidation**: canonical cost implementations moved to `lib/cost/stage.sh` and `lib/cost/iteration.sh`; old paths are backward-compat shims
- **Schema parity**: `stage-costs.jsonl` and `loop-iteration-costs.jsonl` now include `ts_epoch` (Unix int) and `issue` fields, matching `costs.json` schema
- **`emit_event` for iterations**: `record_iteration_cost` fires `cost.iteration_recorded` for parity with the `cost_record` event stream
- **`cost_calculate` warn-once**: unknown model strings now emit a single stderr warning instead of silently applying sonnet pricing
- **Model attribution preserved**: `cost_generate_breakdown` rollup now carries a `models[]` array per stage so retried stages with mixed Opus/Sonnet don't lose attribution
- **`cost_track_stage` decorator**: automatic start/end bracket — `cost_track_stage "build" stage_build`
- **`shipwright doctor`**: new COST INTELLIGENCE section validates `costs.json` and `cost-breakdown.json` schema
- **Test counter fix**: removed local `assert_pass`/`assert_fail` overrides in `sw-cost-test.sh` that shadowed the counting versions (was displaying "All 0 tests passed")

## Test plan

- [x] `bash scripts/sw-cost-test.sh` — 55 tests pass (was showing 0 due to counter bug, now correctly counted)
- [x] `bash scripts/sw-pipeline-test.sh` — 71 tests pass, no regressions
- [x] `bash scripts/sw-loop-test.sh` — 237 tests pass, no regressions
- [x] Backward compat: `lib/stage-cost.sh` and `lib/loop-cost.sh` shims source canonical implementations transparently
- [x] New fields (`ts_epoch`, `issue`) asserted in stage sidecar tests
- [x] `models[]` array asserted in e2e breakdown test

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)