### PR TITLE
refactor(pipeline): phase 5 — unified retry caps via policy.json

### DIFF
--- a/.github/workflows/shipwright-auto-retry.yml
+++ b/.github/workflows/shipwright-auto-retry.yml
@@ -21,6 +21,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Extract issue number from failed run
         id: extract
         run: |
@@ -180,6 +185,9 @@ jobs:
         if: steps.extract.outputs.issue_number != ''
         id: strategy
         run: |
+          # Load retry caps from policy.json — single source of truth
+          . scripts/lib/retry-policy.sh
+
           ISSUE_NUMBER="${{ steps.extract.outputs.issue_number }}"
           ERROR_CATEGORY="${{ steps.categorize.outputs.error_category }}"
 
@@ -192,6 +200,20 @@ jobs:
 
           echo "Current retry count: $RETRY_COUNT"
 
+          # Detect watchdog cancels — the watchdog already dispatched a retry, so
+          # auto-retry must not dispatch a second one. RETRY_COUNT is not incremented
+          # because the run was stuck (not a genuine failure attempt).
+          CANCEL_REASON=$(echo "$COMMENTS" | grep -oE 'SHIPWRIGHT-CANCEL-REASON: [a-z_]+' | tail -1 | cut -d' ' -f2 || true)
+          if [[ "$CANCEL_REASON" == "watchdog" ]]; then
+            echo "Watchdog cancel detected — suppressing auto-retry dispatch (watchdog_cancel)"
+            {
+              echo "should_retry=false"
+              echo "skip_reason=watchdog_cancel"
+              echo "retry_count=$RETRY_COUNT"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Extract last failed stage from result comment
           LAST_STAGE=$(echo "$COMMENTS" | grep -oE 'SHIPWRIGHT-RESULT: [0-9]+:[a-z_]+' | tail -1 | cut -d: -f3 || echo "")
 
@@ -200,7 +222,6 @@ jobs:
           RAW_STAGES=$(echo "$COMMENTS" | grep -oE 'SHIPWRIGHT-STAGE: [a-z_]+:complete' | sed 's/SHIPWRIGHT-STAGE: //' | sed 's/:complete//' | sort -u || echo "")
 
           # Supplement comment-based detection with the branch's authoritative state file.
-          # This job has no actions/checkout, so git commands would fail — use gh api instead.
           # grep -E + sed avoids the GNU grep -P dependency (portable to all GHA runners).
           BRANCH="shipwright/issue-${ISSUE_NUMBER}"
           STATE_B64=$(gh api \
@@ -209,7 +230,7 @@ jobs:
           BRANCH_STAGES=""
           if [[ -n "$STATE_B64" ]]; then
             BRANCH_STAGES=$(printf '%s' "$STATE_B64" | base64 -d 2>/dev/null \
-              | grep -E '^\s+[a-z_]+: complete' \
+              | grep -E '^[[:space:]]+[a-z_]+: complete' \
               | sed 's/^[[:space:]]*//' \
               | sed 's/: complete$//' \
               | sort -u || true)
@@ -241,8 +262,8 @@ jobs:
             exit 0
           fi
 
-          if [[ "$RETRY_COUNT" -ge 3 ]]; then
-            echo "Max retries (3) reached for issue #$ISSUE_NUMBER — giving up"
+          if [[ "$RETRY_COUNT" -ge "${RETRY_MAX_AUTO_RETRIES}" ]]; then
+            echo "Max retries (${RETRY_MAX_AUTO_RETRIES}) reached for issue #$ISSUE_NUMBER — giving up"
             {
               echo "should_retry=false"
               echo "skip_reason=exhausted"

--- a/.github/workflows/shipwright-auto-retry.yml
+++ b/.github/workflows/shipwright-auto-retry.yml
@@ -200,12 +200,16 @@ jobs:
 
           echo "Current retry count: $RETRY_COUNT"
 
-          # Detect watchdog cancels — the watchdog already dispatched a retry, so
-          # auto-retry must not dispatch a second one. RETRY_COUNT is not incremented
-          # because the run was stuck (not a genuine failure attempt).
-          CANCEL_REASON=$(echo "$COMMENTS" | grep -oE 'SHIPWRIGHT-CANCEL-REASON: [a-z_]+' | tail -1 | cut -d' ' -f2 || true)
-          if [[ "$CANCEL_REASON" == "watchdog" ]]; then
-            echo "Watchdog cancel detected — suppressing auto-retry dispatch (watchdog_cancel)"
+          # Detect watchdog cancels scoped to THIS run — the watchdog already
+          # dispatched a retry, so auto-retry must not dispatch a second one.
+          # RETRY_COUNT is not incremented because the run was stuck (not a
+          # genuine failure attempt).  Check for SHIPWRIGHT-WATCHDOG-CANCEL:
+          # <run_id> so a stale marker from a previous cancel cannot suppress
+          # future retries on the same issue.
+          THIS_RUN_ID="${{ steps.extract.outputs.run_id }}"
+          WATCHDOG_CANCEL=$(echo "$COMMENTS" | grep -c "SHIPWRIGHT-WATCHDOG-CANCEL: ${THIS_RUN_ID}" || true)
+          if [[ "${WATCHDOG_CANCEL:-0}" -gt 0 ]]; then
+            echo "Watchdog cancel detected for run ${THIS_RUN_ID} — suppressing auto-retry dispatch (watchdog_cancel)"
             {
               echo "should_retry=false"
               echo "skip_reason=watchdog_cancel"

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -433,6 +433,9 @@ jobs:
       - name: Check claim lock and pipeline start cap
         id: claim_check
         run: |
+          # Load retry caps from policy.json — single source of truth
+          . scripts/lib/retry-policy.sh
+
           CLAIMED=$(gh issue view "$ISSUE_NUMBER" --json labels \
             --jq '[.labels[].name | select(startswith("claimed:"))] | .[0] // ""' 2>/dev/null || echo "")
           if [ -n "$CLAIMED" ]; then
@@ -444,12 +447,12 @@ jobs:
           # Pipeline start cap — prevent runaway retry loops
           PIPELINE_STARTS=$(gh issue view "$ISSUE_NUMBER" --json comments \
             --jq '[.comments[].body | select(contains("Pipeline Starting"))] | length' 2>/dev/null || echo "0")
-          if [ "${PIPELINE_STARTS:-0}" -ge 6 ]; then
+          if [ "${PIPELINE_STARTS:-0}" -ge "${RETRY_MAX_PIPELINE_STARTS}" ]; then
             echo "Pipeline start cap reached ($PIPELINE_STARTS attempts) for issue #$ISSUE_NUMBER"
             gh issue comment "$ISSUE_NUMBER" --body "$(cat <<CAPEOF
           :stop_sign: **Shipwright Pipeline — Start Cap Reached**
 
-          This issue has had **${PIPELINE_STARTS} pipeline attempts** — exceeding the safety cap of 6.
+          This issue has had **${PIPELINE_STARTS} pipeline attempts** — exceeding the safety cap of ${RETRY_MAX_PIPELINE_STARTS}.
 
           This usually means the issue cannot be solved autonomously and needs human review.
           Re-apply the \`shipwright\` label after clearing old pipeline comments to retry.
@@ -461,7 +464,7 @@ jobs:
           fi
 
           echo "skip=false" >> "$GITHUB_OUTPUT"
-          echo "Pipeline starts so far: ${PIPELINE_STARTS:-0}/6"
+          echo "Pipeline starts so far: ${PIPELINE_STARTS:-0}/${RETRY_MAX_PIPELINE_STARTS}"
 
       - name: Install system dependencies
         if: steps.claim_check.outputs.skip != 'true' && env.AUTH_SKIP != 'true'

--- a/.github/workflows/shipwright-watchdog.yml
+++ b/.github/workflows/shipwright-watchdog.yml
@@ -21,8 +21,16 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Monitor in-progress pipeline runs
         run: |
+          # Load retry caps from policy.json — single source of truth
+          . scripts/lib/retry-policy.sh
+
           echo "--- Shipwright Watchdog: $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
           NOW_EPOCH=$(date +%s)
 
@@ -140,8 +148,8 @@ jobs:
               continue
             fi
 
-            # 45 min - 2h silence: cancel and retry
-            if [[ "$SILENT_MINS" -lt 120 ]]; then
+            # 45 min - abandon_after_minutes silence: cancel and retry
+            if [[ "$SILENT_MINS" -lt "${RETRY_ABANDON_AFTER_MINUTES}" ]]; then
               echo "Status: STUCK (${SILENT_MINS}m silence) — cancelling and retrying"
               CANCELLED_COUNT=$((CANCELLED_COUNT + 1))
 
@@ -151,7 +159,8 @@ jobs:
               # Extract completed stages from comments
               COMPLETED_STAGES=$(echo "$COMMENTS_JSON" | jq -r '.body' 2>/dev/null | grep -oE 'SHIPWRIGHT-STAGE: [a-z_]+:complete' | sed 's/SHIPWRIGHT-STAGE: //' | sed 's/:complete//' | tr '\n' ',' | sed 's/,$//' || true)
 
-              # Post cancellation comment
+              # Post cancellation comment — SHIPWRIGHT-CANCEL-REASON: watchdog tells
+              # auto-retry not to increment RETRY_COUNT for this cancel.
               gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
           :rotating_light: **Shipwright Watchdog — Pipeline Cancelled (Stuck)**
 
@@ -166,6 +175,7 @@ jobs:
           | Action | Dispatching retry with resume |
 
           <!-- SHIPWRIGHT-WATCHDOG-CANCEL: $RUN_ID -->
+          <!-- SHIPWRIGHT-CANCEL-REASON: watchdog -->
           EOF
           )" 2>/dev/null || true
 
@@ -198,7 +208,7 @@ jobs:
 
           Run [$RUN_ID](${{ github.server_url }}/${{ github.repository }}/actions/runs/$RUN_ID) was cancelled after **${ELAPSED_MINS} minutes** with no progress for **${SILENT_MINS} minutes**.
 
-          This exceeds the 2-hour silence threshold. The pipeline will **not** be automatically retried.
+          This exceeds the ${RETRY_ABANDON_AFTER_MINUTES}-minute silence threshold. The pipeline will **not** be automatically retried.
 
           | Field | Value |
           |-------|-------|

--- a/config/policy.json
+++ b/config/policy.json
@@ -200,6 +200,11 @@
     "overlap_threshold_percent": 60,
     "strategy_lines": 200
   },
+  "retry": {
+    "max_pipeline_starts": 6,
+    "max_auto_retries": 3,
+    "abandon_after_minutes": 120
+  },
   "sweep": {
     "cron_minutes": 30,
     "stuck_threshold_hours": 4,

--- a/scripts/lib/retry-policy.sh
+++ b/scripts/lib/retry-policy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# retry-policy.sh — Single source of truth for all retry caps.
+# Source this file to get RETRY_MAX_PIPELINE_STARTS, RETRY_MAX_AUTO_RETRIES,
+# RETRY_ABANDON_AFTER_MINUTES read from config/policy.json.
+# Usage: source "$SCRIPT_DIR/lib/retry-policy.sh"
+[[ -n "${_RETRY_POLICY_LOADED:-}" ]] && return 0
+_RETRY_POLICY_LOADED=1
+
+_RETRY_POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_RETRY_POLICY_FILE="${_RETRY_POLICY_DIR}/../../config/policy.json"
+
+RETRY_MAX_PIPELINE_STARTS=$(jq -r '.retry.max_pipeline_starts // 6' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "6")
+RETRY_MAX_AUTO_RETRIES=$(jq -r '.retry.max_auto_retries // 3' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "3")
+RETRY_ABANDON_AFTER_MINUTES=$(jq -r '.retry.abandon_after_minutes // 120' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "120")
+
+export RETRY_MAX_PIPELINE_STARTS RETRY_MAX_AUTO_RETRIES RETRY_ABANDON_AFTER_MINUTES

--- a/scripts/lib/retry-policy.sh
+++ b/scripts/lib/retry-policy.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # retry-policy.sh — Single source of truth for all retry caps.
 # Source this file to get RETRY_MAX_PIPELINE_STARTS, RETRY_MAX_AUTO_RETRIES,
-# RETRY_ABANDON_AFTER_MINUTES read from config/policy.json.
+# RETRY_ABANDON_AFTER_MINUTES read from config/policy.json via policy_get.
 # Usage: source "$SCRIPT_DIR/lib/retry-policy.sh"
 [[ -n "${_RETRY_POLICY_LOADED:-}" ]] && return 0
 _RETRY_POLICY_LOADED=1
 
 _RETRY_POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_RETRY_POLICY_FILE="${_RETRY_POLICY_DIR}/../../config/policy.json"
 
-RETRY_MAX_PIPELINE_STARTS=$(jq -r '.retry.max_pipeline_starts // 6' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "6")
-RETRY_MAX_AUTO_RETRIES=$(jq -r '.retry.max_auto_retries // 3' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "3")
-RETRY_ABANDON_AFTER_MINUTES=$(jq -r '.retry.abandon_after_minutes // 120' "$_RETRY_POLICY_FILE" 2>/dev/null || echo "120")
+# Set REPO_DIR so policy.sh resolves config/policy.json from the repo root.
+REPO_DIR="${REPO_DIR:-$(cd "$_RETRY_POLICY_DIR/../.." && pwd)}"
+# shellcheck source=scripts/lib/policy.sh
+source "$_RETRY_POLICY_DIR/policy.sh"
+
+RETRY_MAX_PIPELINE_STARTS=$(policy_get '.retry.max_pipeline_starts' 6)
+RETRY_MAX_AUTO_RETRIES=$(policy_get '.retry.max_auto_retries' 3)
+RETRY_ABANDON_AFTER_MINUTES=$(policy_get '.retry.abandon_after_minutes' 120)
 
 export RETRY_MAX_PIPELINE_STARTS RETRY_MAX_AUTO_RETRIES RETRY_ABANDON_AFTER_MINUTES

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -264,17 +264,22 @@ assert_contains_regex \
     "$(grep 'RETRY_ABANDON_AFTER_MINUTES' "$WATCHDOG_WORKFLOW" || true)" \
     "RETRY_ABANDON_AFTER_MINUTES"
 
-# watchdog posts SHIPWRIGHT-CANCEL-REASON: watchdog marker on cancel
+# watchdog posts SHIPWRIGHT-CANCEL-REASON: watchdog and SHIPWRIGHT-WATCHDOG-CANCEL markers
 assert_contains_regex \
     "shipwright-watchdog.yml posts SHIPWRIGHT-CANCEL-REASON: watchdog marker" \
     "$(grep 'SHIPWRIGHT-CANCEL-REASON' "$WATCHDOG_WORKFLOW" || true)" \
     "SHIPWRIGHT-CANCEL-REASON:.*watchdog"
 
-# auto-retry detects watchdog cancel reason and skips RETRY_COUNT increment
 assert_contains_regex \
-    "shipwright-auto-retry.yml detects SHIPWRIGHT-CANCEL-REASON: watchdog" \
-    "$(grep 'CANCEL-REASON' "$AUTO_RETRY_WORKFLOW" || true)" \
-    "CANCEL-REASON"
+    "shipwright-watchdog.yml posts SHIPWRIGHT-WATCHDOG-CANCEL run-scoped marker" \
+    "$(grep 'SHIPWRIGHT-WATCHDOG-CANCEL' "$WATCHDOG_WORKFLOW" || true)" \
+    "SHIPWRIGHT-WATCHDOG-CANCEL"
+
+# auto-retry detects watchdog cancel scoped to the specific run_id (not CANCEL-REASON which is unscoped)
+assert_contains_regex \
+    "shipwright-auto-retry.yml detects watchdog cancel via run-scoped SHIPWRIGHT-WATCHDOG-CANCEL marker" \
+    "$(grep 'SHIPWRIGHT-WATCHDOG-CANCEL' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "SHIPWRIGHT-WATCHDOG-CANCEL"
 
 assert_contains_regex \
     "shipwright-auto-retry.yml skips retry count on watchdog cancel (watchdog_cancel)" \

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║  sw-gha-pipeline-test — Static validation of shipwright-pipeline.yml     ║
-# ║  Tests for Phase 1-3: log artifact, npm cache, step ordering, persistence ║
+# ║  Tests for Phases 1-5: log artifact, npm cache, ordering, persistence,    ║
+# ║  and unified retry caps                                                    ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
 set -euo pipefail
 trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
@@ -11,7 +12,7 @@ source "$SCRIPT_DIR/lib/test-helpers.sh"
 
 WORKFLOW="$SCRIPT_DIR/../.github/workflows/shipwright-pipeline.yml"
 
-print_test_header "GHA Pipeline Workflow: Phases 1-3 — Observability, Ordering, Persistence"
+print_test_header "GHA Pipeline Workflow: Phases 1-5 — Observability, Ordering, Persistence, Retry Caps"
 
 # ─── npm cache ─────────────────────────────────────────────────────────────
 
@@ -188,6 +189,97 @@ assert_contains_regex \
     "ruflo orphan-branch save (ruflo_ci_memory_push) still present" \
     "$(grep 'ruflo_ci_memory_push' "$WORKFLOW" || true)" \
     "ruflo_ci_memory_push"
+
+echo ""
+
+# ─── Phase 5: Unified retry caps ────────────────────────────────────────────
+
+AUTO_RETRY_WORKFLOW="$SCRIPT_DIR/../.github/workflows/shipwright-auto-retry.yml"
+WATCHDOG_WORKFLOW="$SCRIPT_DIR/../.github/workflows/shipwright-watchdog.yml"
+RETRY_POLICY_SCRIPT="$SCRIPT_DIR/lib/retry-policy.sh"
+POLICY_JSON="$SCRIPT_DIR/../config/policy.json"
+
+# policy.json has retry section
+assert_contains_regex \
+    "config/policy.json has retry.max_pipeline_starts" \
+    "$(jq -r '.retry.max_pipeline_starts // empty' "$POLICY_JSON" 2>/dev/null || true)" \
+    "[0-9]+"
+
+assert_contains_regex \
+    "config/policy.json has retry.max_auto_retries" \
+    "$(jq -r '.retry.max_auto_retries // empty' "$POLICY_JSON" 2>/dev/null || true)" \
+    "[0-9]+"
+
+assert_contains_regex \
+    "config/policy.json has retry.abandon_after_minutes" \
+    "$(jq -r '.retry.abandon_after_minutes // empty' "$POLICY_JSON" 2>/dev/null || true)" \
+    "[0-9]+"
+
+# retry-policy.sh exists
+RETRY_POLICY_EXISTS=$([ -f "$RETRY_POLICY_SCRIPT" ] && echo "yes" || echo "no")
+assert_eq \
+    "scripts/lib/retry-policy.sh exists" \
+    "yes" "$RETRY_POLICY_EXISTS"
+
+# pipeline.yml sources retry-policy.sh and uses variable
+assert_contains_regex \
+    "shipwright-pipeline.yml sources retry-policy.sh in claim_check step" \
+    "$(grep 'retry-policy\.sh' "$WORKFLOW" || true)" \
+    "retry-policy\.sh"
+
+assert_contains_regex \
+    "shipwright-pipeline.yml uses RETRY_MAX_PIPELINE_STARTS variable (not hardcoded 6)" \
+    "$(grep 'RETRY_MAX_PIPELINE_STARTS' "$WORKFLOW" || true)" \
+    "RETRY_MAX_PIPELINE_STARTS"
+
+# auto-retry.yml has checkout + sources retry-policy.sh + uses variable
+AUTORETRY_CHECKOUT_COUNT=$(grep -c 'actions/checkout' "$AUTO_RETRY_WORKFLOW" || true)
+assert_eq \
+    "shipwright-auto-retry.yml has checkout step" \
+    "1" "$AUTORETRY_CHECKOUT_COUNT"
+
+assert_contains_regex \
+    "shipwright-auto-retry.yml sources retry-policy.sh" \
+    "$(grep 'retry-policy\.sh' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "retry-policy\.sh"
+
+assert_contains_regex \
+    "shipwright-auto-retry.yml uses RETRY_MAX_AUTO_RETRIES variable (not hardcoded 3)" \
+    "$(grep 'RETRY_MAX_AUTO_RETRIES' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "RETRY_MAX_AUTO_RETRIES"
+
+# watchdog.yml has checkout + sources retry-policy.sh + uses variable
+WATCHDOG_CHECKOUT_COUNT=$(grep -c 'actions/checkout' "$WATCHDOG_WORKFLOW" || true)
+assert_eq \
+    "shipwright-watchdog.yml has checkout step" \
+    "1" "$WATCHDOG_CHECKOUT_COUNT"
+
+assert_contains_regex \
+    "shipwright-watchdog.yml sources retry-policy.sh" \
+    "$(grep 'retry-policy\.sh' "$WATCHDOG_WORKFLOW" || true)" \
+    "retry-policy\.sh"
+
+assert_contains_regex \
+    "shipwright-watchdog.yml uses RETRY_ABANDON_AFTER_MINUTES variable (not hardcoded 120)" \
+    "$(grep 'RETRY_ABANDON_AFTER_MINUTES' "$WATCHDOG_WORKFLOW" || true)" \
+    "RETRY_ABANDON_AFTER_MINUTES"
+
+# watchdog posts SHIPWRIGHT-CANCEL-REASON: watchdog marker on cancel
+assert_contains_regex \
+    "shipwright-watchdog.yml posts SHIPWRIGHT-CANCEL-REASON: watchdog marker" \
+    "$(grep 'SHIPWRIGHT-CANCEL-REASON' "$WATCHDOG_WORKFLOW" || true)" \
+    "SHIPWRIGHT-CANCEL-REASON:.*watchdog"
+
+# auto-retry detects watchdog cancel reason and skips RETRY_COUNT increment
+assert_contains_regex \
+    "shipwright-auto-retry.yml detects SHIPWRIGHT-CANCEL-REASON: watchdog" \
+    "$(grep 'CANCEL-REASON' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "CANCEL-REASON"
+
+assert_contains_regex \
+    "shipwright-auto-retry.yml skips retry count on watchdog cancel (watchdog_cancel)" \
+    "$(grep 'watchdog_cancel' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "watchdog_cancel"
 
 echo ""
 print_test_results


### PR DESCRIPTION
## Summary

- **Single source of truth**: all three retry caps moved to `config/policy.json` under `retry.*`
- **New `scripts/lib/retry-policy.sh`**: exports `RETRY_MAX_PIPELINE_STARTS`, `RETRY_MAX_AUTO_RETRIES`, `RETRY_ABANDON_AFTER_MINUTES` from policy.json
- **Watchdog cancel detection**: watchdog posts `SHIPWRIGHT-CANCEL-REASON: watchdog`; auto-retry detects and suppresses double dispatch, doesn't increment `RETRY_COUNT`
- **42 static assertions** in `sw-gha-pipeline-test.sh` (16 new for Phase 5)
- Fixed pre-existing `\s` → `[[:space:]]` Bash 3.2 compat issue in auto-retry

## Test plan
- [x] bash scripts/sw-gha-pipeline-test.sh — 42/42 pass
- [x] npm test — all pass
- [ ] CI: test (ubuntu-latest) and test (macos-latest)

## What's next (Phase 6)

Replace HTML-marker protocol with structured pipeline-status.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)