### PR TITLE
refactor(pipeline): phase 2 — reorder steps for fast early exit

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -616,7 +616,7 @@ jobs:
           echo "Recovered ${RECOVERED} artifact file(s) from partial work branch"
 
       - name: Validate setup
-        if: steps.claim_check.outputs.skip != 'true'
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           echo "--- Environment ---"
           echo "Issue: #$ISSUE_NUMBER"
@@ -641,7 +641,7 @@ jobs:
           shipwright doctor || true
 
       - name: Comment on issue — pipeline starting
-        if: steps.claim_check.outputs.skip != 'true'
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           RESUME_NOTE=""
           if [[ -n "$COMPLETED_STAGES" ]]; then
@@ -668,7 +668,7 @@ jobs:
           )"
 
       - name: Notify dashboard — pipeline starting
-        if: steps.claim_check.outputs.skip != 'true'
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         env:
           DASHBOARD_URL: ${{ secrets.DASHBOARD_URL }}
         run: |

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -400,11 +400,6 @@ jobs:
             echo "No shipwright-data branch found — starting fresh"
           fi
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tmux jq
-
       - name: Restore npm cache
         uses: actions/cache@v4
         with:
@@ -417,7 +412,65 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
 
+      - name: Pre-flight auth check
+        run: |
+          if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not set — pipeline will be skipped"
+            echo "AUTH_SKIP=true" >> "$GITHUB_ENV"
+            exit 0
+          fi
+          echo "Verifying Claude Code authentication..."
+          if claude -p "Reply with exactly: AUTH_OK" --max-turns 1 2>/tmp/auth-check-err.log | grep -q "AUTH_OK"; then
+            echo "Claude Code authentication verified"
+          else
+            echo "::warning::Claude Code authentication failed — check CLAUDE_CODE_OAUTH_TOKEN secret"
+            echo "--- stderr ---"
+            cat /tmp/auth-check-err.log 2>/dev/null || true
+            echo "--- end ---"
+            echo "AUTH_SKIP=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Check claim lock and pipeline start cap
+        id: claim_check
+        run: |
+          CLAIMED=$(gh issue view "$ISSUE_NUMBER" --json labels \
+            --jq '[.labels[].name | select(startswith("claimed:"))] | .[0] // ""' 2>/dev/null || echo "")
+          if [ -n "$CLAIMED" ]; then
+            echo "Issue #$ISSUE_NUMBER claimed by $CLAIMED — CI yielding to local daemon"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pipeline start cap — prevent runaway retry loops
+          PIPELINE_STARTS=$(gh issue view "$ISSUE_NUMBER" --json comments \
+            --jq '[.comments[].body | select(contains("Pipeline Starting"))] | length' 2>/dev/null || echo "0")
+          if [ "${PIPELINE_STARTS:-0}" -ge 6 ]; then
+            echo "Pipeline start cap reached ($PIPELINE_STARTS attempts) for issue #$ISSUE_NUMBER"
+            gh issue comment "$ISSUE_NUMBER" --body "$(cat <<CAPEOF
+          :stop_sign: **Shipwright Pipeline — Start Cap Reached**
+
+          This issue has had **${PIPELINE_STARTS} pipeline attempts** — exceeding the safety cap of 6.
+
+          This usually means the issue cannot be solved autonomously and needs human review.
+          Re-apply the \`shipwright\` label after clearing old pipeline comments to retry.
+          CAPEOF
+          )" 2>/dev/null || true
+            gh issue edit "$ISSUE_NUMBER" --remove-label "shipwright" 2>/dev/null || true
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "Pipeline starts so far: ${PIPELINE_STARTS:-0}/6"
+
+      - name: Install system dependencies
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tmux jq
+
       - name: Install Shipwright (pinned to main snapshot)
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           git fetch --no-tags --depth=1 origin main || git fetch --no-tags origin main
 
@@ -445,6 +498,7 @@ jobs:
           esac
 
       - name: Restore ruflo memory cache
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         uses: actions/cache/restore@v4
         with:
           path: .claude-flow/data/
@@ -454,6 +508,7 @@ jobs:
         continue-on-error: true
 
       - name: Install ruflo (optional — pipeline falls back gracefully if unavailable)
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           _ruflo_install_err="$(mktemp)"
           _ruflo_doctor_err="$(mktemp)"
@@ -482,31 +537,15 @@ jobs:
         continue-on-error: true
 
       - name: Restore ruflo memory from orphan branch
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           source scripts/lib/ruflo-adapter.sh
           ruflo_detect || true
           ruflo_ci_memory_pull
         continue-on-error: true
 
-      - name: Pre-flight auth check
-        run: |
-          if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
-            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN is not set — pipeline will be skipped"
-            echo "AUTH_SKIP=true" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          echo "Verifying Claude Code authentication..."
-          if claude -p "Reply with exactly: AUTH_OK" --max-turns 1 2>/tmp/auth-check-err.log | grep -q "AUTH_OK"; then
-            echo "Claude Code authentication verified"
-          else
-            echo "::warning::Claude Code authentication failed — check CLAUDE_CODE_OAUTH_TOKEN secret"
-            echo "--- stderr ---"
-            cat /tmp/auth-check-err.log 2>/dev/null || true
-            echo "--- end ---"
-            echo "AUTH_SKIP=true" >> "$GITHUB_ENV"
-          fi
-
       - name: Prepare workspace branch (resume WIP or branch from main)
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           BRANCH="shipwright/issue-${ISSUE_NUMBER}"
           USE_WIP=false
@@ -542,6 +581,7 @@ jobs:
           echo "WORKSPACE_BRANCH=${BRANCH}"  >> "$GITHUB_ENV"
 
       - name: Verify CLI still pinned to main snapshot
+        if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'
         run: |
           GLOBAL_PKG="$(npm root -g)/shipwright-cli"
           REAL_TARGET="$(readlink -f "$GLOBAL_PKG" 2>/dev/null || echo "")"
@@ -574,39 +614,6 @@ jobs:
             fi
           done
           echo "Recovered ${RECOVERED} artifact file(s) from partial work branch"
-
-      - name: Check claim lock and pipeline start cap
-        id: claim_check
-        run: |
-          CLAIMED=$(gh issue view "$ISSUE_NUMBER" --json labels \
-            --jq '[.labels[].name | select(startswith("claimed:"))] | .[0] // ""' 2>/dev/null || echo "")
-          if [ -n "$CLAIMED" ]; then
-            echo "Issue #$ISSUE_NUMBER claimed by $CLAIMED — CI yielding to local daemon"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Pipeline start cap — prevent runaway retry loops
-          PIPELINE_STARTS=$(gh issue view "$ISSUE_NUMBER" --json comments \
-            --jq '[.comments[].body | select(contains("Pipeline Starting"))] | length' 2>/dev/null || echo "0")
-          if [ "${PIPELINE_STARTS:-0}" -ge 6 ]; then
-            echo "Pipeline start cap reached ($PIPELINE_STARTS attempts) for issue #$ISSUE_NUMBER"
-            gh issue comment "$ISSUE_NUMBER" --body "$(cat <<CAPEOF
-          :stop_sign: **Shipwright Pipeline — Start Cap Reached**
-
-          This issue has had **${PIPELINE_STARTS} pipeline attempts** — exceeding the safety cap of 6.
-
-          This usually means the issue cannot be solved autonomously and needs human review.
-          Re-apply the \`shipwright\` label after clearing old pipeline comments to retry.
-          CAPEOF
-          )" 2>/dev/null || true
-            gh issue edit "$ISSUE_NUMBER" --remove-label "shipwright" 2>/dev/null || true
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "Pipeline starts so far: ${PIPELINE_STARTS:-0}/6"
 
       - name: Validate setup
         if: steps.claim_check.outputs.skip != 'true'

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -121,5 +121,44 @@ else
         "(cache line=$NPM_CACHE_LINE, install line=$INSTALL_CLAUDE_LINE)"
 fi
 
+# ─── Phase 2: early-exit ordering — auth probe and claim lock before expensive install ─
+
+# Install Claude Code before Pre-flight auth check (auth probe needs claude CLI)
+INSTALL_CLAUDE_LINE2=$(grep -nE '^[[:space:]]*- name: Install Claude Code' "$WORKFLOW" | head -1 | cut -d: -f1 || echo 0)
+AUTH_PROBE_LINE=$(grep -nE '^[[:space:]]*- name: Pre-flight auth check' "$WORKFLOW" | head -1 | cut -d: -f1 || echo 0)
+
+if [[ "$INSTALL_CLAUDE_LINE2" -gt 0 && "$AUTH_PROBE_LINE" -gt 0 && "$INSTALL_CLAUDE_LINE2" -lt "$AUTH_PROBE_LINE" ]]; then
+    assert_pass "Install Claude Code appears before Pre-flight auth check"
+else
+    assert_fail "Install Claude Code appears before Pre-flight auth check" \
+        "(claude line=$INSTALL_CLAUDE_LINE2, auth line=$AUTH_PROBE_LINE)"
+fi
+
+# Pre-flight auth check before Install system dependencies
+INSTALL_DEPS_LINE=$(grep -nE '^[[:space:]]*- name: Install system dependencies' "$WORKFLOW" | head -1 | cut -d: -f1 || echo 0)
+
+if [[ "$AUTH_PROBE_LINE" -gt 0 && "$INSTALL_DEPS_LINE" -gt 0 && "$AUTH_PROBE_LINE" -lt "$INSTALL_DEPS_LINE" ]]; then
+    assert_pass "Pre-flight auth check appears before Install system dependencies"
+else
+    assert_fail "Pre-flight auth check appears before Install system dependencies" \
+        "(auth line=$AUTH_PROBE_LINE, deps line=$INSTALL_DEPS_LINE)"
+fi
+
+# Check claim lock before Install system dependencies
+CLAIM_LOCK_LINE=$(grep -nE '^[[:space:]]*- name: Check claim lock' "$WORKFLOW" | head -1 | cut -d: -f1 || echo 0)
+
+if [[ "$CLAIM_LOCK_LINE" -gt 0 && "$INSTALL_DEPS_LINE" -gt 0 && "$CLAIM_LOCK_LINE" -lt "$INSTALL_DEPS_LINE" ]]; then
+    assert_pass "Check claim lock appears before Install system dependencies"
+else
+    assert_fail "Check claim lock appears before Install system dependencies" \
+        "(claim line=$CLAIM_LOCK_LINE, deps line=$INSTALL_DEPS_LINE)"
+fi
+
+# Install system dependencies has skip guard condition
+assert_contains_regex \
+    "Install system dependencies has claim_check skip guard" \
+    "$(grep -A2 'Install system dependencies' "$WORKFLOW" || true)" \
+    "claim_check.*skip"
+
 echo ""
 print_test_results


### PR DESCRIPTION
## Summary

- Moves **Pre-flight auth check** and **Check claim lock + start cap** to run immediately after `Install Claude Code`, before the expensive install block (apt + Shipwright worktree + ruflo)
- Adds `if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'` guards to `Prepare workspace branch` and `Verify CLI still pinned to main snapshot`
- Fixes a latent bug: `Install system dependencies` and downstream steps referenced `claim_check.outputs.skip` but `claim_check` ran 120+ lines later — those conditions always evaluated as empty string (i.e., always ran)

**Before:** skipped/failed run costs ~3min (full apt + npm installs before early-exit check)
**After:** skipped/failed run aborts in ~15–30s (only `npm install -g @anthropic-ai/claude-code` before exit)

## New pre-install order
1. Restore npm cache (unconditional)
2. Install Claude Code (unconditional)
3. Pre-flight auth check — sets `AUTH_SKIP=true` if token missing/invalid
4. Check claim lock + start cap — sets `skip=true` if claimed or capped
5–9. apt deps + Shipwright + ruflo + state restore (gated by claim_check/AUTH_SKIP)
10–11. Prepare workspace branch + Verify CLI (now also gated)

## Test plan
- [x] All 22 static analysis tests in `sw-gha-pipeline-test.sh` pass (18 Phase 1 + 4 new Phase 2 ordering tests)
- [x] Full `npm test` passes (exit 0)
- [ ] Trigger a run with missing `CLAUDE_CODE_OAUTH_TOKEN` and confirm abort at <30s

## What's next
- Phase 3: Consolidate ruflo persistence (drop redundant `actions/cache` ruflo path)
- Phase 4: Remove `_soft_timeout_handler` watchdog from `sw-pipeline.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)