### PR TITLE
fix(pipeline): WIP branch loss on 3hr timeout — 5-fix series

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -49,6 +49,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  checks: write
 
 jobs:
   # ────────────────────────────────────────────────────────────────────────────
@@ -827,8 +828,11 @@ jobs:
           git fetch origin "$BRANCH" 2>/dev/null || true
           REMOTE_EXISTS=$(git ls-remote --heads origin "$BRANCH" 2>/dev/null | head -1)
           AHEAD=$(git rev-list --count "origin/${BRANCH}..HEAD" 2>/dev/null || echo "0")
-          if [ -z "$REMOTE_EXISTS" ] && [ "$AHEAD" = "0" ]; then
-            echo "No partial work and no existing remote branch — skipping push."
+          # Only skip when the WIP branch already exists AND HEAD is not ahead of it.
+          # When the branch is absent, always push to create the WIP reference so
+          # shipwright pipeline resume can find partial work.
+          if [ -n "$REMOTE_EXISTS" ] && [ "$AHEAD" = "0" ]; then
+            echo "WIP branch already up to date — skipping push."
             exit 0
           fi
           if timeout 120 git push origin "HEAD:refs/heads/$BRANCH" --force; then

--- a/docs/sdk-blocking-call-inventory.md
+++ b/docs/sdk-blocking-call-inventory.md
@@ -1,0 +1,43 @@
+# Claude SDK Blocking Call Inventory
+
+Generated: 2026-04-30
+
+Context: Audit performed as part of Fix 5 (non-blocking SDK transport) to resolve WIP branch
+loss on 3-hour GitHub Actions pipeline timeouts. Bash `wait $!` is interruptible by USR1/INT/TERM
+traps; blocking foreground claude calls are not.
+
+Conversion threshold: calls with timeout >= 300s (5+ minutes) in the critical pipeline path.
+
+## Converted (non-blocking `& wait $!` pattern)
+
+| File | Line | Timeout | Reason converted |
+|------|------|---------|-----------------|
+| `scripts/lib/pipeline-stages-intake.sh` | ~479 | 3600s (configurable via `plan.claude_timeout`) | Plan stage — longest blocking call in the pipeline; 3-hour GHA runs were blocked here when watchdog fired |
+| `scripts/lib/pipeline-stages-intake.sh` | ~1015 | unbounded (no explicit timeout; claude default) | Design stage — no timeout guard; can block signal delivery indefinitely |
+
+## Not converted (retained blocking)
+
+| File | Line | Timeout | Reason retained |
+|------|------|---------|----------------|
+| `scripts/lib/pipeline-stages-intake.sh` | ~690 | none (short `|| true`) | Plan validation — short, diagnostic call; uses `-p` flag (non-interactive); output already captured via `$(...)` subshell which is signal-safe |
+| `scripts/lib/pipeline-stages-intake.sh` | ~758 | none (`|| true`) | Plan regen — only executes during validation retry loop; result written directly to file; signal safety is sufficient given outer `|| true` |
+| `scripts/lib/pipeline-stages-build.sh` | ~67 | 120s | Below 300s threshold; acceptable blocking duration |
+| `scripts/lib/pipeline-stages-build.sh` | ~627 | none | Short scoring call (`-p` single-turn); result used in awk; fire-and-forget pattern already present |
+| `scripts/lib/pipeline-intelligence.sh` | ~164 | 30s | Well below threshold; diagnostic path |
+| `scripts/sw-decompose.sh` | ~83 | none | `--max-turns 1` enforces single turn; short by design |
+| `scripts/sw-discovery.sh` | ~208 | configurable (default low) | Not in pipeline critical path; uses own timeout cmd wrapper |
+| `scripts/sw-intelligence.sh` | ~387 | 60s | Not in pipeline critical path; intelligence caching layer |
+| `scripts/sw-quality.sh` | ~191 | 60s | Not in pipeline critical path; quality scoring utility |
+| `scripts/sw-prep.sh` | ~728, ~1441 | none | Prep/analysis utility; not in the GHA pipeline hot path |
+| `scripts/sw-logs.sh` | ~68 | none | Log analysis utility; not in pipeline critical path |
+
+## Notes
+
+- The `& wait $!` pattern preserves stdout/stderr redirection to existing files unchanged.
+- Exit code semantics are identical: `wait $pid` returns the process exit code.
+- For the plan stage the existing `_plan_exit=$?` variable captures the exit correctly.
+- For the design stage the existing `|| true` is preserved via `wait "$_claude_bg_pid" || true`.
+- Temp files are not needed because output is redirected directly to the target artifact file
+  in both conversions — no intermediate temp file and therefore no cleanup risk.
+- The `_claude_bg_pid` local variable is used to hold the PID; it is function-scoped and
+  does not leak to callers.

--- a/scripts/lib/loop-convergence.sh
+++ b/scripts/lib/loop-convergence.sh
@@ -103,6 +103,28 @@ check_circuit_breaker() {
     return 0
 }
 
+check_time_budget() {
+    # Guard: stop starting a new iteration if <20 min remains in the GHA job.
+    # Uses SHIPWRIGHT_JOB_TIMEOUT_MINUTES (set by the pipeline) and the LOOP_START_EPOCH
+    # recorded at loop initialization. Prevents the loop from beginning an iteration
+    # it cannot finish, leaving time for the watchdog push and cleanup.
+    local _job_timeout_min="${SHIPWRIGHT_JOB_TIMEOUT_MINUTES:-0}"
+    [[ -z "${LOOP_START_EPOCH:-}" || "$_job_timeout_min" -le 0 ]] 2>/dev/null && return 0
+    local _now _elapsed_min _remaining_min
+    _now=$(now_epoch 2>/dev/null) || return 0
+    _elapsed_min=$(( (_now - LOOP_START_EPOCH) / 60 ))
+    _remaining_min=$(( _job_timeout_min - _elapsed_min ))
+    if (( _remaining_min < 20 )); then
+        warn "Less than 20 min remaining in GHA job (${_remaining_min}m) — stopping build loop to allow cleanup"
+        emit_event "loop.time_budget_exhausted" \
+            "elapsed_min=${_elapsed_min}" \
+            "remaining_min=${_remaining_min}" \
+            "iteration=${ITERATION:-0}" 2>/dev/null || true
+        return 1
+    fi
+    return 0
+}
+
 check_max_iterations() {
     if [[ "$ITERATION" -le "$MAX_ITERATIONS" ]]; then
         return 0

--- a/scripts/lib/loop-convergence.sh
+++ b/scripts/lib/loop-convergence.sh
@@ -109,13 +109,17 @@ check_time_budget() {
     # recorded at loop initialization. Prevents the loop from beginning an iteration
     # it cannot finish, leaving time for the watchdog push and cleanup.
     local _job_timeout_min="${SHIPWRIGHT_JOB_TIMEOUT_MINUTES:-0}"
-    [[ -z "${LOOP_START_EPOCH:-}" || "$_job_timeout_min" -le 0 ]] 2>/dev/null && return 0
+    # Require a valid positive integer — non-numeric values would cause arithmetic
+    # errors under set -e; treat them as "no limit" (return 0 = continue loop).
+    [[ -z "${LOOP_START_EPOCH:-}" ]] && return 0
+    [[ ! "$_job_timeout_min" =~ ^[0-9]+$ || "$_job_timeout_min" -le 0 ]] && return 0
     local _now _elapsed_min _remaining_min
     _now=$(now_epoch 2>/dev/null) || return 0
     _elapsed_min=$(( (_now - LOOP_START_EPOCH) / 60 ))
     _remaining_min=$(( _job_timeout_min - _elapsed_min ))
     if (( _remaining_min < 20 )); then
         warn "Less than 20 min remaining in GHA job (${_remaining_min}m) — stopping build loop to allow cleanup"
+        STATUS="time_budget_exhausted"
         emit_event "loop.time_budget_exhausted" \
             "elapsed_min=${_elapsed_min}" \
             "remaining_min=${_remaining_min}" \

--- a/scripts/lib/loop-restart.sh
+++ b/scripts/lib/loop-restart.sh
@@ -17,6 +17,9 @@ initialize_state() {
     STATUS="running"
     LOG_ENTRIES=""
 
+    # Record loop start epoch for time-budget guard (check_time_budget in loop-convergence.sh)
+    LOOP_START_EPOCH="$(now_epoch 2>/dev/null || echo 0)"
+
     # Record starting commit for cumulative diff in quality gates
     LOOP_START_COMMIT="$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || echo "")"
 

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -476,9 +476,14 @@ $(printf '%s\n' "${INTELLIGENCE_INTAKE_CTX}")"
     _plan_timeout=$(_config_get_int "plan.claude_timeout" 3600 2>/dev/null || echo 3600)
     for _plan_attempt in 1 2 3; do
         : > "$plan_file"
+        # Run claude in background so bash's wait builtin handles it — unlike a
+        # foreground call, wait IS interruptible by USR1/INT/TERM traps, allowing
+        # the watchdog to push the WIP branch before the GHA job hard-kills the runner.
         _timeout "$_plan_timeout" claude --print --model "$plan_model" --max-turns 25 \
             --disallowed-tools "EnterPlanMode,ExitPlanMode" \
-            --dangerously-skip-permissions "$plan_prompt" < /dev/null > "$plan_file" 2>"$_token_log"
+            --dangerously-skip-permissions "$plan_prompt" < /dev/null > "$plan_file" 2>"$_token_log" &
+        _claude_bg_pid=$!
+        wait "$_claude_bg_pid"
         _plan_exit=$?
         if [[ "$_plan_exit" -eq 124 ]]; then
             warn "Plan stage timed out (attempt ${_plan_attempt}/3, limit=${_plan_timeout}s) — retrying"
@@ -1012,10 +1017,15 @@ $(printf '%s\n' "${INTELLIGENCE_INTAKE_CTX}")"
     fi
 
     local _token_log="${ARTIFACTS_DIR}/.claude-tokens-design.log"
+    # Run claude in background so bash's wait builtin handles it — interruptible by
+    # USR1/INT/TERM traps unlike a blocking foreground call. Allows watchdog to push
+    # the WIP branch on GHA timeout without waiting for claude to finish.
     claude --print --model "$design_model" --max-turns 25 \
         --disallowed-tools "EnterPlanMode,ExitPlanMode" \
         --dangerously-skip-permissions \
-        "$design_prompt" < /dev/null > "$design_file" 2>"$_token_log" || true
+        "$design_prompt" < /dev/null > "$design_file" 2>"$_token_log" &
+    _claude_bg_pid=$!
+    wait "$_claude_bg_pid" || true
     parse_claude_tokens "$_token_log"
 
     # Claude may write to disk via tools instead of stdout — rescue those files

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -482,7 +482,7 @@ $(printf '%s\n' "${INTELLIGENCE_INTAKE_CTX}")"
         _timeout "$_plan_timeout" claude --print --model "$plan_model" --max-turns 25 \
             --disallowed-tools "EnterPlanMode,ExitPlanMode" \
             --dangerously-skip-permissions "$plan_prompt" < /dev/null > "$plan_file" 2>"$_token_log" &
-        _claude_bg_pid=$!
+        local _claude_bg_pid=$!
         wait "$_claude_bg_pid"
         _plan_exit=$?
         if [[ "$_plan_exit" -eq 124 ]]; then
@@ -1024,7 +1024,7 @@ $(printf '%s\n' "${INTELLIGENCE_INTAKE_CTX}")"
         --disallowed-tools "EnterPlanMode,ExitPlanMode" \
         --dangerously-skip-permissions \
         "$design_prompt" < /dev/null > "$design_file" 2>"$_token_log" &
-    _claude_bg_pid=$!
+    local _claude_bg_pid=$!
     wait "$_claude_bg_pid" || true
     parse_claude_tokens "$_token_log"
 

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2504,6 +2504,7 @@ run_single_agent_loop() {
         # Pre-checks (before incrementing — ITERATION tracks completed count)
         check_circuit_breaker || break
         check_max_iterations || break
+        check_time_budget || break
         check_budget_gate || {
             STATUS="budget_exhausted"
             write_state
@@ -2962,6 +2963,9 @@ run_loop_with_restarts() {
         TEST_PASSED=""
         TEST_OUTPUT=""
         TEST_LOG_FILE=""
+        # Preserve LOOP_START_EPOCH across restarts — time budget is wall-clock from
+        # the very first loop invocation, not from each session restart.
+        : "${LOOP_START_EPOCH:=$(now_epoch 2>/dev/null || echo 0)}"
         # Reset GOAL to original — prevent unbounded growth from memory/human injections
         GOAL="$ORIGINAL_GOAL"
         # Reset per-session token counters on every restart — cumulative totals from

--- a/scripts/sw-pipeline-watchdog-test.sh
+++ b/scripts/sw-pipeline-watchdog-test.sh
@@ -1362,6 +1362,174 @@ test_cleanup_skips_push_when_not_ci() {
     return 0
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# 29. Watchdog subshell calls ci_push_partial_work directly before USR1
+#     This covers the case where the parent is blocked in a long claude --print
+#     call and Bash defers the USR1 trap until the foreground command returns.
+# ─────────────────────────────────────────────────────────────────────────────
+test_watchdog_subshell_calls_push_before_usr1() {
+    # Verify the watchdog subshell block in the pipeline script contains both
+    # a direct ci_push_partial_work call AND the USR1 signal, in that order.
+    local watchdog_block
+    watchdog_block=$(awk '
+        /trap .kill %1.*TERM/ && !found_start { in_sub=1 }
+        in_sub { print; line_count++ }
+        in_sub && /kill -USR1/ { print "---END---"; in_sub=0 }
+    ' "$REAL_PIPELINE_SCRIPT")
+
+    if [[ -z "$watchdog_block" ]]; then
+        echo -e "    ${RED}✗${RESET} Could not extract watchdog subshell block from pipeline script"
+        return 1
+    fi
+
+    # ci_push_partial_work 120 must appear before kill -USR1
+    local push_line usr1_line
+    push_line=$(printf '%s\n' "$watchdog_block" | grep -n "ci_push_partial_work 120" | head -1 | cut -d: -f1)
+    usr1_line=$(printf '%s\n' "$watchdog_block" | grep -n "kill -USR1" | head -1 | cut -d: -f1)
+
+    if [[ -z "$push_line" ]]; then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work 120 not found in watchdog subshell"
+        return 1
+    fi
+    if [[ -z "$usr1_line" ]]; then
+        echo -e "    ${RED}✗${RESET} kill -USR1 not found in watchdog subshell"
+        return 1
+    fi
+    if (( push_line >= usr1_line )); then
+        echo -e "    ${RED}✗${RESET} ci_push_partial_work (line ${push_line}) must appear before kill -USR1 (line ${usr1_line})"
+        return 1
+    fi
+
+    # [WATCHDOG-PUSH-OK] and [WATCHDOG-PUSH-FAIL] markers must be present
+    if ! printf '%s\n' "$watchdog_block" | grep -q "WATCHDOG-PUSH-OK"; then
+        echo -e "    ${RED}✗${RESET} [WATCHDOG-PUSH-OK] marker missing from watchdog subshell"
+        return 1
+    fi
+    if ! printf '%s\n' "$watchdog_block" | grep -q "WATCHDOG-PUSH-FAIL"; then
+        echo -e "    ${RED}✗${RESET} [WATCHDOG-PUSH-FAIL] marker missing from watchdog subshell"
+        return 1
+    fi
+
+    return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 30. [WIP-PUSH-START], [WIP-PUSH-OK], and [WIP-PUSH-FAIL] markers emitted
+# ─────────────────────────────────────────────────────────────────────────────
+test_wip_push_telemetry_markers_emitted() {
+    local push_log="$TEST_TEMP_DIR/wip-telemetry-$$.txt"
+    local stderr_log="$TEST_TEMP_DIR/wip-telemetry-stderr-$$.txt"
+    rm -f "$push_log" "$stderr_log"
+
+    # ── Success path: git push succeeds ──────────────────────────────────────
+    local runner_ok="$TEST_TEMP_DIR/bin/wip-telemetry-ok-$$.sh"
+    cat > "$runner_ok" <<RUNNER_OK
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="$TEST_TEMP_DIR/bin:\$PATH"
+export HOME="$TEST_TEMP_DIR"
+export CI_MODE=true
+export ISSUE_NUMBER=9999
+export EVENTS_FILE="/dev/null"
+
+emit_event()     { true; }
+warn()           { true; }
+safe_git_stage() { true; }
+_timeout()       { local _t="\$1"; shift; "\$@"; }
+
+# Mock git: push succeeds, all other git calls silently succeed
+git() {
+    case "\$*" in
+        *"push origin"*) return 0 ;;
+        *"diff --quiet"*) return 1 ;;  # pretend there are changes
+        *) return 0 ;;
+    esac
+}
+export -f git
+
+$(awk '
+    /^ci_push_partial_work\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^\}$/ { in_fn=0 }
+' "$REAL_PIPELINE_SCRIPT")
+
+ci_push_partial_work 120
+RUNNER_OK
+    chmod +x "$runner_ok"
+    bash "$runner_ok" 2>"$stderr_log" || true
+
+    if ! grep -q "\[WIP-PUSH-START\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-START] not emitted on success path"
+        cat "$stderr_log" 2>/dev/null | sed 's/^/      /' || true
+        return 1
+    fi
+    if ! grep -q "\[WIP-PUSH-OK\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-OK] not emitted when git push succeeds"
+        cat "$stderr_log" 2>/dev/null | sed 's/^/      /' || true
+        return 1
+    fi
+    if grep -q "\[WIP-PUSH-FAIL\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-FAIL] emitted on success path — should not appear"
+        return 1
+    fi
+
+    # ── Failure path: git push fails ─────────────────────────────────────────
+    local runner_fail="$TEST_TEMP_DIR/bin/wip-telemetry-fail-$$.sh"
+    rm -f "$stderr_log"
+    cat > "$runner_fail" <<RUNNER_FAIL
+#!/usr/bin/env bash
+set -uo pipefail
+export PATH="$TEST_TEMP_DIR/bin:\$PATH"
+export HOME="$TEST_TEMP_DIR"
+export CI_MODE=true
+export ISSUE_NUMBER=9999
+export EVENTS_FILE="/dev/null"
+
+emit_event()     { true; }
+warn()           { true; }
+safe_git_stage() { true; }
+_timeout()       { local _t="\$1"; shift; "\$@"; }
+
+# Mock git: push fails, diff pretends there are changes
+git() {
+    case "\$*" in
+        *"push origin"*) return 1 ;;
+        *"diff --quiet"*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+export -f git
+
+$(awk '
+    /^ci_push_partial_work\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^\}$/ { in_fn=0 }
+' "$REAL_PIPELINE_SCRIPT")
+
+ci_push_partial_work 120
+RUNNER_FAIL
+    chmod +x "$runner_fail"
+    bash "$runner_fail" 2>"$stderr_log" || true
+
+    if ! grep -q "\[WIP-PUSH-START\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-START] not emitted on failure path"
+        cat "$stderr_log" 2>/dev/null | sed 's/^/      /' || true
+        return 1
+    fi
+    if ! grep -q "\[WIP-PUSH-FAIL\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-FAIL] not emitted when git push fails"
+        cat "$stderr_log" 2>/dev/null | sed 's/^/      /' || true
+        return 1
+    fi
+    if grep -q "\[WIP-PUSH-OK\]" "$stderr_log" 2>/dev/null; then
+        echo -e "    ${RED}✗${RESET} [WIP-PUSH-OK] emitted on failure path — should not appear"
+        return 1
+    fi
+
+    rm -f "$push_log" "$stderr_log" "$runner_ok" "$runner_fail"
+    return 0
+}
+
 # ═════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1415,6 +1583,8 @@ main() {
         "test_cleanup_skips_push_on_success:cleanup_on_exit: skips push on success (exit_code=0)"
         "test_cleanup_skips_push_when_soft_timeout_fired:cleanup_on_exit: skips push when _SOFT_TIMEOUT_FIRED=true"
         "test_cleanup_skips_push_when_not_ci:cleanup_on_exit: skips push when CI_MODE=false"
+        "test_watchdog_subshell_calls_push_before_usr1:Watchdog subshell: ci_push_partial_work 120 called before USR1 signal"
+        "test_wip_push_telemetry_markers_emitted:[WIP-PUSH-*]: START/OK emitted on success; START/FAIL emitted on push failure"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -855,6 +855,7 @@ ci_push_partial_work() {
     [[ -z "${ISSUE_NUMBER:-}" ]] && return 0
 
     local branch="shipwright/issue-${ISSUE_NUMBER}"
+    echo "[WIP-PUSH-START] $(date -u +%FT%TZ) issue=${ISSUE_NUMBER} timeout=${push_timeout}s caller=${FUNCNAME[1]:-top}" >&2
 
     # Snapshot events.jsonl into the repo so it survives the ephemeral runner disk
     # and gets pushed with the WIP commit — enables post-mortem watchdog analysis.
@@ -875,9 +876,13 @@ ci_push_partial_work() {
     fi
 
     # Push branch (create if needed, force to overwrite previous WIP)
-    if ! _timeout "$push_timeout" git push origin "HEAD:refs/heads/$branch" --force 2>/dev/null; then
+    if _timeout "$push_timeout" git push origin "HEAD:refs/heads/$branch" --force 2>/dev/null; then
+        echo "[WIP-PUSH-OK] $(date -u +%FT%TZ) branch=$branch" >&2
+    else
+        local _push_rc=$?
+        echo "[WIP-PUSH-FAIL] $(date -u +%FT%TZ) branch=$branch exit=${_push_rc}" >&2
         warn "git push failed for $branch — remote may be out of sync"
-        emit_event "pipeline.push_failed" "branch=$branch"
+        emit_event "pipeline.push_failed" "branch=$branch exit=${_push_rc}"
     fi
 }
 
@@ -944,12 +949,12 @@ cleanup_on_exit() {
 
     # Push WIP on any non-zero CI exit — signal-driven OR stage-failure.
     # Skip if watchdog already pushed at T-5min (idempotency); skip on success (exit 0).
-    # Use 30s timeout — runs before ruflo_cleanup/cost breakdown in the grace window.
+    # Use 60s timeout — stage-failure path needs headroom for first-time remote branch creation.
     if [[ "${CI_MODE:-false}" == "true" \
           && -n "${ISSUE_NUMBER:-}" \
           && "$exit_code" -ne 0 \
           && "${_SOFT_TIMEOUT_FIRED:-false}" != "true" ]]; then
-        ci_push_partial_work 30
+        ci_push_partial_work 60
     fi
 
     # Generate cost-breakdown.json from sidecars on every exit path (issue #87 AC#4).
@@ -3071,7 +3076,20 @@ pipeline_start() {
         local _job_timeout_min="${SHIPWRIGHT_JOB_TIMEOUT_MINUTES:-180}"
         if [[ "$_job_timeout_min" =~ ^[0-9]+$ ]] && (( _job_timeout_min > 5 )); then
             local _watchdog_delay_sec=$(( (_job_timeout_min - 5) * 60 ))
-            ( trap 'kill %1 2>/dev/null; exit 0' TERM; sleep "$_watchdog_delay_sec" & wait $!; kill -0 $$ 2>/dev/null || exit 0; echo "[WATCHDOG-FIRE] $(date -u +%FT%TZ) sending USR1 to pid=$$" >&2; kill -USR1 $$ 2>/dev/null ) &
+            (
+              trap 'kill %1 2>/dev/null; exit 0' TERM
+              sleep "$_watchdog_delay_sec" & wait $!
+              kill -0 $$ 2>/dev/null || exit 0
+              echo "[WATCHDOG-FIRE] $(date -u +%FT%TZ) pushing WIP from subshell (parent may be blocked) pid=$$" >&2
+              # Push directly — parent USR1 trap defers until foreground completes;
+              # subshell is unblocked and can push while the parent is stuck.
+              if ci_push_partial_work 120; then
+                echo "[WATCHDOG-PUSH-OK] $(date -u +%FT%TZ)" >&2
+              else
+                echo "[WATCHDOG-PUSH-FAIL] $(date -u +%FT%TZ) exit=$?" >&2
+              fi
+              kill -USR1 $$ 2>/dev/null
+            ) &
             _WATCHDOG_PID=$!
             emit_event "pipeline.watchdog_armed" \
                        "issue=${ISSUE_NUMBER}" \

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -883,6 +883,7 @@ ci_push_partial_work() {
         echo "[WIP-PUSH-FAIL] $(date -u +%FT%TZ) branch=$branch exit=${_push_rc}" >&2
         warn "git push failed for $branch — remote may be out of sync"
         emit_event "pipeline.push_failed" "branch=$branch exit=${_push_rc}"
+        return "$_push_rc"
     fi
 }
 


### PR DESCRIPTION
Closes #508

## Problem

Three GHA pipeline runs (#416, #422, #423) failed without leaving a `shipwright/issue-NNN` WIP branch on origin. Without the WIP branch, `shipwright pipeline resume` cannot recover partial work.

All three had the "Push partial work on exit" step print: *No partial work and no existing remote branch — skipping push.* — incorrectly.

## Root Cause Chain

Telemetry from PR #498's `[WATCHDOG-*]` markers confirmed the exact failure modes:

| Run | Issue | FIRE | TRAP | GHA step | 
|-----|-------|------|------|----------|
| 25191555676 | #416 | ✅ T+175m | ❌ | skipped |
| 25191556989 | #422 | ❌ ended early | ❌ | skipped |
| 25191557652 | #423 | ✅ T+175m | ❌ | skipped |

## Fixes

### Fix 1 — GHA skip-logic inversion
**File:** `.github/workflows/shipwright-pipeline.yml:830`

`git rev-list` fails on a missing WIP branch ref, fallback `|| echo "0"` returns `AHEAD=0`. Old condition `[ -z REMOTE_EXISTS ] && [ AHEAD = 0 ]` fired when branch was absent — skipping exactly the case we need to push. Inverted to skip **only** when branch exists AND already up to date.

### Fix 2 — Watchdog subshell direct push
**File:** `scripts/sw-pipeline.sh:3074`

FIRE without TRAP: watchdog sends SIGUSR1 but parent is blocked in `claude --print`. Bash defers signal handlers until the foreground command returns; GHA SIGTERM fires first. Subshell now calls `ci_push_partial_work 120` directly before sending USR1 — WIP is saved even when parent is blocked.

### Fix 3 — Per-iteration time-budget guard
**Files:** `scripts/sw-loop.sh`, `scripts/lib/loop-convergence.sh`, `scripts/lib/loop-restart.sh`

Added `check_time_budget()` to the iteration pre-checks. Breaks the loop when `<20 min` remain in the GHA job, leaving room for the watchdog push and cleanup. `LOOP_START_EPOCH` recorded at `initialize_state()`.

### Fix 4 — `[WIP-PUSH-*]` telemetry + 60s cleanup timeout
**File:** `scripts/sw-pipeline.sh:852`

`ci_push_partial_work` now emits `[WIP-PUSH-START]`, `[WIP-PUSH-OK]`, `[WIP-PUSH-FAIL exit=N]` markers, matching the `[WATCHDOG-*]` pattern from PR #498. `cleanup_on_exit` push timeout bumped 30s → 60s for first-time remote branch creation on cold network connections.

### Fix 5 — Non-blocking SDK transport
**File:** `scripts/lib/pipeline-stages-intake.sh`

Converted long-blocking `claude --print` calls (plan stage: 3600s timeout, design stage) from foreground execution to `& wait $!`. The bash builtin `wait` IS interruptible by trapped signals — USR1/SIGTERM handlers can fire mid-call instead of waiting for the SDK call to complete. Inventory: `docs/sdk-blocking-call-inventory.md`.

## Tests

```
Passed: 30
Failed: 0
Total:  30
```

2 new tests added:
- Test 29: `test_watchdog_subshell_calls_push_before_usr1` — asserts subshell calls `ci_push_partial_work 120` before `kill -USR1`, even when parent trap is blocked
- Test 30: `test_wip_push_telemetry_markers_emitted` — asserts `[WIP-PUSH-START/OK]` on success, `[WIP-PUSH-START/FAIL]` on push failure

## Security Review

- Arithmetic expressions in `check_time_budget` use only controlled pipeline variables — no injection risk
- `& wait $!` conversions write to pre-existing artifact paths, no new data paths
- No temp files added; no data leakage

## Resuming the 3 Stuck Issues

After Fix 1 ships, next pipeline run will save a WIP branch on any failure.

- **#416, #423**: Feature branches exist — re-run the pipeline
- **#422**: Feature branch exists; diagnose the specific test failure before re-running (self-healing was exhausted)