### PR TITLE
fix(pipeline): push WIP branch on stage failure + watchdog telemetry + reduce min free GB

### DIFF
--- a/scripts/sw-doctor.sh
+++ b/scripts/sw-doctor.sh
@@ -945,7 +945,7 @@ echo -e "${DIM}  ─────────────────────
 doctor_check_active_pipelines() {
     local dir="${SHIPWRIGHT_ACTIVE_PIPELINES_DIR:-$HOME/.shipwright/active-pipelines}"
     local max_active="${SHIPWRIGHT_MAX_ACTIVE_PIPELINES:-1}"
-    local min_free_gb="${SHIPWRIGHT_MIN_FREE_GB:-4}"
+    local min_free_gb="${SHIPWRIGHT_MIN_FREE_GB:-1}"
 
     if [[ ! -d "$dir" ]]; then
         info "  No active-pipelines directory ${DIM}(created on first pipeline start)${RESET}"

--- a/scripts/sw-pipeline-watchdog-test.sh
+++ b/scripts/sw-pipeline-watchdog-test.sh
@@ -1207,6 +1207,161 @@ TMPL
     return 1
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# 25–28. cleanup_on_exit: new ungated WIP push block (Phase 1 fix)
+# These four tests verify the gate fix: push on any non-zero CI exit,
+# not only on signal-driven exits.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_write_cleanup_runner() {
+    # Helper: writes a runner script that calls cleanup_on_exit with the given
+    # state variables. Args: runner_path push_log_path [extra_state_lines...]
+    local runner="$1" push_log="$2"
+    shift 2
+    local extra_state="${*:-}"
+
+    cat > "$runner" <<RUNNER_HDR
+#!/usr/bin/env bash
+set -uo pipefail
+# Minimal stubs — no set -e so (exit N) sets \$? without aborting script
+emit_event()               { true; }
+info()                     { true; }
+warn()                     { true; }
+error()                    { true; }
+now_iso()                  { echo "2024-01-01T00:00:00Z"; }
+write_state()              { true; }
+_timeout()                 { local _t="\$1"; shift; "\$@"; }
+_config_get_int()          { echo "30"; }
+pipeline_cancel_check_runs() { true; }
+stop_heartbeat()           { true; }
+release_active_pipeline_lock() { true; }
+DIM="" RESET="" BOLD="" GREEN="" RED="" CYAN="" PURPLE=""
+
+# Track push calls
+ci_push_partial_work() {
+    echo "PUSH_CALLED:\${1:-default}" >> "$push_log"
+}
+
+# Default state (override via extra_state lines below)
+PIPELINE_STATUS="running"
+STATE_FILE="state"
+_PIPELINE_SIGNALED=false
+_SOFT_TIMEOUT_FIRED=false
+CI_MODE=true
+ISSUE_NUMBER=463
+STASHED_CHANGES=false
+_cleanup_done=""
+_WATCHDOG_PID=""
+ARTIFACTS_DIR=""
+_PIPELINE_LOCK_ID=""
+GH_AVAILABLE=false
+
+$extra_state
+
+$(awk '
+    /^cleanup_on_exit\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^\}$/ { in_fn=0 }
+' "$REAL_PIPELINE_SCRIPT")
+RUNNER_HDR
+}
+
+# 25. Stage failure (exit_code=1, _PIPELINE_SIGNALED=false) must push WIP.
+test_cleanup_pushes_on_stage_failure() {
+    local push_log="$TEST_TEMP_DIR/push-stage-fail-$$.txt"
+    local runner="$TEST_TEMP_DIR/bin/cleanup-stage-fail-$$.sh"
+    rm -f "$push_log"
+
+    _write_cleanup_runner "$runner" "$push_log"
+    echo 'echo "REACHED" >> '"$push_log" >> "$runner"
+    echo '(exit 1); cleanup_on_exit' >> "$runner"
+    chmod +x "$runner"
+    bash "$runner" 2>/dev/null || true
+
+    if ! grep -q "REACHED" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} Runner did not reach cleanup_on_exit"
+        return 1
+    fi
+    if ! grep -q "PUSH_CALLED:" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work not called on stage failure (exit_code=1, _PIPELINE_SIGNALED=false)"
+        return 1
+    fi
+    rm -f "$push_log" "$runner"
+    return 0
+}
+
+# 26. Success (exit_code=0) must NOT push WIP.
+test_cleanup_skips_push_on_success() {
+    local push_log="$TEST_TEMP_DIR/push-success-$$.txt"
+    local runner="$TEST_TEMP_DIR/bin/cleanup-success-$$.sh"
+    rm -f "$push_log"
+
+    _write_cleanup_runner "$runner" "$push_log"
+    echo 'echo "REACHED" >> '"$push_log" >> "$runner"
+    echo '(exit 0); cleanup_on_exit' >> "$runner"
+    chmod +x "$runner"
+    bash "$runner" 2>/dev/null || true
+
+    if ! grep -q "REACHED" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} Runner did not reach cleanup_on_exit"
+        return 1
+    fi
+    if grep -q "PUSH_CALLED:" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work was called on success (exit_code=0) — should be skipped"
+        return 1
+    fi
+    rm -f "$push_log" "$runner"
+    return 0
+}
+
+# 27. When _SOFT_TIMEOUT_FIRED=true (watchdog already pushed) must NOT push again.
+test_cleanup_skips_push_when_soft_timeout_fired() {
+    local push_log="$TEST_TEMP_DIR/push-soft-fired-$$.txt"
+    local runner="$TEST_TEMP_DIR/bin/cleanup-soft-fired-$$.sh"
+    rm -f "$push_log"
+
+    _write_cleanup_runner "$runner" "$push_log" '_SOFT_TIMEOUT_FIRED=true'
+    echo 'echo "REACHED" >> '"$push_log" >> "$runner"
+    echo '(exit 1); cleanup_on_exit' >> "$runner"
+    chmod +x "$runner"
+    bash "$runner" 2>/dev/null || true
+
+    if ! grep -q "REACHED" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} Runner did not reach cleanup_on_exit"
+        return 1
+    fi
+    if grep -q "PUSH_CALLED:" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work called when _SOFT_TIMEOUT_FIRED=true — watchdog already pushed"
+        return 1
+    fi
+    rm -f "$push_log" "$runner"
+    return 0
+}
+
+# 28. When CI_MODE=false must NOT push.
+test_cleanup_skips_push_when_not_ci() {
+    local push_log="$TEST_TEMP_DIR/push-no-ci-$$.txt"
+    local runner="$TEST_TEMP_DIR/bin/cleanup-no-ci-$$.sh"
+    rm -f "$push_log"
+
+    _write_cleanup_runner "$runner" "$push_log" 'CI_MODE=false'
+    echo 'echo "REACHED" >> '"$push_log" >> "$runner"
+    echo '(exit 1); cleanup_on_exit' >> "$runner"
+    chmod +x "$runner"
+    bash "$runner" 2>/dev/null || true
+
+    if ! grep -q "REACHED" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} Runner did not reach cleanup_on_exit"
+        return 1
+    fi
+    if grep -q "PUSH_CALLED:" "$push_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work called when CI_MODE=false"
+        return 1
+    fi
+    rm -f "$push_log" "$runner"
+    return 0
+}
+
 # ═════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1215,9 +1370,9 @@ main() {
     local filter="${1:-}"
 
     echo ""
-    echo -e "${PURPLE}${BOLD}╔═══════════════════════════════════════════════════════════════════╗${RESET}"
-    echo -e "${PURPLE}${BOLD}║  shipwright watchdog test — Issue #463 (ci_push + soft-timeout)  ║${RESET}"
-    echo -e "${PURPLE}${BOLD}╚═══════════════════════════════════════════════════════════════════╝${RESET}"
+    echo -e "${PURPLE}${BOLD}╔══════════════════════════════════════════════════════════════════════╗${RESET}"
+    echo -e "${PURPLE}${BOLD}║  shipwright watchdog test — Issue #463 (ci_push + soft-timeout)     ║${RESET}"
+    echo -e "${PURPLE}${BOLD}╚══════════════════════════════════════════════════════════════════════╝${RESET}"
     echo ""
 
     if [[ ! -f "$REAL_PIPELINE_SCRIPT" ]]; then
@@ -1256,6 +1411,10 @@ main() {
         "test_watchdog_armed_event_emitted:Watchdog spawn: pipeline.watchdog_armed event emitted"
         "test_soft_timeout_emits_event:Watchdog: _soft_timeout_handler emits soft_timeout_push event"
         "test_watchdog_armed_event_logged_in_e2e:E2E: watchdog armed event in events log (intake pipeline)"
+        "test_cleanup_pushes_on_stage_failure:cleanup_on_exit: pushes WIP on stage failure (exit_code=1, not signaled)"
+        "test_cleanup_skips_push_on_success:cleanup_on_exit: skips push on success (exit_code=0)"
+        "test_cleanup_skips_push_when_soft_timeout_fired:cleanup_on_exit: skips push when _SOFT_TIMEOUT_FIRED=true"
+        "test_cleanup_skips_push_when_not_ci:cleanup_on_exit: skips push when CI_MODE=false"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -858,10 +858,13 @@ ci_push_partial_work() {
 
     # Snapshot events.jsonl into the repo so it survives the ephemeral runner disk
     # and gets pushed with the WIP commit — enables post-mortem watchdog analysis.
+    # Stage immediately after copy so git diff --cached detects it even when it is
+    # the only change (untracked files are invisible to git diff --quiet).
     if [[ -f "${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}" ]]; then
         mkdir -p ".shipwright" 2>/dev/null || true
-        cp "${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}" \
-           ".shipwright/events-${ISSUE_NUMBER}-${GITHUB_RUN_ID:-local}.jsonl" 2>/dev/null || true
+        local _events_snap=".shipwright/events-${ISSUE_NUMBER}-${GITHUB_RUN_ID:-local}.jsonl"
+        cp "${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}" "$_events_snap" 2>/dev/null || true
+        git add "$_events_snap" 2>/dev/null || true
     fi
 
     # Only push if we have uncommitted changes (excluding daemon-config.json runtime writes)

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -522,7 +522,7 @@ TASKS_FILE=""
 # the lowest-end developer host (16 GB / 4-core); operators can override per
 # host via the env vars below.
 SHIPWRIGHT_MAX_ACTIVE_PIPELINES="${SHIPWRIGHT_MAX_ACTIVE_PIPELINES:-1}"
-SHIPWRIGHT_MIN_FREE_GB="${SHIPWRIGHT_MIN_FREE_GB:-4}"
+SHIPWRIGHT_MIN_FREE_GB="${SHIPWRIGHT_MIN_FREE_GB:-1}"
 # Validate env vars are integers; reset to safe defaults on bad input so
 # arithmetic comparisons in check_admission_gate never receive non-numeric values.
 if [[ ! "$SHIPWRIGHT_MAX_ACTIVE_PIPELINES" =~ ^[1-9][0-9]*$ ]]; then
@@ -530,8 +530,8 @@ if [[ ! "$SHIPWRIGHT_MAX_ACTIVE_PIPELINES" =~ ^[1-9][0-9]*$ ]]; then
     SHIPWRIGHT_MAX_ACTIVE_PIPELINES=1
 fi
 if [[ ! "$SHIPWRIGHT_MIN_FREE_GB" =~ ^[0-9]+$ ]]; then
-    warn "SHIPWRIGHT_MIN_FREE_GB='$SHIPWRIGHT_MIN_FREE_GB' is not a non-negative integer — resetting to 4"
-    SHIPWRIGHT_MIN_FREE_GB=4
+    warn "SHIPWRIGHT_MIN_FREE_GB='$SHIPWRIGHT_MIN_FREE_GB' is not a non-negative integer — resetting to 1"
+    SHIPWRIGHT_MIN_FREE_GB=1
 fi
 SHIPWRIGHT_ACTIVE_PIPELINES_DIR="${SHIPWRIGHT_ACTIVE_PIPELINES_DIR:-$HOME/.shipwright/active-pipelines}"
 # Capture once at top-level so trap-time `$$` (which would resolve in any
@@ -616,7 +616,7 @@ show_help() {
     echo -e "${BOLD}ADMISSION GATE${RESET}  ${DIM}(per-host concurrency + memory floor)${RESET}"
     echo -e "  • Refuses ${BOLD}start${RESET} / ${BOLD}resume${RESET} when too many pipelines are live or free RAM is low"
     echo -e "  • ${CYAN}SHIPWRIGHT_MAX_ACTIVE_PIPELINES${RESET}=N   max concurrent pipelines per host (default: 1)"
-    echo -e "  • ${CYAN}SHIPWRIGHT_MIN_FREE_GB${RESET}=N            min free memory in GB to admit (default: 4)"
+    echo -e "  • ${CYAN}SHIPWRIGHT_MIN_FREE_GB${RESET}=N            min free memory in GB to admit (default: 1)"
     echo -e "  • Inspect locks: ${CYAN}shipwright doctor${RESET}  ${DIM}(ACTIVE PIPELINES & MEMORY section)${RESET}"
     echo ""
     echo -e "${BOLD}EXAMPLES${RESET}"
@@ -856,6 +856,14 @@ ci_push_partial_work() {
 
     local branch="shipwright/issue-${ISSUE_NUMBER}"
 
+    # Snapshot events.jsonl into the repo so it survives the ephemeral runner disk
+    # and gets pushed with the WIP commit — enables post-mortem watchdog analysis.
+    if [[ -f "${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}" ]]; then
+        mkdir -p ".shipwright" 2>/dev/null || true
+        cp "${EVENTS_FILE:-$HOME/.shipwright/events.jsonl}" \
+           ".shipwright/events-${ISSUE_NUMBER}-${GITHUB_RUN_ID:-local}.jsonl" 2>/dev/null || true
+    fi
+
     # Only push if we have uncommitted changes (excluding daemon-config.json runtime writes)
     if ! git diff --quiet -- ':!.claude/daemon-config.json' 2>/dev/null || \
        ! git diff --cached --quiet -- ':!.claude/daemon-config.json' 2>/dev/null; then
@@ -919,14 +927,6 @@ cleanup_on_exit() {
         warn "Pipeline interrupted — state saved."
         echo -e "  Resume: ${DIM}shipwright pipeline resume${RESET}"
 
-        # Push partial work in CI mode — skip if watchdog already pushed at T-5min
-        # to avoid a spurious pipeline.push_failed event on an already-clean tree.
-        # Use 30s timeout here (vs watchdog's 120s) — we still have most of the
-        # SIGTERM grace window since this runs before ruflo_cleanup/cost breakdown.
-        if [[ "${_SOFT_TIMEOUT_FIRED:-false}" != "true" ]]; then
-            ci_push_partial_work 30
-        fi
-
         # Cancel lingering in_progress GitHub Check Runs
         pipeline_cancel_check_runs 2>/dev/null || true
 
@@ -937,6 +937,16 @@ cleanup_on_exit() {
                 emit_event "pipeline.comment_failed" "issue=$ISSUE_NUMBER"
             fi
         fi
+    fi
+
+    # Push WIP on any non-zero CI exit — signal-driven OR stage-failure.
+    # Skip if watchdog already pushed at T-5min (idempotency); skip on success (exit 0).
+    # Use 30s timeout — runs before ruflo_cleanup/cost breakdown in the grace window.
+    if [[ "${CI_MODE:-false}" == "true" \
+          && -n "${ISSUE_NUMBER:-}" \
+          && "$exit_code" -ne 0 \
+          && "${_SOFT_TIMEOUT_FIRED:-false}" != "true" ]]; then
+        ci_push_partial_work 30
     fi
 
     # Generate cost-breakdown.json from sidecars on every exit path (issue #87 AC#4).
@@ -998,6 +1008,7 @@ _SOFT_TIMEOUT_FIRED=false
 _soft_timeout_handler() {
     [[ "${_SOFT_TIMEOUT_FIRED}" == "true" ]] && return 0
     _SOFT_TIMEOUT_FIRED=true
+    echo "[WATCHDOG-TRAP] $(date -u +%FT%TZ) USR1 trap running in parent pid=$$" >&2
     warn "Soft timeout — pushing WIP branch (pipeline continues until hard deadline)"
     ci_push_partial_work 120
     emit_event "pipeline.soft_timeout_push" \
@@ -3057,11 +3068,12 @@ pipeline_start() {
         local _job_timeout_min="${SHIPWRIGHT_JOB_TIMEOUT_MINUTES:-180}"
         if [[ "$_job_timeout_min" =~ ^[0-9]+$ ]] && (( _job_timeout_min > 5 )); then
             local _watchdog_delay_sec=$(( (_job_timeout_min - 5) * 60 ))
-            ( trap 'kill %1 2>/dev/null; exit 0' TERM; sleep "$_watchdog_delay_sec" & wait $!; kill -0 $$ 2>/dev/null && kill -USR1 $$ 2>/dev/null ) &
+            ( trap 'kill %1 2>/dev/null; exit 0' TERM; sleep "$_watchdog_delay_sec" & wait $!; kill -0 $$ 2>/dev/null || exit 0; echo "[WATCHDOG-FIRE] $(date -u +%FT%TZ) sending USR1 to pid=$$" >&2; kill -USR1 $$ 2>/dev/null ) &
             _WATCHDOG_PID=$!
             emit_event "pipeline.watchdog_armed" \
                        "issue=${ISSUE_NUMBER}" \
                        "fires_in_sec=${_watchdog_delay_sec}" 2>/dev/null || true
+            echo "[WATCHDOG-ARM] $(date -u +%FT%TZ) delay=${_watchdog_delay_sec}s pid=$$" >&2
         fi
     fi
 


### PR DESCRIPTION
## Summary

- **Phase 0 (telemetry):** Adds `[WATCHDOG-ARM]`, `[WATCHDOG-FIRE]`, `[WATCHDOG-TRAP]` stderr markers to GHA logs so post-mortems can confirm whether the watchdog subshell fired and whether the USR1 trap ran in the parent. Snapshots `events.jsonl` into the repo before each WIP push so watchdog events survive the ephemeral runner disk.
- **Phase 1 (gate fix):** `cleanup_on_exit` previously only called `ci_push_partial_work` when `_PIPELINE_SIGNALED=true`. Stage failures (compound_quality circuit-breaker, build loop exhaustion) exit with a non-zero code without setting the flag — so WIP was never pushed for issues #416, #422, #423. The push now runs on any `CI_MODE=true` + `exit_code != 0` exit, skipping only when the watchdog already pushed (`_SOFT_TIMEOUT_FIRED=true`) or the run succeeded.
- **Default min free GB:** `SHIPWRIGHT_MIN_FREE_GB` default changed from 4 → 1 in `sw-pipeline.sh` and `sw-doctor.sh` to reduce false admission refusals.
- **4 new TDD tests** added to `sw-pipeline-watchdog-test.sh` (28 total, all pass).

## Test plan

- [x] All 28 watchdog tests pass locally
- [x] All 72 pipeline tests pass locally
- [x] All doctor tests pass locally
- [x] Memory guard tests (18) pass locally
- [ ] CI green
- [ ] After merge: verify next stage-failure run creates `shipwright/issue-N` branch with WIP commit and `.shipwright/events-*.jsonl`

## Phase 2 decision rule

Ship Phase 2 (direct watchdog push from subshell) only if Phase 0 telemetry from a cap-bound run shows `[WATCHDOG-FIRE]` present but `[WATCHDOG-TRAP]` absent. If both markers appear, Phase 1 alone is sufficient.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)