### PR TITLE
fix: introduce CI_JOB_START_EPOCH to prevent build loop insta-exit across CI jobs

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -393,6 +393,14 @@ jobs:
             > .git/hooks/commit-msg
           chmod +x .git/hooks/commit-msg
 
+      - name: Record CI job start epoch
+        run: |
+          # Per-CI-job budget anchor for check_time_budget() in loop-convergence.sh.
+          # Ephemeral — never written to .claude/pipeline-state.md. Replaces the
+          # PIPELINE_RUN_EPOCH export from commit 591c8e8, which inadvertently used
+          # a persisted field that survived across CI jobs via the WIP branch.
+          echo "CI_JOB_START_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Restore persistent state
         run: |
           mkdir -p ~/.shipwright/memory

--- a/scripts/lib/loop-convergence.sh
+++ b/scripts/lib/loop-convergence.sh
@@ -144,6 +144,7 @@ check_time_budget() {
     # errors under set -e; treat them as "no limit" (return 0 = continue loop).
     local _ref_epoch="${CI_JOB_START_EPOCH:-${LOOP_START_EPOCH:-}}"
     [[ -z "$_ref_epoch" || "$_ref_epoch" == "0" ]] && return 0
+    [[ ! "$_ref_epoch" =~ ^[0-9]+$ ]] && return 0
     [[ ! "$_job_timeout_min" =~ ^[0-9]+$ || "$_job_timeout_min" -le 0 ]] && return 0
     local _now _elapsed_min _remaining_min
     _now=$(now_epoch 2>/dev/null) || return 0

--- a/scripts/lib/loop-convergence.sh
+++ b/scripts/lib/loop-convergence.sh
@@ -133,20 +133,33 @@ check_circuit_breaker() {
 
 check_time_budget() {
     # Guard: stop starting a new iteration if <20 min remains in the GHA job.
-    # Uses SHIPWRIGHT_JOB_TIMEOUT_MINUTES (set by the pipeline) and the pipeline-level
-    # start epoch. PIPELINE_RUN_EPOCH (exported by pipeline-stages-build.sh before
-    # invoking sw loop) is used when available so that compound_quality→build re-entries
-    # don't reset the elapsed clock. Falls back to LOOP_START_EPOCH for standalone
-    # sw loop invocations that have no pipeline wrapper.
+    # Anchors on CI_JOB_START_EPOCH (set once per GHA job by the pipeline workflow,
+    # never persisted to disk). Falls back to LOOP_START_EPOCH for standalone
+    # `sw loop` invocations with no CI wrapper.
+    # PIPELINE_RUN_EPOCH is intentionally NOT read here: it survives across CI jobs
+    # via the WIP branch, making it an unsafe budget anchor. It remains the
+    # historical "pipeline first start" marker for display purposes only.
     local _job_timeout_min="${SHIPWRIGHT_JOB_TIMEOUT_MINUTES:-0}"
     # Require a valid positive integer — non-numeric values would cause arithmetic
     # errors under set -e; treat them as "no limit" (return 0 = continue loop).
-    local _ref_epoch="${PIPELINE_RUN_EPOCH:-${LOOP_START_EPOCH:-}}"
+    local _ref_epoch="${CI_JOB_START_EPOCH:-${LOOP_START_EPOCH:-}}"
     [[ -z "$_ref_epoch" || "$_ref_epoch" == "0" ]] && return 0
     [[ ! "$_job_timeout_min" =~ ^[0-9]+$ || "$_job_timeout_min" -le 0 ]] && return 0
     local _now _elapsed_min _remaining_min
     _now=$(now_epoch 2>/dev/null) || return 0
     _elapsed_min=$(( (_now - _ref_epoch) / 60 ))
+    # Stale-epoch defense: GHA hard-kills the job at SHIPWRIGHT_JOB_TIMEOUT_MINUTES,
+    # so _elapsed_min > _job_timeout_min is physically impossible during a healthy run.
+    # If we see it, the anchor is from a prior CI job — some entry point bypassed
+    # the workflow step that sets CI_JOB_START_EPOCH. Continue rather than insta-exit;
+    # emit telemetry to surface the regression.
+    if (( _elapsed_min > _job_timeout_min )); then
+        emit_event "loop.time_budget_stale_ref" \
+            "elapsed_min=${_elapsed_min}" \
+            "ref_epoch=${_ref_epoch}" \
+            "job_timeout_min=${_job_timeout_min}" 2>/dev/null || true
+        return 0
+    fi
     _remaining_min=$(( _job_timeout_min - _elapsed_min ))
     if (( _remaining_min < 20 )); then
         warn "Less than 20 min remaining in GHA job (${_remaining_min}m) — stopping build loop to allow cleanup"

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -577,12 +577,13 @@ ${_build_recall_ctx}"
     # Export so SW_LOG_PROMPTS=github|both can post/update GitHub comments from the loop subprocess.
     export ISSUE_NUMBER="${ISSUE_NUMBER:-}"
     export PROGRESS_COMMENT_ID="${PROGRESS_COMMENT_ID:-}"
-    # Export pipeline-level start epoch so check_time_budget in the loop subprocess
-    # measures elapsed time from pipeline start (not from each loop re-entry).
-    # Use empty-string default (not "0") so the loop can still fall back to
-    # LOOP_START_EPOCH when PIPELINE_RUN_EPOCH was never populated (e.g. resume
-    # paths with older pipeline state).
-    export PIPELINE_RUN_EPOCH="${PIPELINE_RUN_EPOCH:-}"
+    # Export per-CI-job start epoch. Set by the workflow's "Record CI job start epoch"
+    # step (.github/workflows/shipwright-pipeline.yml). Empty when running outside CI
+    # (local sw pipeline) — check_time_budget falls back to LOOP_START_EPOCH.
+    # Replaces PIPELINE_RUN_EPOCH export from commit 591c8e8: that field is persisted
+    # across CI jobs in .claude/pipeline-state.md and is therefore an unsafe budget anchor.
+    # PIPELINE_RUN_EPOCH remains in the state file for historical display only.
+    export CI_JOB_START_EPOCH="${CI_JOB_START_EPOCH:-}"
     sw loop "${loop_args[@]}" < /dev/null 2>"$_token_log" || {
         local _loop_exit=$?
         parse_claude_tokens "$_token_log"

--- a/scripts/sw-gha-pipeline-test.sh
+++ b/scripts/sw-gha-pipeline-test.sh
@@ -472,21 +472,21 @@ assert_contains_regex \
     "$(grep 'gh issue view' "$SCRIPT_DIR/sw-predictive.sh" || true)" \
     "gh issue view"
 
-# Phase 1 fix (Bug C): check_time_budget must use PIPELINE_RUN_EPOCH not LOOP_START_EPOCH
+# check_time_budget must use CI_JOB_START_EPOCH (per-job ephemeral anchor, not persisted field)
 assert_contains_regex \
-    "check_time_budget in loop-convergence.sh uses PIPELINE_RUN_EPOCH (not loop-level epoch)" \
-    "$(grep 'PIPELINE_RUN_EPOCH' "$LOOP_CONVERGENCE_SH" || true)" \
-    "PIPELINE_RUN_EPOCH"
+    "check_time_budget in loop-convergence.sh uses CI_JOB_START_EPOCH (not persisted PIPELINE_RUN_EPOCH)" \
+    "$(grep 'CI_JOB_START_EPOCH' "$LOOP_CONVERGENCE_SH" || true)" \
+    "CI_JOB_START_EPOCH"
 
 assert_contains_regex \
-    "loop-convergence.sh check_time_budget falls back to LOOP_START_EPOCH when PIPELINE_RUN_EPOCH absent" \
-    "$(grep 'LOOP_START_EPOCH\|PIPELINE_RUN_EPOCH' "$LOOP_CONVERGENCE_SH" || true)" \
+    "loop-convergence.sh check_time_budget falls back to LOOP_START_EPOCH when CI_JOB_START_EPOCH absent" \
+    "$(grep 'LOOP_START_EPOCH\|CI_JOB_START_EPOCH' "$LOOP_CONVERGENCE_SH" || true)" \
     "LOOP_START_EPOCH"
 
 assert_contains_regex \
-    "pipeline-stages-build.sh exports PIPELINE_RUN_EPOCH before invoking sw loop" \
-    "$(grep 'export PIPELINE_RUN_EPOCH' "$PIPELINE_STAGES_BUILD_SH" || true)" \
-    "export PIPELINE_RUN_EPOCH"
+    "pipeline-stages-build.sh exports CI_JOB_START_EPOCH before invoking sw loop" \
+    "$(grep 'export CI_JOB_START_EPOCH' "$PIPELINE_STAGES_BUILD_SH" || true)" \
+    "export CI_JOB_START_EPOCH"
 
 echo ""
 print_test_results

--- a/scripts/sw-lib-loop-convergence-test.sh
+++ b/scripts/sw-lib-loop-convergence-test.sh
@@ -231,6 +231,67 @@ _t7_warn=$(_count "$WARN_CALLS")
 assert_eq "Test 7: emit_event still fires on restart detection (now 5)" "5" "$_t7_emit"
 assert_eq "Test 7: warn still fires on restart detection (now 5)" "5" "$_t7_warn"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# check_time_budget — CI_JOB_START_EPOCH path (issue #460 / commit 591c8e8 fix)
+# ═══════════════════════════════════════════════════════════════════════════════
+# now_epoch is sourced from helpers.sh via loop-convergence.sh (line 66 above).
+# Redefine AFTER source — bash function redefinition replaces the prior binding.
+# Do NOT invoke check_time_budget inside $(...) — overrides don't cross subshells.
+_MOCK_NOW=""
+now_epoch() { echo "$_MOCK_NOW"; }
+_BASE="$(date +%s)"
+
+print_test_section "check_time_budget T1: recent CI_JOB_START_EPOCH → continue"
+unset PIPELINE_RUN_EPOCH LOOP_START_EPOCH || true
+export SHIPWRIGHT_JOB_TIMEOUT_MINUTES=300
+export CI_JOB_START_EPOCH=$(( _BASE - 100 ))     # 1m 40s elapsed
+_MOCK_NOW="$_BASE"
+check_time_budget
+assert_eq "T1: recent epoch returns 0 (loop continues)" "0" "$?"
+
+print_test_section "check_time_budget T2: nearly-exhausted CI_JOB_START_EPOCH → stop"
+export CI_JOB_START_EPOCH=$(( _BASE - 17000 ))   # 283m elapsed; 17m remaining < 20m threshold
+_MOCK_NOW="$_BASE"
+_ctb_result=0; check_time_budget || _ctb_result=$?
+assert_eq "T2: near-exhausted returns 1 (loop stops)" "1" "$_ctb_result"
+
+print_test_section "check_time_budget T3a: CI_JOB_START_EPOCH wins over PIPELINE_RUN_EPOCH above"
+# Both set. PIPELINE_RUN_EPOCH is nearly-exhausted (would force return 1 if consulted);
+# CI_JOB_START_EPOCH is recent. Catches re-introduction of PIPELINE_RUN_EPOCH ABOVE
+# CI_JOB_START_EPOCH in the chain (the original 591c8e8 structure).
+# Using a year-2001 PIPELINE_RUN_EPOCH would be defeated by the stale-ref defense —
+# a nearly-exhausted value produces a real regression signal.
+export PIPELINE_RUN_EPOCH=$(( _BASE - 17000 ))   # nearly-exhausted: 17m remaining if consulted
+export CI_JOB_START_EPOCH=$(( _BASE - 100 ))     # recent: controls correct result
+_MOCK_NOW="$_BASE"
+check_time_budget
+assert_eq "T3a: CI_JOB_START_EPOCH dominates: returns 0" "0" "$?"
+
+print_test_section "check_time_budget T3b: PIPELINE_RUN_EPOCH not consulted as sole fallback"
+# Only PIPELINE_RUN_EPOCH set; CI_JOB_START_EPOCH and LOOP_START_EPOCH unset.
+# If PIPELINE_RUN_EPOCH were in the chain: _remaining_min=17 < 20 → return 1.
+# If it is NOT in the chain: _ref_epoch is empty → [[ -z ]] guard → return 0.
+# Same nearly-exhausted value: year-2001 would pass via stale-ref defense → vacuous.
+unset CI_JOB_START_EPOCH LOOP_START_EPOCH || true
+export PIPELINE_RUN_EPOCH=$(( _BASE - 17000 ))   # nearly-exhausted: would force return 1 if consulted
+_MOCK_NOW="$_BASE"
+check_time_budget
+assert_eq "T3b: PIPELINE_RUN_EPOCH not in chain: returns 0 (empty _ref_epoch)" "0" "$?"
+
+print_test_section "check_time_budget T4: stale-ref defense fires when anchor is impossibly old"
+unset CI_JOB_START_EPOCH PIPELINE_RUN_EPOCH || true
+export LOOP_START_EPOCH=1000000000               # year 2001 — forces _elapsed_min > _job_timeout_min
+_MOCK_NOW="$_BASE"
+: > "$EMIT_CALLS"                                # clear previous emit captures
+check_time_budget
+assert_eq "T4: stale-ref defense returns 0 (not insta-exit)" "0" "$?"
+# emit_event mock (line 44) writes "$*" space-joined onto one line.
+# $EMIT_CALLS: "loop.time_budget_stale_ref elapsed_min=N ref_epoch=N job_timeout_min=N"
+assert_contains "T4: stale-ref defense emits loop.time_budget_stale_ref" \
+    "$(cat "$EMIT_CALLS")" "loop.time_budget_stale_ref"
+
+unset PIPELINE_RUN_EPOCH CI_JOB_START_EPOCH LOOP_START_EPOCH SHIPWRIGHT_JOB_TIMEOUT_MINUTES || true
+
 # Emit explicit "$PASS/$TOTAL pass" as the final visible line for DoD audit parsers.
 printf '%s/%s pass\n' "$PASS" "$TOTAL"
 print_test_results


### PR DESCRIPTION
## Summary

- **Root cause**: `PIPELINE_RUN_EPOCH` is persisted to `.claude/pipeline-state.md` and survives across CI jobs via the WIP branch. When a job starts hours after pipeline init, `check_time_budget()` computed `_remaining_min ≈ -1002` → loop exits before Claude ever ran (~24s builds, no iteration prompts)
- **Fix**: Introduce `CI_JOB_START_EPOCH` — ephemeral env var set once per GHA job in the workflow, never persisted. `check_time_budget()` anchors on it (falling back to `LOOP_START_EPOCH` for local runs). `PIPELINE_RUN_EPOCH` retains its historical/display role only
- **Stale-ref defense**: if `_elapsed_min > _job_timeout_min` (impossible in healthy run), emit `loop.time_budget_stale_ref` event and return 0 instead of insta-exiting

## Changes

| File | Change |
|------|--------|
| `.github/workflows/shipwright-pipeline.yml` | New "Record CI job start epoch" step in pipeline job after "Configure git" |
| `scripts/lib/loop-convergence.sh` | Switch `_ref_epoch` to `CI_JOB_START_EPOCH`; add stale-ref guard; update comment |
| `scripts/lib/pipeline-stages-build.sh` | Replace `PIPELINE_RUN_EPOCH` export with `CI_JOB_START_EPOCH` |
| `scripts/sw-lib-loop-convergence-test.sh` | 5 new regression tests (T1–T4, with T3 split into 3a/3b) |

## Test plan

- [x] bash scripts/sw-lib-loop-convergence-test.sh — all 24 tests pass (5 new cases)
- [x] T3a: CI_JOB_START_EPOCH wins over a nearly-exhausted PIPELINE_RUN_EPOCH (catches re-introduction above)
- [x] T3b: PIPELINE_RUN_EPOCH not consulted as sole fallback (catches re-introduction below)
- [x] T4: stale-ref defense fires for impossibly old anchors and emits telemetry
- [ ] CI re-trigger of issue #460: Agent Prompt - Iteration 1 appears within ~10s of "Build started"

Generated with Claude Code