### PR TITLE
fix(loop): normalize DoD checkbox markers — accept any completion indicator

### DIFF
--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -2277,6 +2277,47 @@ else
 fi
 rm -f "$dgs_test_log"
 
+# ─── DoD checkbox normalization ───────────────────────────────────────────────
+
+# Test: _normalize_dod_checkboxes function exists in sw-loop.sh
+if grep -q '^_normalize_dod_checkboxes()' "$SCRIPT_DIR/sw-loop.sh"; then
+    assert_pass "_normalize_dod_checkboxes function defined in sw-loop.sh"
+else
+    assert_fail "_normalize_dod_checkboxes function defined in sw-loop.sh"
+fi
+
+# Test: _normalize_dod_checkboxes correctly converts all indicator styles to [x]
+_norm_body="$(sed -n '/^_normalize_dod_checkboxes()/,/^}/p' "$SCRIPT_DIR/sw-loop.sh")"
+_norm_fixture="$(printf '%s\n' \
+    '- [✓] item one' \
+    '- [X] item two' \
+    '- [/] item three' \
+    '- [ ] item four ✓ (confirmed)' \
+    '- [ ] item five')"
+_norm_result="$(eval "$_norm_body"; _normalize_dod_checkboxes <<< "$_norm_fixture" 2>/dev/null)"
+_norm_pass=true
+for _expected in \
+    '- [x] item one' \
+    '- [x] item two' \
+    '- [x] item three' \
+    '- [x] item four ✓ (confirmed)'; do
+    if ! grep -qFe "$_expected" <<< "$_norm_result"; then
+        _norm_pass=false
+        break
+    fi
+done
+# Genuinely unchecked item must remain unchanged
+if ! grep -qFe '- [ ] item five' <<< "$_norm_result"; then
+    _norm_pass=false
+fi
+if [[ "$_norm_pass" == "true" ]]; then
+    assert_pass "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] unchanged"
+else
+    assert_fail "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] unchanged" \
+        "$(printf 'output:\n%s' "$_norm_result")"
+fi
+unset _norm_body _norm_fixture _norm_result _norm_pass _expected
+
 # ─── Circuit breaker: DoD-only failures (#237) ────────────────────────────────
 
 # Test: bypass emits 'skipping circuit breaker strike' message

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -2293,7 +2293,8 @@ _norm_fixture="$(printf '%s\n' \
     '- [X] item two' \
     '- [/] item three' \
     '- [ ] item four ✓ (confirmed)' \
-    '- [ ] item five')"
+    '- [ ] item five' \
+    '- [ ] Parser must handle ✓ markers in output')"
 _norm_result="$(eval "$_norm_body"; _normalize_dod_checkboxes <<< "$_norm_fixture" 2>/dev/null)"
 _norm_pass=true
 for _expected in \
@@ -2306,17 +2307,22 @@ for _expected in \
         break
     fi
 done
-# Genuinely unchecked item must remain unchanged
-if ! grep -qFe '- [ ] item five' <<< "$_norm_result"; then
-    _norm_pass=false
-fi
+# Genuinely unchecked items must remain unchanged
+for _unchanged in \
+    '- [ ] item five' \
+    '- [ ] Parser must handle ✓ markers in output'; do
+    if ! grep -qFe "$_unchanged" <<< "$_norm_result"; then
+        _norm_pass=false
+        break
+    fi
+done
 if [[ "$_norm_pass" == "true" ]]; then
-    assert_pass "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] unchanged"
+    assert_pass "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] and mid-text ✓ unchanged"
 else
-    assert_fail "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] unchanged" \
+    assert_fail "_normalize_dod_checkboxes: [✓] [X] [/] trailing-✓ all → [x]; bare [ ] and mid-text ✓ unchanged" \
         "$(printf 'output:\n%s' "$_norm_result")"
 fi
-unset _norm_body _norm_fixture _norm_result _norm_pass _expected
+unset _norm_body _norm_fixture _norm_result _norm_pass _expected _unchanged
 
 # ─── Circuit breaker: DoD-only failures (#237) ────────────────────────────────
 

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1514,6 +1514,24 @@ ${_todo_locations}"
     fi
 }
 
+_normalize_dod_checkboxes() {
+    local _line
+    while IFS= read -r _line || [[ -n "$_line" ]]; do
+        case "$_line" in
+            "- [x]"*) ;;
+            "- [ ]"*)
+                case "$_line" in *✓*|*✔*|*✅*|*☑*)
+                    _line="- [x]${_line#- \[*\]}" ;;
+                esac
+                ;;
+            "- ["*"]"*)
+                _line="- [x]${_line#- \[*\]}"
+                ;;
+        esac
+        printf '%s\n' "$_line"
+    done
+}
+
 check_definition_of_done() {
     if [[ ! -f "$DOD_FILE" ]]; then
         warn "Definition of done file not found: $DOD_FILE"
@@ -1522,6 +1540,7 @@ check_definition_of_done() {
 
     local dod_content
     dod_content="$(cat "$DOD_FILE")"
+    dod_content="$(_normalize_dod_checkboxes <<< "$dod_content")"
 
     # Use cumulative diff from loop start (not just HEAD~1) so the evaluator
     # can see ALL work done across every iteration, not just the latest commit.
@@ -1617,6 +1636,11 @@ ${branch_diff_content}
 For each item in the Definition of Done, determine if the project satisfies it.
 Use the Full Branch diff above as the authoritative view of all work done on this branch.
 The runtime facts above are verified by the harness — trust them as ground truth.
+
+IMPORTANT: A checkbox item is satisfied if ANY of the following are true:
+- Its brackets contain any non-space marker: [x], [X], [✓], [✔], [✅], [☑], [*], [+], [~], or similar
+- Its brackets are empty [ ] but the item text contains ✓, ✔, ✅, ☑, or a similar completion symbol
+Treat any such item as satisfied=true regardless of whether the bracket uses [x] specifically.
 
 IMPORTANT: Respond with a JSON object followed by a verdict line. No prose, no markdown fences, no code blocks. Format:
 {"verdict":"pass","items":[{"item":"...","satisfied":true,"reason":"..."}],"summary":"..."}

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -1515,17 +1515,29 @@ ${_todo_locations}"
 }
 
 _normalize_dod_checkboxes() {
-    local _line
+    local _line _bracket
     while IFS= read -r _line || [[ -n "$_line" ]]; do
         case "$_line" in
             "- [x]"*) ;;
             "- [ ]"*)
-                case "$_line" in *✓*|*✔*|*✅*|*☑*)
-                    _line="- [x]${_line#- \[*\]}" ;;
+                # Only promote when a check symbol is a trailing completion annotation:
+                # either at the very end of the line, or followed by a parenthetical note.
+                # Avoids false-positives when the description merely references a symbol
+                # (e.g. "- [ ] Parser must handle ✓ markers in output" stays unchecked).
+                case "$_line" in
+                    *✓|*✔|*✅|*☑|\
+                    *'✓ ('*')'|*'✔ ('*')'|*'✅ ('*')'|*'☑ ('*')')
+                        _line="- [x]${_line#"- [ ]"}" ;;
                 esac
                 ;;
             "- ["*"]"*)
-                _line="- [x]${_line#- \[*\]}"
+                # Normalize only when bracket content contains a non-whitespace character.
+                # Prevents "- [  ] item" (multiple spaces) from being promoted.
+                _bracket="${_line#"- ["}"
+                _bracket="${_bracket%%]*}"
+                if [[ "$_bracket" =~ [^[:space:]] ]]; then
+                    _line="- [x]${_line#- \[*\]}"
+                fi
                 ;;
         esac
         printf '%s\n' "$_line"
@@ -1637,10 +1649,8 @@ For each item in the Definition of Done, determine if the project satisfies it.
 Use the Full Branch diff above as the authoritative view of all work done on this branch.
 The runtime facts above are verified by the harness — trust them as ground truth.
 
-IMPORTANT: A checkbox item is satisfied if ANY of the following are true:
-- Its brackets contain any non-space marker: [x], [X], [✓], [✔], [✅], [☑], [*], [+], [~], or similar
-- Its brackets are empty [ ] but the item text contains ✓, ✔, ✅, ☑, or a similar completion symbol
-Treat any such item as satisfied=true regardless of whether the bracket uses [x] specifically.
+IMPORTANT: A checkbox item is satisfied if its brackets contain any non-space marker: [x], [X], [✓], [✔], [✅], [☑], [*], [+], [~], or similar. Treat any such item as satisfied=true.
+An unchecked [ ] item may also be satisfied if a check symbol (✓ ✔ ✅ ☑) appears appended at the END of the item text as an explicit completion annotation (e.g. "- [ ] item ✓ (confirmed)"). Do NOT treat an item as satisfied merely because its description text references or discusses a check symbol.
 
 IMPORTANT: Respond with a JSON object followed by a verdict line. No prose, no markdown fences, no code blocks. Format:
 {"verdict":"pass","items":[{"item":"...","satisfied":true,"reason":"..."}],"summary":"..."}


### PR DESCRIPTION
## Summary

- The `check_definition_of_done` function was sending raw `dod.md` content to Claude, which only recognised `[x]` as a completion marker. Items written as `[X]`, `[✓]`, `[/]`, or `- [ ] item ✓ (note)` were evaluated as unsatisfied, causing the build loop to keep cycling even when all work was done.
- Adds `_normalize_dod_checkboxes()` — a pure-bash helper that converts any non-empty bracket content (any character that isn't a space) to canonical `[x]` before the DoD evaluator sees the file. Also promotes `[ ]` items that have a trailing check symbol (✓ ✔ ✅ ☑) in the line text.
- Updates the DoD evaluator prompt to explicitly instruct Claude that any non-space marker inside brackets counts as satisfied (belt-and-suspenders for indicators the normalizer doesn't see).

## Test plan
- [ ] New structural test: grep confirms `_normalize_dod_checkboxes` exists in `sw-loop.sh`
- [ ] New behavioral test: `[✓]`, `[X]`, `[/]` (arbitrary marker), and `[ ] item ✓` all normalize to `[x]`; bare `[ ]` is left unchanged
- [ ] All 260 existing loop tests continue to pass
- [ ] Run `npm test` locally — all green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)