### PR TITLE
fix(pipeline): heartbeat orphan, PR diff false-negative, drift detection silent skip

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -622,8 +622,9 @@ jobs:
           # Heartbeat: post progress marker every 10 minutes so watchdog knows we're alive.
           # Visible body first so subscribers see content; HTML comment retained for
           # watchdog parsing (shipwright-watchdog.yml uses `contains("SHIPWRIGHT-HEARTBEAT")`).
-          (while true; do
-            sleep 600
+          (trap 'kill %1 2>/dev/null; exit 0' TERM; while true; do
+            sleep 600 &
+            wait $!
             _HB_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
             _HB_DISPLAY=$(date -u '+%H:%M UTC')
             _HB_BODY="⏳ Pipeline still running — last heartbeat ${_HB_DISPLAY}"$'\n'"<!-- SHIPWRIGHT-HEARTBEAT: ${_HB_TS}:running -->"

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -622,9 +622,11 @@ jobs:
           # Heartbeat: post progress marker every 10 minutes so watchdog knows we're alive.
           # Visible body first so subscribers see content; HTML comment retained for
           # watchdog parsing (shipwright-watchdog.yml uses `contains("SHIPWRIGHT-HEARTBEAT")`).
-          (trap 'kill %1 2>/dev/null; exit 0' TERM; while true; do
+          (sleep_pid=""; trap 'if [[ -n "${sleep_pid:-}" ]]; then kill "$sleep_pid" 2>/dev/null || true; fi; exit 0' TERM; while true; do
             sleep 600 &
-            wait $!
+            sleep_pid=$!
+            wait "$sleep_pid"
+            sleep_pid=""
             _HB_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
             _HB_DISPLAY=$(date -u '+%H:%M UTC')
             _HB_BODY="⏳ Pipeline still running — last heartbeat ${_HB_DISPLAY}"$'\n'"<!-- SHIPWRIGHT-HEARTBEAT: ${_HB_TS}:running -->"

--- a/scripts/lib/pipeline-stages-review.sh
+++ b/scripts/lib/pipeline-stages-review.sh
@@ -39,12 +39,11 @@ detect_plan_drift() {
     [[ -n "$section" ]] || return 0
 
     # Get actual changed files; fail-open if git fails entirely.
-    # Validate base branch first — _safe_base_diff falls back to HEAD~5 when BASE_BRANCH
-    # is unverifiable, which produces misleading drift results.
+    # Validate base branch — check local ref first, then origin/<base>.
     local actual_changed=""
     local _git_ok=true
     local _base="${BASE_BRANCH:-main}"
-    if ! (cd "$project_root" && git rev-parse --verify "$_base" >/dev/null 2>&1); then
+    if ! (cd "$project_root" && { git rev-parse --verify "$_base" >/dev/null 2>&1 || git rev-parse --verify "origin/$_base" >/dev/null 2>&1; }); then
         return 0
     fi
     if declare -f _safe_base_diff >/dev/null 2>&1; then

--- a/scripts/lib/pipeline-stages.sh
+++ b/scripts/lib/pipeline-stages.sh
@@ -140,8 +140,13 @@ guard_prompt_size() {
 # These helpers return empty output instead of crashing under set -euo pipefail.
 _safe_base_log() {
     local branch="${BASE_BRANCH:-main}"
-    git rev-parse --verify "$branch" >/dev/null 2>&1 || { echo ""; return 0; }
-    git log "$@" "${branch}..HEAD" 2>/dev/null || true
+    if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+        git log "$@" "${branch}..HEAD" 2>/dev/null || true
+    elif git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+        git log "$@" "origin/${branch}..HEAD" 2>/dev/null || true
+    else
+        echo ""
+    fi
 }
 
 _safe_base_diff() {

--- a/scripts/lib/pipeline-stages.sh
+++ b/scripts/lib/pipeline-stages.sh
@@ -146,8 +146,14 @@ _safe_base_log() {
 
 _safe_base_diff() {
     local branch="${BASE_BRANCH:-main}"
-    git rev-parse --verify "$branch" >/dev/null 2>&1 || { git diff HEAD~5 "$@" 2>/dev/null || true; return 0; }
-    git diff "${branch}...HEAD" "$@" 2>/dev/null || true
+    if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+        git diff "${branch}...HEAD" "$@" 2>/dev/null || true
+    elif git rev-parse --verify "origin/$branch" >/dev/null 2>&1; then
+        git diff "origin/${branch}...HEAD" "$@" 2>/dev/null || true
+    else
+        echo "[warn] _safe_base_diff: neither $branch nor origin/$branch verifiable; using HEAD~5" >&2
+        git diff HEAD~5 "$@" 2>/dev/null || true
+    fi
 }
 
 show_stage_preview() {


### PR DESCRIPTION
## Summary

Three related bugs all rooted in the same missing `origin/` fallback pattern, observed during the issue #451 pipeline run:

- **Heartbeat keeps running after pipeline failure** — `sleep 600` becomes an orphan when `kill $HEARTBEAT_PID` fires; GHA process-group wait holds the step open up to 10 min
- **PR stage falsely rejects branches as "no changes"** — in GHA `main` is only `origin/main`, so `_safe_base_diff` falls back to `git diff HEAD~5` and sees only `.claude/` artifacts  
- **Drift detection silently skips in CI** — same `git rev-parse --verify main` guard in the review stage short-circuits before even reaching `_safe_base_diff`, a worse failure mode (silent vs. visible)

## Changes

| File | Lines | Fix |
|------|-------|-----|
| `.github/workflows/shipwright-pipeline.yml` | 625–631 | `trap 'kill %1' TERM` + `sleep & wait $!` — mirrors commit 1a21406 |
| `scripts/lib/pipeline-stages.sh` | 147–151 | Three-tier fallback: local ref → `origin/$branch` → `HEAD~5` + stderr warn |
| `scripts/lib/pipeline-stages-review.sh` | 42–49 | Guard now accepts `origin/$_base`; stale comment updated |

## Test plan

- [x] Heartbeat smoke test: `pgrep -P $$ sleep` → `OK: no orphan` after kill
- [x] `./scripts/sw-pipeline-test.sh` — 72/72 passed
- [ ] `npm test` (running)
- [ ] Confirm next real pipeline run reaches PR stage on a branch where `main` is not a local ref

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)