### PR TITLE
fix(harness): stop goal/original_goal inflation — sidecar context + sentinel scrubbing (#444)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"bcb2cd19-8c04-446d-b47f-7f71607af228","pid":4235,"acquiredAt":1777292847415}

--- a/scripts/lib/goal-sanitize.sh
+++ b/scripts/lib/goal-sanitize.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║  goal-sanitize.sh — Strip synthesized pipeline context from goal strings  ║
+# ║                                                                          ║
+# ║  Called at capture time (sw-loop.sh:419) and on resume                   ║
+# ║  (loop-restart.sh, pipeline-state.sh).                                  ║
+# ║                                                                          ║
+# ║  Bash 3.2 safe: uses %% operator only, no regex, no associative arrays.  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+
+_strip_synthesized_sections() {
+    local _s="$1"
+
+    # Strip prefix forms first (KNOWN FIX prepended with blank line after)
+    if [[ "$_s" == "KNOWN FIX (from past success):"* ]]; then
+        _s="${_s#*$'\n\n'}"
+    fi
+
+    # Strip all suffix sentinels (Bash 3.2 safe: %% operator, no regex)
+    _s="${_s%%$'\n\n## Plan Summary'*}"
+    _s="${_s%%$'\n\n## Key Design Decisions'*}"
+    _s="${_s%%$'\n\nIMPORTANT (TDD mode)'*}"
+    _s="${_s%%$'\n\nHistorical context'*}"
+    _s="${_s%%$'\n\nDiscoveries from'*}"
+    _s="${_s%%$'\n\nFile hotspots'*}"
+    _s="${_s%%$'\n\nActive security alerts'*}"
+    _s="${_s%%$'\n\nCoverage baseline'*}"
+    _s="${_s%%$'\n\n## Skill Guidance'*}"
+    _s="${_s%%$'\n\n## Historical Build Context'*}"
+    _s="${_s%%$'\n\nBLOCKING ISSUES'*}"
+    _s="${_s%%$'\n\nIMPORTANT — Previous build'*}"
+    _s="${_s%%$'\n\nIMPORTANT — Code review'*}"
+    _s="${_s%%$'\n\nIMPORTANT — Architecture'*}"
+    _s="${_s%%$'\n\nIMPORTANT — Compound quality'*}"
+    _s="${_s%%$'\n\nHUMAN FEEDBACK'*}"
+    _s="${_s%%$'\n\n## Previous Session Context'*}"
+    _s="${_s%%$'\n\nWARNING: Memory system'*}"
+
+    printf '%s' "$_s"
+}

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -362,15 +362,12 @@ ${last_error}"
         fi
     fi
 
-    # When stuck, truncate to the high-level objective only (first paragraph).
-    # Use ORIGINAL_GOAL (not GOAL) so memory-injected prefixes like "KNOWN FIX: ..."
-    # don't replace the actual task objective. Use printf to avoid echo mis-parsing
-    # goals that start with -n/-e or contain backslash escapes.
-    local prompt_goal="$GOAL"
+    # Always use ORIGINAL_GOAL so memory-injected prefixes (KNOWN FIX, BLOCKING ISSUES, etc.)
+    # never inflate the ## Your Goal section. When stuck, truncate to the first paragraph only.
+    local prompt_goal="${ORIGINAL_GOAL:-$GOAL}"
     if [[ "$stuckness_detected" == "true" ]]; then
-        local _base_goal="${ORIGINAL_GOAL:-$GOAL}"
-        prompt_goal="$(printf '%s\n' "$_base_goal" | awk 'NR==1{print; next} /^[[:space:]]*$/{exit} {print}')"
-        [[ -z "$prompt_goal" ]] && prompt_goal="$_base_goal"
+        prompt_goal="$(printf '%s\n' "$prompt_goal" | awk 'NR==1{print; next} /^[[:space:]]*$/{exit} {print}')"
+        [[ -z "$prompt_goal" ]] && prompt_goal="${ORIGINAL_GOAL:-$GOAL}"
     fi
 
     # Session restart context — inject previous session progress

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -370,6 +370,19 @@ ${last_error}"
         [[ -z "$prompt_goal" ]] && prompt_goal="${ORIGINAL_GOAL:-$GOAL}"
     fi
 
+    # Pipeline context section (Layer A: sidecar delivery of synthesized context)
+    local pipeline_context_section=""
+    if [[ -n "${LOOP_CONTEXT_FILE:-}" && -f "${LOOP_CONTEXT_FILE:-}" ]]; then
+        local _ctx
+        _ctx="$(cat "$LOOP_CONTEXT_FILE" 2>/dev/null || true)"
+        if [[ -n "$_ctx" ]]; then
+            pipeline_context_section="## Pipeline Context
+${_ctx}
+
+"
+        fi
+    fi
+
     # Session restart context — inject previous session progress
     local restart_section=""
     if [[ "$SESSION_RESTART" == "true" ]] && [[ -f "$LOG_DIR/progress.md" ]]; then
@@ -429,7 +442,7 @@ ${resume_section}
 ## Your Goal
 ${prompt_goal}
 
-${cumulative_section}
+${pipeline_context_section}${cumulative_section}
 ${task_section:+## Task Progress
 $task_section
 

--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -221,18 +221,19 @@ resume_state() {
 
 write_state() {
     local tmp_state="${STATE_FILE}.tmp.$$"
-    # Encode GOAL and ORIGINAL_GOAL separately so they never converge to the same
-    # synthesized value.  ORIGINAL_GOAL must be set by the caller (sw-loop.sh line 419)
-    # before the first write_state call; the lazy bootstrap is removed to prevent
-    # contamination when ORIGINAL_GOAL is still empty and GOAL is already mutated.
-    local _goal_esc="${GOAL//\\/\\\\}"
-    _goal_esc="${_goal_esc//$'\n'/\\n}"
+    # Always persist ORIGINAL_GOAL (clean) to both goal: and original_goal: fields.
+    # Layer A+B ensure GOAL is clean before this is called in normal operation, but
+    # bootstrap here for the --issue pipeline flow where intake calls write_state
+    # with GOAL set from the issue title and ORIGINAL_GOAL still empty.
+    if [[ -z "${ORIGINAL_GOAL:-}" && -n "${GOAL:-}" ]]; then
+        ORIGINAL_GOAL="$GOAL"
+    fi
     local _orig_goal_esc="${ORIGINAL_GOAL//\\/\\\\}"
     _orig_goal_esc="${_orig_goal_esc//$'\n'/\\n}"
     # Use printf instead of heredoc to avoid delimiter injection from GOAL
     {
         printf -- '---\n'
-        printf 'goal: "%s"\n' "$_goal_esc"
+        printf 'goal: "%s"\n' "$_orig_goal_esc"
         printf 'original_goal: "%s"\n' "$_orig_goal_esc"
         printf 'iteration: %s\n' "$ITERATION"
         printf 'max_iterations: %s\n' "$MAX_ITERATIONS"

--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -3,6 +3,10 @@
 [[ -n "${_LOOP_RESTART_LOADED:-}" ]] && return 0
 _LOOP_RESTART_LOADED=1
 
+# Source goal sanitization helper (strips synthesized sections from goals)
+# shellcheck source=goal-sanitize.sh
+[[ -f "$(dirname "${BASH_SOURCE[0]}")/goal-sanitize.sh" ]] && source "$(dirname "${BASH_SOURCE[0]}")/goal-sanitize.sh"
+
 # ─── State Management ────────────────────────────────────────────────────────
 
 initialize_state() {
@@ -121,21 +125,31 @@ resume_state() {
     done < "$STATE_FILE"
 
     if $_has_original_goal; then
-        # New state file: original_goal field was present — ORIGINAL_GOAL already set by parser.
-        # No sentinel stripping needed; the stored goal is already clean.
-        :
+        # New state file: original_goal field was present.
+        # Apply unified sentinel stripping to BOTH fields — defense in depth.
+        # If ORIGINAL_GOAL somehow has synthesis pollution, clean it.
+        if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+            ORIGINAL_GOAL="$(_strip_synthesized_sections "$ORIGINAL_GOAL")"
+            GOAL="${GOAL:-$ORIGINAL_GOAL}"
+            GOAL="$(_strip_synthesized_sections "$GOAL")"
+        fi
     else
         # Legacy state file: no original_goal field — apply backward-compat sentinel stripping.
-        # Only applies to files written before this fix. Uses %% (bash 3.2 safe, no regex).
-        if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
-        if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
-        if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
-        # KNOWN FIX is prepended — strip from start through first blank line
-        if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+        # Uses the unified helper if available, fallback to inline sentinels.
+        if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+            GOAL="$(_strip_synthesized_sections "$GOAL")"
+        else
+            # Fallback (if goal-sanitize.sh failed to load) — inline legacy sentinels only
+            if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
+            if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
+            if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
+            # KNOWN FIX is prepended — strip from start through first blank line
+            if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+        fi
         ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
     fi
 

--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -207,21 +207,19 @@ resume_state() {
 
 write_state() {
     local tmp_state="${STATE_FILE}.tmp.$$"
-    # Encode GOAL: escape backslashes first, then newlines, so that a literal \n
-    # in the goal is stored as \\n (unambiguous) while a real newline becomes \n.
-    local _write_goal="${ORIGINAL_GOAL:-$GOAL}"
-    # Bootstrap ORIGINAL_GOAL in memory on first non-empty write (handles cases where
-    # GOAL is populated after initialization, leaving ORIGINAL_GOAL empty until here).
-    if [[ -z "${ORIGINAL_GOAL:-}" && -n "${_write_goal}" ]]; then
-        ORIGINAL_GOAL="$_write_goal"
-    fi
-    local _goal_esc="${_write_goal//\\/\\\\}"
+    # Encode GOAL and ORIGINAL_GOAL separately so they never converge to the same
+    # synthesized value.  ORIGINAL_GOAL must be set by the caller (sw-loop.sh line 419)
+    # before the first write_state call; the lazy bootstrap is removed to prevent
+    # contamination when ORIGINAL_GOAL is still empty and GOAL is already mutated.
+    local _goal_esc="${GOAL//\\/\\\\}"
     _goal_esc="${_goal_esc//$'\n'/\\n}"
+    local _orig_goal_esc="${ORIGINAL_GOAL//\\/\\\\}"
+    _orig_goal_esc="${_orig_goal_esc//$'\n'/\\n}"
     # Use printf instead of heredoc to avoid delimiter injection from GOAL
     {
         printf -- '---\n'
         printf 'goal: "%s"\n' "$_goal_esc"
-        printf 'original_goal: "%s"\n' "$_goal_esc"
+        printf 'original_goal: "%s"\n' "$_orig_goal_esc"
         printf 'iteration: %s\n' "$ITERATION"
         printf 'max_iterations: %s\n' "$MAX_ITERATIONS"
         printf 'status: %s\n' "$STATUS"

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -186,20 +186,24 @@ stage_build() {
         memory_context=$(bash "$SCRIPT_DIR/sw-memory.sh" inject "build" 2>/dev/null) || true
     fi
 
-    # Build enriched goal with compact context (avoids prompt bloat)
-    local enriched_goal
-    enriched_goal=$(_pipeline_compact_goal "$GOAL" "$plan_file" "$design_file")
+    # Build clean goal (no synthesis context)
+    local clean_goal
+    clean_goal="$GOAL"
+
+    # Build synthesized context separately (Layer A: sidecar delivery)
+    local build_context_body
+    build_context_body=$(_pipeline_compact_goal "$GOAL" "$plan_file" "$design_file")
 
     # TDD: when test_first ran, tell build to make existing tests pass
     if [[ "${TDD_ENABLED:-false}" == "true" || "${PIPELINE_TDD:-}" == "true" ]]; then
-        enriched_goal="${enriched_goal}
+        build_context_body="${build_context_body}
 
 IMPORTANT (TDD mode): Test files already exist and define the expected behavior. Write implementation code to make ALL tests pass. Do not delete or modify the test files."
     fi
 
     # Inject memory context
     if [[ -n "$memory_context" ]]; then
-        enriched_goal="${enriched_goal}
+        build_context_body="${build_context_body}
 
 Historical context (lessons from previous pipelines):
 ${memory_context}"
@@ -210,7 +214,7 @@ ${memory_context}"
         local build_discoveries
         build_discoveries=$("$SCRIPT_DIR/sw-discovery.sh" inject "src/*,*.ts,*.tsx,*.js" 2>/dev/null | head -20 || true)
         if [[ -n "$build_discoveries" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 Discoveries from other pipelines:
 ${build_discoveries}"
@@ -240,7 +244,7 @@ ${build_discoveries}"
         local build_hotspots
         build_hotspots=$(gh_file_change_frequency 2>/dev/null | head -5 || true)
         if [[ -n "$build_hotspots" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 File hotspots (most frequently changed — review these carefully):
 ${build_hotspots}"
@@ -252,7 +256,7 @@ ${build_hotspots}"
         local build_alerts
         build_alerts=$(gh_security_alerts 2>/dev/null | head -3 || true)
         if [[ -n "$build_alerts" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 Active security alerts (do not introduce new vulnerabilities):
 ${build_alerts}"
@@ -267,7 +271,7 @@ ${build_alerts}"
         local coverage_baseline
         coverage_baseline=$(jq -r '.coverage_percent // empty' "$coverage_file_build" 2>/dev/null || true)
         if [[ -n "$coverage_baseline" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 Coverage baseline: ${coverage_baseline}% — do not decrease coverage."
         fi
@@ -280,7 +284,7 @@ Coverage baseline: ${coverage_baseline}% — do not decrease coverage."
         local prevention_text
         prevention_text=$(bash "$SCRIPT_DIR/sw-predictive.sh" inject-prevention "build" "$issue_json_build" 2>/dev/null || true)
         if [[ -n "$prevention_text" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 ${prevention_text}"
         fi
@@ -304,7 +308,7 @@ ${prevention_text}"
     fi
     if [[ -n "$_skill_prompts" ]]; then
         _skill_prompts=$(prune_context_section "skills" "$_skill_prompts" 8000)
-        enriched_goal="${enriched_goal}
+        build_context_body="${build_context_body}
 
 ## Skill Guidance (${INTELLIGENCE_ISSUE_TYPE:-backend} issue, AI-selected)
 ${_skill_prompts}
@@ -347,7 +351,7 @@ ${_skill_prompts}
             warn "Ruflo: recall output was sanitized before injection (potential injection attempt or malformed data)"
         fi
         if [[ -n "$_build_recall_ctx" ]]; then
-            enriched_goal="${enriched_goal}
+            build_context_body="${build_context_body}
 
 ## Historical Build Context
 ${_build_recall_ctx}"
@@ -355,7 +359,16 @@ ${_build_recall_ctx}"
         fi
     fi
 
-    loop_args+=("$enriched_goal")
+    # Layer A: Write synthesized context to sidecar (atomic write)
+    local _ctx_file="${ARTIFACTS_DIR}/build-context.md"
+    local _ctx_tmp="${_ctx_file}.tmp.$$"
+    printf '%s\n' "$build_context_body" > "$_ctx_tmp"
+    mv "$_ctx_tmp" "$_ctx_file"
+    info "Build context written to ${_ctx_file} ($(wc -c < "$_ctx_file") bytes)"
+
+    # Pass clean goal to loop (not enriched with context)
+    loop_args+=("$clean_goal")
+    loop_args+=(--context-file "$_ctx_file")
 
     # Build loop args from pipeline config + CLI overrides
     CURRENT_STAGE_ID="build"

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -604,24 +604,20 @@ write_state() {
 
     # Atomic write: build content in tmp file, then mv into place.
     # This prevents partial/corrupt state files when interrupted by signals.
-    # Encode GOAL: escape backslashes first, then newlines, so that a literal \n
-    # in the goal is stored as \\n (unambiguous) while a real newline becomes \n.
+    # Encode GOAL and ORIGINAL_GOAL separately: escape backslashes first, then newlines,
+    # so that a literal \n in the goal is stored as \\n (unambiguous) while a real
+    # newline becomes \n.  Never merge both fields into one variable — that's how
+    # synthesized content from GOAL contaminates ORIGINAL_GOAL permanently.
     local tmp_state="${STATE_FILE}.tmp.$$"
-    local _write_goal="${ORIGINAL_GOAL:-$GOAL}"
-    # Bootstrap ORIGINAL_GOAL in memory on first non-empty write (e.g. --issue runs where
-    # intake fills GOAL after pipeline_start, leaving ORIGINAL_GOAL empty until here).
-    # Safe because callers (sw-pipeline.sh, sw-loop.sh) set ORIGINAL_GOAL before the first
-    # write_state call when GOAL may already be mutated, preventing contamination.
-    if [[ -z "${ORIGINAL_GOAL:-}" && -n "${_write_goal}" ]]; then
-        ORIGINAL_GOAL="$_write_goal"
-    fi
-    local _goal_esc="${_write_goal//\\/\\\\}"
+    local _goal_esc="${GOAL//\\/\\\\}"
     _goal_esc="${_goal_esc//$'\n'/\\n}"
+    local _orig_goal_esc="${ORIGINAL_GOAL//\\/\\\\}"
+    _orig_goal_esc="${_orig_goal_esc//$'\n'/\\n}"
     {
         printf -- '---\n'
         printf 'pipeline: %s\n' "$PIPELINE_NAME"
         printf 'goal: "%s"\n' "$_goal_esc"
-        printf 'original_goal: "%s"\n' "$_goal_esc"
+        printf 'original_goal: "%s"\n' "$_orig_goal_esc"
         printf 'status: %s\n' "$PIPELINE_STATUS"
         printf 'issue: "%s"\n' "${GITHUB_ISSUE:-}"
         printf 'branch: "%s"\n' "${GIT_BRANCH:-}"

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -608,19 +608,19 @@ write_state() {
 
     # Atomic write: build content in tmp file, then mv into place.
     # This prevents partial/corrupt state files when interrupted by signals.
-    # Encode GOAL and ORIGINAL_GOAL separately: escape backslashes first, then newlines,
-    # so that a literal \n in the goal is stored as \\n (unambiguous) while a real
-    # newline becomes \n.  Never merge both fields into one variable — that's how
-    # synthesized content from GOAL contaminates ORIGINAL_GOAL permanently.
+    # Always persist ORIGINAL_GOAL (clean) to both goal: and original_goal: fields.
+    # Bootstrap ORIGINAL_GOAL from GOAL on first non-empty write for the --issue flow
+    # where intake calls write_state with GOAL set and ORIGINAL_GOAL still empty.
+    if [[ -z "${ORIGINAL_GOAL:-}" && -n "${GOAL:-}" ]]; then
+        ORIGINAL_GOAL="$GOAL"
+    fi
     local tmp_state="${STATE_FILE}.tmp.$$"
-    local _goal_esc="${GOAL//\\/\\\\}"
-    _goal_esc="${_goal_esc//$'\n'/\\n}"
     local _orig_goal_esc="${ORIGINAL_GOAL//\\/\\\\}"
     _orig_goal_esc="${_orig_goal_esc//$'\n'/\\n}"
     {
         printf -- '---\n'
         printf 'pipeline: %s\n' "$PIPELINE_NAME"
-        printf 'goal: "%s"\n' "$_goal_esc"
+        printf 'goal: "%s"\n' "$_orig_goal_esc"
         printf 'original_goal: "%s"\n' "$_orig_goal_esc"
         printf 'status: %s\n' "$PIPELINE_STATUS"
         printf 'issue: "%s"\n' "${GITHUB_ISSUE:-}"

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -3,6 +3,10 @@
 [[ -n "${_PIPELINE_STATE_LOADED:-}" ]] && return 0
 _PIPELINE_STATE_LOADED=1
 
+# Source goal sanitization helper (strips synthesized sections from goals)
+# shellcheck source=goal-sanitize.sh
+[[ -f "$(dirname "${BASH_SOURCE[0]}")/goal-sanitize.sh" ]] && source "$(dirname "${BASH_SOURCE[0]}")/goal-sanitize.sh"
+
 # Ensure _trim is available (normally provided by helpers.sh, but this file
 # may be sourced in test harnesses that stub helpers instead of sourcing them).
 if ! type _trim >/dev/null 2>&1; then
@@ -709,21 +713,31 @@ ${sid}:${sst}"
     done < "$STATE_FILE"
 
     if $_has_original_goal; then
-        # New state file: original_goal field was present — ORIGINAL_GOAL already set by parser.
-        # No sentinel stripping needed; the stored goal is already clean.
-        :
+        # New state file: original_goal field was present.
+        # Apply unified sentinel stripping to BOTH fields — defense in depth.
+        # If ORIGINAL_GOAL somehow has synthesis pollution, clean it.
+        if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+            ORIGINAL_GOAL="$(_strip_synthesized_sections "$ORIGINAL_GOAL")"
+            GOAL="${GOAL:-$ORIGINAL_GOAL}"
+            GOAL="$(_strip_synthesized_sections "$GOAL")"
+        fi
     else
         # Legacy state file: no original_goal field — apply backward-compat sentinel stripping.
-        # Only applies to files written before this fix. Uses %% (bash 3.2 safe, no regex).
-        if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
-        if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
-        if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
-        if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
-        # KNOWN FIX is prepended — strip from start through first blank line
-        if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+        # Uses the unified helper if available, fallback to inline sentinels.
+        if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+            GOAL="$(_strip_synthesized_sections "$GOAL")"
+        else
+            # Fallback (if goal-sanitize.sh failed to load) — inline legacy sentinels only
+            if [[ "$GOAL" == *$'\n\nBLOCKING ISSUES'* ]];              then GOAL="${GOAL%%$'\n\nBLOCKING ISSUES'*}";              fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Previous build'* ]];   then GOAL="${GOAL%%$'\n\nIMPORTANT — Previous build'*}";   fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Code review'* ]];      then GOAL="${GOAL%%$'\n\nIMPORTANT — Code review'*}";      fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Architecture'* ]];     then GOAL="${GOAL%%$'\n\nIMPORTANT — Architecture'*}";     fi
+            if [[ "$GOAL" == *$'\n\nIMPORTANT — Compound quality'* ]]; then GOAL="${GOAL%%$'\n\nIMPORTANT — Compound quality'*}"; fi
+            if [[ "$GOAL" == *$'\n\nHUMAN FEEDBACK'* ]];               then GOAL="${GOAL%%$'\n\nHUMAN FEEDBACK'*}";               fi
+            if [[ "$GOAL" == *$'\n\n## Previous Session Context'* ]];  then GOAL="${GOAL%%$'\n\n## Previous Session Context'*}";  fi
+            # KNOWN FIX is prepended — strip from start through first blank line
+            if [[ "$GOAL" == "KNOWN FIX (from past success):"* ]];     then GOAL="${GOAL#*$'\n\n'}";                              fi
+        fi
         ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
     fi
 

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -610,6 +610,8 @@ write_state() {
     local _write_goal="${ORIGINAL_GOAL:-$GOAL}"
     # Bootstrap ORIGINAL_GOAL in memory on first non-empty write (e.g. --issue runs where
     # intake fills GOAL after pipeline_start, leaving ORIGINAL_GOAL empty until here).
+    # Safe because callers (sw-pipeline.sh, sw-loop.sh) set ORIGINAL_GOAL before the first
+    # write_state call when GOAL may already be mutated, preventing contamination.
     if [[ -z "${ORIGINAL_GOAL:-}" && -n "${_write_goal}" ]]; then
         ORIGINAL_GOAL="$_write_goal"
     fi

--- a/scripts/sw-cost-test.sh
+++ b/scripts/sw-cost-test.sh
@@ -304,7 +304,10 @@ else
     assert_fail "--by-iteration flag renders iteration section" "output: $(echo "$_iter_output" | grep -i iter | head -3)"
 fi
 
+_no_iter_dir="$TEST_TEMP_DIR/no-iter-artifacts"
+mkdir -p "$_no_iter_dir"
 _no_iter_output=$(env HOME="$TEST_TEMP_DIR/home" PATH="$TEST_TEMP_DIR/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin" \
+    ARTIFACTS_DIR="$_no_iter_dir" \
     bash "$SCRIPT_DIR/sw-cost.sh" show --by-iteration 2>&1) || true
 if echo "$_no_iter_output" | grep -qi "no iteration data\|no.*iteration\|iteration.*data"; then
     assert_pass "--by-iteration with no artifact shows graceful message"

--- a/scripts/sw-lib-loop-restart-test.sh
+++ b/scripts/sw-lib-loop-restart-test.sh
@@ -370,6 +370,40 @@ else
     assert_fail "show_summary stuck display string mentions stuck" "got: $_stuck_arm"
 fi
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Layer C: resume_state — unified synthesis sentinel stripping (#444)
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "Layer C: resume_state sentinel stripping (issue #444)"
+
+# Source goal-sanitize helper
+source "$SCRIPT_DIR/lib/goal-sanitize.sh" 2>/dev/null || {
+    assert_fail "goal-sanitize.sh not found" "cannot load $_GOAL_SANITIZE_PATH"
+}
+
+# Test H1: resume_state strips ## Plan Summary from original_goal field
+_write_state_with_status "running" "$(printf 'Clean goal\n\n## Plan Summary\nCompile plan here')"
+GOAL="" ORIGINAL_GOAL="" STATUS=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Plan Summary from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H2: resume_state strips ## Skill Guidance from original_goal field
+_write_state_with_status "running" "$(printf 'Clean goal\n\n## Skill Guidance\nGuide content here')"
+GOAL="" ORIGINAL_GOAL="" STATUS=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Skill Guidance from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H3: resume_state strips ## Historical Build Context from original_goal field
+_write_state_with_status "running" "$(printf 'Clean goal\n\n## Historical Build Context\nHistory here')"
+GOAL="" ORIGINAL_GOAL="" STATUS=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Historical Build Context from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H4: legacy — resume_state strips ## Plan Summary from goal field when no original_goal field
+_write_legacy_loop_state "$(printf 'Clean goal\n\n## Plan Summary\nPlan details')"
+GOAL="" ORIGINAL_GOAL="" STATUS=""
+resume_state 2>/dev/null
+assert_eq "legacy: resume_state strips ## Plan Summary from goal" "Clean goal" "$GOAL"
+
 # Emit explicit "$PASS/$TOTAL pass" as the final visible line for DoD audit parsers.
 printf '%s/%s pass\n' "$PASS" "$TOTAL"
 print_test_results

--- a/scripts/sw-lib-pipeline-stages-test.sh
+++ b/scripts/sw-lib-pipeline-stages-test.sh
@@ -530,7 +530,10 @@ _build_recall_capture="$TEST_TEMP_DIR/build-recall-goal.txt"
 export RUFLO_HIVE_BUILD=false
 export RUFLO_BUILD_AGENT=false
 
-# Re-create capturing sw mock for goal inspection
+# Re-create capturing sw mock for goal inspection.
+# With Layer A the goal arg is now clean; synthesized context goes to the sidecar
+# written at --context-file path. Capture both the goal arg and the context-file
+# path so tests can verify each channel independently.
 cat > "$TEST_TEMP_DIR/bin/sw" <<'SWMOCK'
 #!/usr/bin/env bash
 set -- "$@"
@@ -538,6 +541,12 @@ _saw_loop=false
 while [[ $# -gt 0 ]]; do
   case "$1" in
     loop) _saw_loop=true; shift ;;
+    --context-file)
+        shift
+        if [[ -n "${CAPTURED_BUILD_PROMPT:-}" && $# -gt 0 ]]; then
+            printf '%s' "$1" > "${CAPTURED_BUILD_PROMPT}.context-file"
+        fi
+        shift ;;
     --*) shift; [[ $# -gt 0 ]] && shift ;;
     *) if [[ "$_saw_loop" == true && -n "${CAPTURED_BUILD_PROMPT:-}" ]]; then
            printf '%s' "$1" > "${CAPTURED_BUILD_PROMPT}"
@@ -561,19 +570,21 @@ CAPTURED_BUILD_PROMPT="$_build_recall_capture" stage_build 2>/dev/null || true
 set -e
 
 if [[ -f "$_build_recall_capture" ]]; then
-    # This file is written by the sw mock when sw loop is called — proving
-    # that the enriched goal (with recall context) actually reached the loop
-    # invocation, not just that it was set in a local variable.
-    _build_goal=$(cat "$_build_recall_capture")
-    if echo "$_build_goal" | grep -q "## Historical Build Context"; then
+    # Layer A: synthesized context goes to the sidecar (--context-file), not the goal arg.
+    # Read sidecar path from the captured context-file arg, then check its content.
+    _ctx_file_path=""
+    [[ -f "${_build_recall_capture}.context-file" ]] && _ctx_file_path=$(cat "${_build_recall_capture}.context-file")
+    _build_context=""
+    [[ -n "$_ctx_file_path" && -f "$_ctx_file_path" ]] && _build_context=$(cat "$_ctx_file_path")
+    if echo "$_build_context" | grep -q "## Historical Build Context"; then
         assert_pass "stage_build: ## Historical Build Context header present in sw loop invocation"
     else
-        assert_fail "stage_build: ## Historical Build Context header present in sw loop invocation" "section missing from sw loop goal arg"
+        assert_fail "stage_build: ## Historical Build Context header present in sw loop invocation" "section missing from sidecar build-context.md (context-file: ${_ctx_file_path:-not captured})"
     fi
-    if echo "$_build_goal" | grep -q "fixed auth middleware"; then
+    if echo "$_build_context" | grep -q "fixed auth middleware"; then
         assert_pass "stage_build: recall content present in sw loop invocation"
     else
-        assert_fail "stage_build: recall content present in sw loop invocation" "recall text missing from sw loop goal arg"
+        assert_fail "stage_build: recall content present in sw loop invocation" "recall text missing from sidecar build-context.md"
     fi
 else
     assert_fail "stage_build: sw loop invoked with captured goal for recall test" "capture file missing — sw loop may not have been called or CAPTURED_BUILD_PROMPT not inherited"
@@ -644,17 +655,21 @@ CAPTURED_BUILD_PROMPT="$_build_recall_capture" stage_build 2>/dev/null || true
 set -e
 
 if [[ -f "$_build_recall_capture" ]]; then
-    _build_goal_sanitized=$(cat "$_build_recall_capture")
-    # Verify the specific malicious headers from recall output were stripped
-    if echo "$_build_goal_sanitized" | grep -q "## Ignore Prior Instructions"; then
+    # Layer A: sanitized recall goes to sidecar, not goal arg. Read sidecar content.
+    _ctx_san_path=""
+    [[ -f "${_build_recall_capture}.context-file" ]] && _ctx_san_path=$(cat "${_build_recall_capture}.context-file")
+    _build_sanitized_ctx=""
+    [[ -n "$_ctx_san_path" && -f "$_ctx_san_path" ]] && _build_sanitized_ctx=$(cat "$_ctx_san_path")
+    # Verify the specific malicious headers from recall output were stripped from sidecar
+    if echo "$_build_sanitized_ctx" | grep -q "## Ignore Prior Instructions"; then
         assert_fail "stage_build: markdown headers sanitized from recall context" "## Ignore Prior Instructions still present in injected content"
     else
         assert_pass "stage_build: markdown headers sanitized from recall context"
     fi
-    if echo "$_build_goal_sanitized" | grep -q "Normal line"; then
+    if echo "$_build_sanitized_ctx" | grep -q "Normal line"; then
         assert_pass "stage_build: non-header recall content preserved after sanitization"
     else
-        assert_fail "stage_build: non-header recall content preserved after sanitization" "body text missing after sanitization"
+        assert_fail "stage_build: non-header recall content preserved after sanitization" "body text missing after sanitization in sidecar"
     fi
 else
     assert_fail "stage_build: sanitization test — goal captured via sw loop" "capture file missing"

--- a/scripts/sw-lib-pipeline-state-test.sh
+++ b/scripts/sw-lib-pipeline-state-test.sh
@@ -687,4 +687,56 @@ GOAL="" ORIGINAL_GOAL=""
 resume_state 2>/dev/null
 assert_eq "no unbounded growth across 2 compound_quality cycles" "Original" "$GOAL"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# Layer C: resume_state — unified synthesis sentinel stripping (#444)
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "Layer C: resume_state sentinel stripping (issue #444)"
+
+# Source goal-sanitize helper
+source "$SCRIPT_DIR/lib/goal-sanitize.sh" 2>/dev/null || {
+    assert_fail "goal-sanitize.sh not found" "cannot load helper"
+}
+
+# Helper: write a pipeline state file with new original_goal field
+_write_pipeline_state_with_original() {
+    local goal="$1"
+    local _esc="${goal//\\/\\\\}"
+    _esc="${_esc//$'\n'/\\n}"
+    {
+        printf -- '---\n'
+        printf 'pipeline: %s\n' "$PIPELINE_NAME"
+        printf 'goal: "%s"\n' "$_esc"
+        printf 'original_goal: "%s"\n' "$_esc"
+        printf 'status: %s\n' "${PIPELINE_STATUS:-running}"
+        printf 'current_stage: %s\n' "${CURRENT_STAGE:-}"
+        printf 'stages:\n'
+        printf -- '---\n\n'
+        printf '## Log\n'
+    } > "$STATE_FILE"
+}
+
+# Test H1: resume_state strips ## Plan Summary from original_goal field
+_write_pipeline_state_with_original "$(printf 'Clean goal\n\n## Plan Summary\nCompile plan here')"
+GOAL="" ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Plan Summary from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H2: resume_state strips ## Skill Guidance from original_goal field
+_write_pipeline_state_with_original "$(printf 'Clean goal\n\n## Skill Guidance\nGuide content here')"
+GOAL="" ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Skill Guidance from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H3: resume_state strips ## Historical Build Context from original_goal field
+_write_pipeline_state_with_original "$(printf 'Clean goal\n\n## Historical Build Context\nHistory here')"
+GOAL="" ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "resume_state strips ## Historical Build Context from original_goal" "Clean goal" "$ORIGINAL_GOAL"
+
+# Test H4: legacy — resume_state strips ## Plan Summary from goal field when no original_goal field
+_write_legacy_state "$(printf 'Clean goal\n\n## Plan Summary\nPlan details')"
+GOAL="" ORIGINAL_GOAL=""
+resume_state 2>/dev/null
+assert_eq "legacy: resume_state strips ## Plan Summary from goal" "Clean goal" "$GOAL"
+
 print_test_results

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -136,6 +136,9 @@ ADDITIONAL_TEST_CMDS=()   # Array of extra test commands (from --additional-test
 # ─── Context Budget ──────────────────────────────────────────────────────────
 CONTEXT_BUDGET_CHARS="${CONTEXT_BUDGET_CHARS:-200000}"  # Max prompt chars before trimming
 
+# ─── Pipeline Context File (Layer A sidecar) ──────────────────────────────────
+LOOP_CONTEXT_FILE="${LOOP_CONTEXT_FILE:-}"  # Sidecar with synthesized build context
+
 # ─── Parse Arguments ──────────────────────────────────────────────────────────
 show_help() {
     echo -e "${CYAN}${BOLD}shipwright${RESET} ${DIM}v${VERSION}${RESET} — ${BOLD}Continuous Loop${RESET}"
@@ -307,6 +310,12 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --roles=*) AGENT_ROLES="${1#--roles=}"; shift ;;
+        --context-file)
+            LOOP_CONTEXT_FILE="${2:-}"
+            [[ -z "$LOOP_CONTEXT_FILE" ]] && { error "Missing value for --context-file"; exit 1; }
+            shift 2
+            ;;
+        --context-file=*) LOOP_CONTEXT_FILE="${1#--context-file=}"; shift ;;
         --help|-h)
             show_help
             exit 0
@@ -413,6 +422,21 @@ fi
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     error "Not inside a git repository. The loop requires git for progress tracking."
     exit 1
+fi
+
+# Validate --context-file path (if provided by pipeline)
+if [[ -n "$LOOP_CONTEXT_FILE" ]]; then
+    PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+    if [[ "$LOOP_CONTEXT_FILE" != "$PROJECT_ROOT"* ]]; then
+        error "context-file must be inside project root ($PROJECT_ROOT)"
+        exit 1
+    fi
+fi
+
+# Layer B: Strip synthesized sections from GOAL before preserving as ORIGINAL_GOAL
+# Defense-in-depth: if the build stage passed an enriched goal, scrub it here.
+if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+    GOAL="$(_strip_synthesized_sections "$GOAL")"
 fi
 
 # Preserve original goal before any appending (memory fixes, human feedback)

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -427,15 +427,21 @@ fi
 # Validate --context-file path (if provided by pipeline)
 if [[ -n "$LOOP_CONTEXT_FILE" ]]; then
     PROJECT_ROOT="$(git rev-parse --show-toplevel)"
-    if [[ "$LOOP_CONTEXT_FILE" != "$PROJECT_ROOT"* ]]; then
-        error "context-file must be inside project root ($PROJECT_ROOT)"
-        exit 1
-    fi
+    # Use trailing-slash boundary to reject sibling-prefix paths like
+    # /workspace/shipwright-evil/x.md when PROJECT_ROOT=/workspace/shipwright
+    case "$LOOP_CONTEXT_FILE" in
+        "${PROJECT_ROOT}/"*) : ;;
+        *)
+            error "context-file must be inside project root ($PROJECT_ROOT)"
+            exit 1
+            ;;
+    esac
 fi
 
-# Layer B: Strip synthesized sections from GOAL before preserving as ORIGINAL_GOAL
-# Defense-in-depth: if the build stage passed an enriched goal, scrub it here.
-if declare -f _strip_synthesized_sections >/dev/null 2>&1; then
+# Layer B: Strip synthesized sections from GOAL before preserving as ORIGINAL_GOAL.
+# Only applied when --context-file was passed (i.e. invoked by the pipeline build stage),
+# so standalone sw-loop invocations with multi-section user goals are never truncated.
+if [[ -n "$LOOP_CONTEXT_FILE" ]] && declare -f _strip_synthesized_sections >/dev/null 2>&1; then
     GOAL="$(_strip_synthesized_sections "$GOAL")"
 fi
 

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -2896,6 +2896,8 @@ pipeline_start() {
                 warn "CI resume: failed to create or checkout branch ${GIT_BRANCH}"
             fi
         fi
+        # Capture clean goal before write_state — prevents lazy bootstrap contamination
+        ORIGINAL_GOAL="${ORIGINAL_GOAL:-$GOAL}"
         write_state 2>/dev/null || true
     fi
 


### PR DESCRIPTION
## Summary

- **Layer A**: `pipeline-stages-build.sh` now writes all synthesized pipeline context (Plan Summary, Design Decisions, memory context, discoveries, hotspots, security alerts, skill guidance, etc.) to `.claude/pipeline-artifacts/build-context.md` sidecar and passes clean `$GOAL` to `sw loop`. The loop assembles it as a dedicated `## Pipeline Context` prompt section — never mixed into `## Your Goal`.
- **Layer B**: `sw-loop.sh` scrubs synthesized sections from GOAL before `ORIGINAL_GOAL="$GOAL"` assignment — defense-in-depth against any caller that passes an already-enriched goal string.
- **Layer C**: `resume_state` in both `loop-restart.sh` and `pipeline-state.sh` now applies the unified 19-sentinel strip to both GOAL and ORIGINAL_GOAL in both branches (previously only stripped in the legacy no-original_goal-field branch).
- New shared helper `scripts/lib/goal-sanitize.sh` with complete 19-sentinel list (Bash 3.2 safe).

## Test plan
- [x] `bash scripts/sw-lib-loop-restart-test.sh` — all pass (4 new tests)
- [x] `bash scripts/sw-lib-pipeline-state-test.sh` — all pass (4 new tests)
- [x] `npm test` — exit 0, no regressions
- [x] `bash -n scripts/lib/goal-sanitize.sh` — Bash 3.2 syntax clean

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)