### PR TITLE
Remove pipeline artifacts upload step from workflow

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -939,17 +939,6 @@ jobs:
           echo "job.status: ${{ job.status }}"
           echo "Branch on origin: $(git ls-remote --heads origin "shipwright/issue-${ISSUE_NUMBER}" 2>/dev/null || echo none)"
 
-      - name: Upload pipeline artifacts
-        if: always() && steps.claim_check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: pipeline-artifacts-${{ env.ISSUE_NUMBER }}
-          path: |
-            .claude/pipeline-state.md
-            .claude/pipeline-artifacts/
-          retention-days: 30
-          if-no-files-found: ignore
-
       - name: Persist state to shipwright-data branch
         if: always() && steps.claim_check.outputs.skip != 'true'
         run: |


### PR DESCRIPTION
## Summary

Removes the "Upload pipeline artifacts" step from the shipwright-pipeline workflow. This step was uploading pipeline state and artifacts to GitHub Actions for retention, but this functionality is being consolidated or replaced by the subsequent "Persist state to shipwright-data branch" step.

## Changes

- Removed the `actions/upload-artifact@v4` step that was uploading `.claude/pipeline-state.md` and `.claude/pipeline-artifacts/` with 30-day retention
- The state persistence logic via the shipwright-data branch remains intact

## Test Plan

N/A - This is a workflow configuration change. The remaining workflow steps will continue to execute and persist state as before.

## Related Issues

<!-- Link any related issues if applicable -->

## Additional Context

The artifact upload step is being removed in favor of the existing state persistence mechanism that commits to the shipwright-data branch, reducing redundant artifact storage.

https://claude.ai/code/session_01ArTyA43JJq732hBSH9ZTGG