### PR TITLE
fix(pipeline): prevent GHA hang from background FD leaks

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -598,8 +598,7 @@ jobs:
         if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         id: pipeline
         run: |
-          set +e          # Don't abort on failure — we capture the exit code
-          set -o pipefail # CRITICAL: preserve pipeline exit code through | tee
+          set +e  # Don't abort on failure — we capture the exit code
 
           PIPELINE_ARGS=(
             --issue "$ISSUE_NUMBER"
@@ -634,12 +633,26 @@ jobs:
           done) &
           HEARTBEAT_PID=$!
 
-          shipwright pipeline start "${PIPELINE_ARGS[@]}" 2>&1 | tee /tmp/pipeline.log
-          PIPELINE_EXIT=${PIPESTATUS[0]}  # Get exit code of pipeline, not tee
+          # Run pipeline writing directly to log file — avoids pipe-lifetime hang.
+          # Any background grandchildren that hold the write FD open cannot block
+          # us because we wait on the PID, not on pipe EOF. (#426, #484)
+          > /tmp/pipeline.log
+          shipwright pipeline start "${PIPELINE_ARGS[@]}" >> /tmp/pipeline.log 2>&1 &
+          PIPELINE_PID=$!
 
-          # Stop heartbeat
+          # Stream log to GHA stdout for real-time step visibility
+          tail -f /tmp/pipeline.log &
+          TAIL_PID=$!
+
+          wait $PIPELINE_PID
+          PIPELINE_EXIT=$?
+
+          # Stop heartbeat; let tail flush last lines before killing it
           kill $HEARTBEAT_PID 2>/dev/null || true
           wait $HEARTBEAT_PID 2>/dev/null || true
+          sleep 1
+          kill $TAIL_PID 2>/dev/null || true
+          wait $TAIL_PID 2>/dev/null || true
 
           echo "exit_code=$PIPELINE_EXIT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -640,18 +640,19 @@ jobs:
           shipwright pipeline start "${PIPELINE_ARGS[@]}" >> /tmp/pipeline.log 2>&1 &
           PIPELINE_PID=$!
 
-          # Stream log to GHA stdout for real-time step visibility
-          tail -f /tmp/pipeline.log &
+          # Stream full log to GHA stdout for real-time step visibility.
+          # -n +1 starts from line 1 so no startup lines are missed even if the
+          # pipeline wrote before tail began following.  --pid exits tail
+          # automatically when the pipeline process exits — no sleep needed.
+          tail -n +1 --pid="$PIPELINE_PID" -f /tmp/pipeline.log &
           TAIL_PID=$!
 
           wait $PIPELINE_PID
           PIPELINE_EXIT=$?
 
-          # Stop heartbeat; let tail flush last lines before killing it
+          # Stop heartbeat; tail exits automatically via --pid.
           kill $HEARTBEAT_PID 2>/dev/null || true
           wait $HEARTBEAT_PID 2>/dev/null || true
-          sleep 1
-          kill $TAIL_PID 2>/dev/null || true
           wait $TAIL_PID 2>/dev/null || true
 
           echo "exit_code=$PIPELINE_EXIT" >> "$GITHUB_OUTPUT"

--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -536,7 +536,7 @@ compound_audit_run_cycle() {
             local output
             output=$(echo "$prompt" | claude -p --model "$model" 2>/dev/null) || output='{"findings":[]}'
             echo "$output" > "$temp_dir/${agent}.json"
-        ) &
+        ) 2>/dev/null &
         pids+=($!)
     done
 

--- a/scripts/lib/ruflo-adapter.sh
+++ b/scripts/lib/ruflo-adapter.sh
@@ -443,6 +443,10 @@ ruflo_with_timeout() {
         # safety net for unexpected termination. (#441)
         # shellcheck disable=SC2064
         trap "rm -f '$_rft_tmp' 2>/dev/null || true" EXIT TERM
+        # stderr is suppressed rather than merged into _rft_tmp intentionally:
+        # callers often capture output via $() and expect clean text/JSON; mixing
+        # stderr would corrupt those values.  ruflo_with_timeout emits its own
+        # warn()/emit_event diagnostics on failure via the circuit-breaker path. (#484)
         ( "$@" ) >"$_rft_tmp" 2>/dev/null &
         local bg_pid=$!
         # Poll with adaptive backoff: 0.1s for the first 10 ticks (1 s fast

--- a/scripts/lib/ruflo-adapter.sh
+++ b/scripts/lib/ruflo-adapter.sh
@@ -443,7 +443,7 @@ ruflo_with_timeout() {
         # safety net for unexpected termination. (#441)
         # shellcheck disable=SC2064
         trap "rm -f '$_rft_tmp' 2>/dev/null || true" EXIT TERM
-        ( "$@" ) >"$_rft_tmp" &
+        ( "$@" ) >"$_rft_tmp" 2>/dev/null &
         local bg_pid=$!
         # Poll with adaptive backoff: 0.1s for the first 10 ticks (1 s fast
         # window) to handle short-lived operations cheaply, then 1s intervals


### PR DESCRIPTION
## Summary

- **Root cause**: `dd0ed82` wired `ruflo coordination orchestrate` into the compound_quality stage. That command spawns Node.js workers with `detached: true`, which escape the BFS kill sweep and hold the inherited pipe write FD (stderr) open. `tee` never receives EOF → GHA step hangs for 3 hours.
- **Prior fix** (`8fa016c`) only addressed the auto-learn subshell — same class of bug, different callsite.
- **Three changes** fix it holistically:

| Change | File | What |
|--------|------|------|
| Suppress stderr in `ruflo_with_timeout` subshell | `scripts/lib/ruflo-adapter.sh:446` | `2>/dev/null` added to background subshell |
| Suppress stderr in compound audit agent spawner | `scripts/lib/compound-audit.sh:539` | `2>/dev/null` added to background subshell |
| Replace `\| tee` with background+wait in GHA | `.github/workflows/shipwright-pipeline.yml` | Class fix — wait on PID not pipe EOF |

The GHA change is the **class fix**: `wait $PIPELINE_PID` unblocks when the pipeline process exits regardless of what its grandchildren are doing with their FDs. `tail -f /tmp/pipeline.log` preserves real-time log streaming in the GHA UI.

## Test plan

- [x] `sw-lib-pipeline-intelligence-test.sh` — 110/110 pass
- [x] `sw-e2e-smoke-test.sh` — 24/24 pass
- [x] `npm test` — 28/28 pass
- [ ] Verify next GHA pipeline run completes (passes or fails cleanly) rather than hanging for 3 hours

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)