### PR TITLE
refactor(pipeline): phase 6 — replace HTML-marker protocol with structured status JSON

### DIFF
--- a/.github/workflows/pipeline-resume.yml
+++ b/.github/workflows/pipeline-resume.yml
@@ -83,7 +83,18 @@ jobs:
             DETECTED="$OVERRIDE_STAGES"
             SOURCE="manual override"
           else
-            # Try branch state file via gh api (no checkout needed; contents: read is sufficient)
+            # Primary: structured pipeline-status.json (written at each stage transition)
+            STATUS_B64=$(gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-status.json?ref=$BRANCH" \
+              --jq '.content' 2>/dev/null || true)
+            JSON_STAGES=""
+            if [[ -n "$STATUS_B64" ]]; then
+              JSON_STAGES=$(printf '%s' "$STATUS_B64" | base64 -d 2>/dev/null \
+                | jq -r '.completed_stages[]?' 2>/dev/null \
+                | sort -u || true)
+            fi
+
+            # Fallback: try branch state file via gh api (no checkout needed; contents: read is sufficient)
             STATE_B64=$(gh api \
               "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-state.md?ref=$BRANCH" \
               --jq '.content' 2>/dev/null) || STATE_B64=""
@@ -93,15 +104,15 @@ jobs:
               # GitHub API base64 includes line breaks every 60 chars; base64 -d handles them
               # Use grep -E + sed (portable; avoids GNU grep -P dependency)
               BRANCH_STAGES=$(printf '%s' "$STATE_B64" | base64 -d 2>/dev/null \
-                | grep -E '^\s+[a-z_]+: complete' \
+                | grep -E '^[[:space:]]+[a-z_]+: complete' \
                 | sed 's/^[[:space:]]*//' \
                 | sed 's/: complete$//' \
                 | sort -u || true)
             fi
 
-            # Fallback: parse issue comments for SHIPWRIGHT-STAGE markers
+            # Final fallback: parse issue comments for SHIPWRIGHT-STAGE markers
             COMMENT_STAGES=""
-            if [[ -z "$BRANCH_STAGES" ]]; then
+            if [[ -z "$JSON_STAGES" && -z "$BRANCH_STAGES" ]]; then
               COMMENTS=$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
                 --json comments --jq '.comments[].body' 2>/dev/null || true)
               COMMENT_STAGES=$(printf '%s' "$COMMENTS" \
@@ -110,10 +121,12 @@ jobs:
                 | sort -u || true)
             fi
 
-            STAGES_NL="${BRANCH_STAGES:-$COMMENT_STAGES}"
+            STAGES_NL="${JSON_STAGES:-${BRANCH_STAGES:-$COMMENT_STAGES}}"
             DETECTED=$(printf '%s' "$STAGES_NL" | tr '\n' ',' | sed 's/,$//;s/^,//')
 
-            if [[ -n "$BRANCH_STAGES" ]]; then
+            if [[ -n "$JSON_STAGES" ]]; then
+              SOURCE="structured pipeline-status.json ($BRANCH)"
+            elif [[ -n "$BRANCH_STAGES" ]]; then
               SOURCE="branch state file ($BRANCH)"
             elif [[ -n "$COMMENT_STAGES" ]]; then
               SOURCE="issue comments"

--- a/.github/workflows/shipwright-auto-retry.yml
+++ b/.github/workflows/shipwright-auto-retry.yml
@@ -200,6 +200,19 @@ jobs:
 
           echo "Current retry count: $RETRY_COUNT"
 
+          # Primary: read completed_stages and retry_count from pipeline-status.json
+          BRANCH="shipwright/issue-${ISSUE_NUMBER}"
+          STATUS_B64=$(gh api \
+            "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-status.json?ref=$BRANCH" \
+            --jq '.content' 2>/dev/null || true)
+          if [[ -n "$STATUS_B64" ]]; then
+            STATUS_JSON=$(printf '%s' "$STATUS_B64" | base64 -d 2>/dev/null || true)
+            JSON_STAGES=$(echo "$STATUS_JSON" | jq -r '.completed_stages[]?' 2>/dev/null | sort -u || true)
+            JSON_RETRY=$(echo "$STATUS_JSON" | jq -r '.retry_count // empty' 2>/dev/null || true)
+            # JSON retry_count wins over comment-parsed count when available
+            [[ -n "$JSON_RETRY" ]] && RETRY_COUNT="$JSON_RETRY"
+          fi
+
           # Detect watchdog cancels scoped to THIS run — the watchdog already
           # dispatched a retry, so auto-retry must not dispatch a second one.
           # RETRY_COUNT is not incremented because the run was stuck (not a
@@ -227,7 +240,6 @@ jobs:
 
           # Supplement comment-based detection with the branch's authoritative state file.
           # grep -E + sed avoids the GNU grep -P dependency (portable to all GHA runners).
-          BRANCH="shipwright/issue-${ISSUE_NUMBER}"
           STATE_B64=$(gh api \
             "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-state.md?ref=$BRANCH" \
             --jq '.content' 2>/dev/null) || STATE_B64=""
@@ -239,8 +251,8 @@ jobs:
               | sed 's/: complete$//' \
               | sort -u || true)
           fi
-          # Merge both sources; keep newline-separated through the merge for correct sort -u deduplication
-          RAW_STAGES=$(printf '%s\n%s\n' "$RAW_STAGES" "$BRANCH_STAGES" | sort -u | grep -v '^$' || true)
+          # Merge all sources (JSON, comments, state file); keep newline-separated for correct sort -u deduplication
+          RAW_STAGES=$(printf '%s\n%s\n%s\n' "$RAW_STAGES" "$BRANCH_STAGES" "$JSON_STAGES" | sort -u | grep -v '^$' || true)
 
           COMPLETED_STAGES=""
           for stage in $RAW_STAGES; do

--- a/.github/workflows/shipwright-auto-retry.yml
+++ b/.github/workflows/shipwright-auto-retry.yml
@@ -209,8 +209,12 @@ jobs:
             STATUS_JSON=$(printf '%s' "$STATUS_B64" | base64 -d 2>/dev/null || true)
             JSON_STAGES=$(echo "$STATUS_JSON" | jq -r '.completed_stages[]?' 2>/dev/null | sort -u || true)
             JSON_RETRY=$(echo "$STATUS_JSON" | jq -r '.retry_count // empty' 2>/dev/null || true)
-            # JSON retry_count wins over comment-parsed count when available
-            [[ -n "$JSON_RETRY" ]] && RETRY_COUNT="$JSON_RETRY"
+            # Use JSON retry_count only when it exceeds the comment-parsed value —
+            # the JSON field defaults to 0 when RETRY_COUNT wasn't exported to the
+            # pipeline env, so a zero JSON value must not overwrite a comment-derived count.
+            if [[ -n "$JSON_RETRY" && "$JSON_RETRY" -gt "$RETRY_COUNT" ]]; then
+              RETRY_COUNT="$JSON_RETRY"
+            fi
           fi
 
           # Detect watchdog cancels scoped to THIS run — the watchdog already

--- a/.github/workflows/shipwright-sweep.yml
+++ b/.github/workflows/shipwright-sweep.yml
@@ -144,9 +144,24 @@ jobs:
               # Failed but no auto-retry has kicked in yet — dispatch with higher template
               echo "Issue #$issue: failed without retry — dispatching with full template"
 
-              # Extract completed stages from stage event comments
+              # Primary: pipeline-status.json for stage data
+              SWEEP_BRANCH="shipwright/issue-${issue}"
+              STATUS_B64=$(gh api \
+                "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-status.json?ref=$SWEEP_BRANCH" \
+                --jq '.content' 2>/dev/null || true)
+              JSON_STAGES=""
+              if [[ -n "$STATUS_B64" ]]; then
+                JSON_STAGES=$(printf '%s' "$STATUS_B64" | base64 -d 2>/dev/null \
+                  | jq -r '.completed_stages[]?' 2>/dev/null | sort -u || true)
+              fi
+
+              # Extract completed stages from stage event comments (fallback)
               # Only skip pre-build stages on retry — build must always re-run to produce code changes
               RAW_STAGES=$(echo "$COMMENTS" | grep -oE 'SHIPWRIGHT-STAGE: [a-z_]+:complete' | sed 's/SHIPWRIGHT-STAGE: //' | sed 's/:complete//' | sort -u || echo "")
+
+              # Merge JSON and comment sources
+              RAW_STAGES=$(printf '%s\n%s\n' "$RAW_STAGES" "$JSON_STAGES" | sort -u | grep -v '^$' || echo "")
+
               COMPLETED_STAGES=""
               for stage in $RAW_STAGES; do
                 case "$stage" in

--- a/.github/workflows/shipwright-watchdog.yml
+++ b/.github/workflows/shipwright-watchdog.yml
@@ -79,6 +79,17 @@ jobs:
 
             echo "Associated issue: #$ISSUE_NUMBER"
 
+            # Primary: read last_heartbeat from pipeline-status.json on WIP branch
+            BRANCH="shipwright/issue-${ISSUE_NUMBER}"
+            STATUS_B64=$(gh api \
+              "repos/$GITHUB_REPOSITORY/contents/.claude/pipeline-status.json?ref=$BRANCH" \
+              --jq '.content' 2>/dev/null || true)
+            JSON_HEARTBEAT=""
+            if [[ -n "$STATUS_B64" ]]; then
+              JSON_HEARTBEAT=$(printf '%s' "$STATUS_B64" | base64 -d 2>/dev/null \
+                | jq -r '.last_heartbeat // empty' 2>/dev/null || true)
+            fi
+
             # Get issue comments with timestamps to find latest progress signal
             COMMENTS_JSON=$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
               --json comments --jq '.comments[] | {createdAt, body}' 2>/dev/null || echo "")
@@ -95,8 +106,8 @@ jobs:
             # Check for the initial run ID marker: <!-- SHIPWRIGHT-RUN-ID: ... -->
             START_DATE=$(echo "$COMMENTS_JSON" | jq -r "select(.body | contains(\"SHIPWRIGHT-RUN-ID: $RUN_ID\")) | .createdAt" 2>/dev/null | tail -1 || true)
 
-            # Use the most recent signal
-            for date in "$HEARTBEAT_DATE" "$STAGE_DATE" "$START_DATE"; do
+            # Use the most recent signal (JSON heartbeat as primary)
+            for date in "$JSON_HEARTBEAT" "$HEARTBEAT_DATE" "$STAGE_DATE" "$START_DATE"; do
               if [[ -n "$date" && ("$date" > "$LAST_SIGNAL_DATE" || -z "$LAST_SIGNAL_DATE") ]]; then
                 LAST_SIGNAL_DATE="$date"
               fi

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -195,6 +195,49 @@ update_status() {
     write_state
 }
 
+write_pipeline_status_json() {
+    local state_file=".claude/pipeline-status.json"
+    local tmp_file="${state_file}.tmp.$$"
+
+    # Build completed_stages JSON array from STAGE_STATUSES
+    local completed_arr="[]"
+    local stage line
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        stage="${line%%:*}"
+        local st="${line#*:}"
+        if [[ "$st" == "complete" && -n "$stage" ]]; then
+            local _new_arr
+            if _new_arr=$(printf '%s' "$completed_arr" | jq --arg s "$stage" '. + [$s]' 2>/dev/null); then
+                completed_arr="$_new_arr"
+            else
+                completed_arr="[]"
+            fi
+        fi
+    done <<EOF
+$STAGE_STATUSES
+EOF
+
+    # Get current stage (last started, not yet complete)
+    local current_stage=""
+    current_stage=$(echo "$STAGE_STATUSES" | grep ':in_progress$' | tail -1 | cut -d: -f1 || true)
+    [[ -z "$current_stage" ]] && current_stage=$(echo "$STAGE_STATUSES" | grep ':complete$' | tail -1 | cut -d: -f1 || true)
+
+    mkdir -p ".claude" 2>/dev/null || true
+    jq -n \
+        --arg run_id "${GITHUB_RUN_ID:-local}" \
+        --arg branch "shipwright/issue-${ISSUE_NUMBER:-0}" \
+        --arg stage "${current_stage:-}" \
+        --argjson iteration "${CURRENT_ITERATION:-0}" \
+        --argjson retry_count "${RETRY_COUNT:-0}" \
+        --arg last_heartbeat "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg exit_reason "" \
+        --arg error_category "" \
+        --argjson completed_stages "${completed_arr:-[]}" \
+        '{run_id:$run_id,branch:$branch,stage:$stage,iteration:$iteration,retry_count:$retry_count,last_heartbeat:$last_heartbeat,exit_reason:$exit_reason,error_category:$error_category,completed_stages:$completed_stages}' \
+        > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$state_file" 2>/dev/null || { rm -f "$tmp_file" 2>/dev/null; return 1; }
+}
+
 mark_stage_complete() {
     local stage_id="$1"
     record_stage_end "$stage_id"
@@ -288,6 +331,9 @@ mark_stage_complete() {
             '{stage: $stage, status: $status, issue: $issue, goal: $goal, template: $template, ts: "'"$(now_iso)"'"}')
         db_save_checkpoint "pipeline-${SHIPWRIGHT_PIPELINE_ID:-$$}" "$checkpoint_data" 2>/dev/null || true
     fi
+
+    # Write structured JSON status file for meta-workflows
+    write_pipeline_status_json || warn "Failed to write pipeline-status.json"
 }
 
 persist_artifacts() {

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -300,7 +300,7 @@ assert_contains_regex \
 
 assert_contains_regex \
     "pipeline-state.sh calls write_pipeline_status_json from mark_stage_complete" \
-    "$(grep -A100 'mark_stage_complete()' "$PIPELINE_STATE_SH" | grep 'write_pipeline_status_json' || true)" \
+    "$(awk '/^mark_stage_complete\(\)/,/^\}/' "$PIPELINE_STATE_SH" | grep 'write_pipeline_status_json' || true)" \
     "write_pipeline_status_json"
 
 assert_contains_regex \

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/lib/test-helpers.sh"
 
 WORKFLOW="$SCRIPT_DIR/../.github/workflows/shipwright-pipeline.yml"
 
-print_test_header "GHA Pipeline Workflow: Phases 1-5 — Observability, Ordering, Persistence, Retry Caps"
+print_test_header "GHA Pipeline Workflow: Phases 1-6 — Observability, Ordering, Persistence, Retry Caps, JSON Status"
 
 # ─── npm cache ─────────────────────────────────────────────────────────────
 
@@ -285,6 +285,58 @@ assert_contains_regex \
     "shipwright-auto-retry.yml skips retry count on watchdog cancel (watchdog_cancel)" \
     "$(grep 'watchdog_cancel' "$AUTO_RETRY_WORKFLOW" || true)" \
     "watchdog_cancel"
+
+echo ""
+
+# ─── Phase 6: pipeline-status.json ─────────────────────────────────────────
+
+PIPELINE_STATE_SH="$SCRIPT_DIR/lib/pipeline-state.sh"
+RESUME_WORKFLOW="$SCRIPT_DIR/../.github/workflows/pipeline-resume.yml"
+
+assert_contains_regex \
+    "pipeline-state.sh has write_pipeline_status_json function" \
+    "$(grep 'write_pipeline_status_json' "$PIPELINE_STATE_SH" || true)" \
+    "write_pipeline_status_json"
+
+assert_contains_regex \
+    "pipeline-state.sh calls write_pipeline_status_json from mark_stage_complete" \
+    "$(grep -A100 'mark_stage_complete()' "$PIPELINE_STATE_SH" | grep 'write_pipeline_status_json' || true)" \
+    "write_pipeline_status_json"
+
+assert_contains_regex \
+    "shipwright-watchdog.yml reads pipeline-status.json for last_heartbeat" \
+    "$(grep 'pipeline-status\.json' "$WATCHDOG_WORKFLOW" || true)" \
+    "pipeline-status\.json"
+
+assert_contains_regex \
+    "shipwright-auto-retry.yml reads pipeline-status.json for completed_stages" \
+    "$(grep 'pipeline-status\.json' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "pipeline-status\.json"
+
+assert_contains_regex \
+    "pipeline-resume.yml reads pipeline-status.json as primary stage source" \
+    "$(grep 'pipeline-status\.json' "$RESUME_WORKFLOW" || true)" \
+    "pipeline-status\.json"
+
+assert_contains_regex \
+    "shipwright-sweep.yml reads pipeline-status.json for completed_stages" \
+    "$(grep 'pipeline-status\.json' "$SCRIPT_DIR/../.github/workflows/shipwright-sweep.yml" 2>/dev/null || echo "")" \
+    "pipeline-status\.json"
+
+assert_contains_regex \
+    "shipwright-watchdog.yml uses JSON_HEARTBEAT as primary signal" \
+    "$(grep 'JSON_HEARTBEAT' "$WATCHDOG_WORKFLOW" || true)" \
+    "JSON_HEARTBEAT"
+
+assert_contains_regex \
+    "shipwright-auto-retry.yml uses JSON_RETRY for retry_count" \
+    "$(grep 'JSON_RETRY' "$AUTO_RETRY_WORKFLOW" || true)" \
+    "JSON_RETRY"
+
+assert_contains_regex \
+    "pipeline-resume.yml fixes Bash 3.2 \\\\s → [[:space:]] in grep" \
+    "$(grep 'grep -E' "$RESUME_WORKFLOW" || true)" \
+    "\[\[:space:\]\]"
 
 echo ""
 print_test_results


### PR DESCRIPTION
## Summary

- pipeline-state.sh: New write_pipeline_status_json() writes .claude/pipeline-status.json atomically at every stage transition.
- shipwright-watchdog.yml: Reads JSON_HEARTBEAT from pipeline-status.json as primary freshness signal.
- shipwright-auto-retry.yml: Reads JSON_STAGES + JSON_RETRY; merges with comment fallback.
- pipeline-resume.yml: Reads pipeline-status.json as primary; fixes Bash 3.2 backslash-s bug.
- shipwright-sweep.yml: Reads pipeline-status.json in Check 4 failure path.
- sw-gha-pipeline-test.sh: 9 new Phase 6 assertions (52 total, all passing).

## Test plan
- 52/52 sw-gha-pipeline-test pass
- 85/85 sw-lib-pipeline-state-test pass

Generated with Claude Code