### PR TITLE
fix(ci): drop redundant snapshot flat adds; use GITHUBTOKEN PAT for workflow pushes

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -355,6 +355,7 @@ jobs:
       COMPLETED_STAGES: ${{ github.event.inputs.completed_stages || '' }}
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUBTOKEN: ${{ secrets.GITHUBTOKEN }}
       NO_COLOR: "1"
       SHIPWRIGHT_JOB_TIMEOUT_MINUTES: "300"   # MUST match timeout-minutes: 300 above
 
@@ -907,8 +908,6 @@ jobs:
           # intelligence-cache.json) are intentionally excluded — they are
           # regenerable and would grow the repo unboundedly across issues.
           git add -f .claude/pipeline-artifacts/plan.md                2>/dev/null || true
-          git add -f .claude/pipeline-artifacts/dod.md                 2>/dev/null || true
-          git add -f .claude/pipeline-artifacts/design.md              2>/dev/null || true
           git add -f .claude/pipeline-artifacts/context-bundle.md      2>/dev/null || true
           git add -f .claude/pipeline-artifacts/composed-pipeline.json 2>/dev/null || true
           git add -f ".claude/pipeline-artifacts/issue-${ISSUE_NUMBER}/" 2>/dev/null || true
@@ -926,12 +925,24 @@ jobs:
               commit -m "chore: resume snapshot for #${ISSUE_NUMBER} (run ${{ github.run_id }}, status=${OUTCOME}) [skip ci]" \
               --no-verify 2>/dev/null || true
 
+          # Use GITHUBTOKEN (PAT with workflow scope) when available so pushes
+          # that include workflow file changes are not rejected by the default
+          # GITHUB_TOKEN, which cannot be granted workflows permission.
+          if [[ -n "${GITHUBTOKEN:-}" ]]; then
+            git remote set-url origin "https://x-access-token:${GITHUBTOKEN}@github.com/${{ github.repository }}.git"
+          else
+            echo "INFO: GITHUBTOKEN secret is not set — push will fail if this branch modifies workflow files (add the secret to fix this)"
+          fi
+
           if timeout 120 git push origin "HEAD:refs/heads/${BRANCH}" --force-with-lease 2>/dev/null \
               || timeout 120 git push origin "HEAD:refs/heads/${BRANCH}" --force; then
             echo "✓ Resume snapshot pushed to ${BRANCH} (status=${OUTCOME})"
           else
             echo "WARN: resume snapshot push timed out or failed (non-fatal)"
           fi
+
+          # Scrub PAT from remote URL immediately after push
+          git remote set-url origin "https://github.com/${{ github.repository }}.git" 2>/dev/null || true
 
       - name: Diagnose exit signals (issue #463)
         if: always() && steps.claim_check.outputs.skip != 'true'

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -939,17 +939,6 @@ jobs:
           echo "job.status: ${{ job.status }}"
           echo "Branch on origin: $(git ls-remote --heads origin "shipwright/issue-${ISSUE_NUMBER}" 2>/dev/null || echo none)"
 
-      - name: Upload pipeline artifacts
-        if: always() && steps.claim_check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: pipeline-artifacts-${{ env.ISSUE_NUMBER }}
-          path: |
-            .claude/pipeline-state.md
-            .claude/pipeline-artifacts/
-          retention-days: 30
-          if-no-files-found: ignore
-
       - name: Persist state to shipwright-data branch
         if: always() && steps.claim_check.outputs.skip != 'true'
         run: |

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -928,7 +928,10 @@ jobs:
           # Use GITHUBTOKEN (PAT with workflow scope) when available so pushes
           # that include workflow file changes are not rejected by the default
           # GITHUB_TOKEN, which cannot be granted workflows permission.
+          # actions/checkout persists an Authorization extraheader that takes
+          # precedence over URL-embedded credentials, so we must clear it first.
           if [[ -n "${GITHUBTOKEN:-}" ]]; then
+            git config --unset-all "http.https://github.com/.extraheader" 2>/dev/null || true
             git remote set-url origin "https://x-access-token:${GITHUBTOKEN}@github.com/${{ github.repository }}.git"
           else
             echo "INFO: GITHUBTOKEN secret is not set — push will fail if this branch modifies workflow files (add the secret to fix this)"


### PR DESCRIPTION
## Summary

- **Remove redundant flat artifact adds** — \`dod.md\` and \`design.md\` were force-added twice in the snapshot step: once as flat files and once inside \`issue-\${ISSUE_NUMBER}/\`. The recovery step (\`Verify merged artifacts\`) explicitly restores from the issue-scoped copy when the flat one is missing, so the flat adds were pure noise in WIP branch history.
- **Fix push rejection for workflow-touching branches** — \`GITHUB_TOKEN\` cannot be granted \`workflows\` scope. When \`GITHUBTOKEN\` (a PAT with workflow scope) is set, the snapshot step now: (1) clears the \`actions/checkout\` persist-credentials Authorization extraheader (which would otherwise override URL-embedded credentials), (2) switches the remote URL to use the PAT, (3) pushes, and (4) scrubs the PAT from the remote URL immediately after. When unset, it prints an informational message explaining why the push will fail rather than failing silently.
- **Remove \`Upload pipeline artifacts\` step** (prior commit \`46c165e\`) — The step uploaded ~500KB of \`.claude/\` state to GitHub artifact storage on every pipeline run, but no workflow or job ever consumed those artifacts via \`download-artifact\`. The only \`download-artifact\` call in the repo targets \`release-artifacts\` in \`release.yml\`, which is unrelated. Removing the step reduces noise and storage usage without affecting any consumer.

## Root cause (push rejection)

Issue #460 is itself a change to \`.github/workflows/shipwright-pipeline.yml\`. Claude's build commits land on the WIP branch, and the snapshot force-push carries them. The default \`GITHUB_TOKEN\` is issued by the GitHub Actions App and cannot push workflow files — a PAT with \`workflow\` scope is required. Additionally, \`actions/checkout@v4\` with default \`persist-credentials: true\` sets an \`http.https://github.com/.extraheader\` Authorization header that takes precedence over URL-embedded credentials, so the extraheader must be cleared before the PAT URL takes effect.

## Test plan

- [ ] Static: YAML parses without error
- [ ] Diff covers exactly: 2 lines removed (dod/design flat adds), 1 env line added, push block updated with extraheader clear + set-url + scrub, upload-artifact step absent
- [ ] Happy path: pipeline on a workflow-touching issue → snapshot push succeeds, no \`remote rejected\`
- [ ] Recovery path: \`Verify merged artifacts\` still restores \`dod.md\`/\`design.md\` from \`issue-N/\` snapshot
- [ ] Negative path: \`GITHUBTOKEN\` unset + non-workflow branch → INFO message printed, push succeeds via \`GITHUB_TOKEN\`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)