### PR TITLE
fix: hoist iter-2 marching orders and expand cumulative progress to full branch

### DIFF
--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -212,7 +212,7 @@ Fix these specific errors. Each line above is one distinct error from the test o
             local _test_summary
             _test_summary="$(echo "$TEST_OUTPUT" | grep -E 'pass|All [0-9]+ tests passed' | tail -3 || true)"
             test_section="TESTS PASSED.
-${_test_summary:-(see iteration-${ITERATION}.log for full output)}"
+${_test_summary:-(see iteration-$((ITERATION - 1)).log for full output)}"
         else
             test_section="$TEST_OUTPUT"
         fi
@@ -516,9 +516,10 @@ ${_test_tail}
     local cumulative_section=""
     if [[ "${ITERATION:-1}" -gt 1 ]]; then
         local _base_branch _merge_base
-        _base_branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||')"
+        # || true prevents errexit from firing when origin/HEAD is absent (no remote / offline repo).
         # git rev-parse --abbrev-ref outputs 'origin/HEAD' verbatim (→ 'HEAD' after sed) when the
-        # ref doesn't exist (no remote). Treat 'HEAD' as the failure sentinel.
+        # ref doesn't exist. Treat 'HEAD' as the failure sentinel alongside the empty-string case.
+        _base_branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||' || true)"
         [[ -z "$_base_branch" || "$_base_branch" == "HEAD" ]] && _base_branch="main"
         _merge_base="$(git -C "$PROJECT_ROOT" merge-base "origin/${_base_branch}" HEAD 2>/dev/null \
             || git -C "$PROJECT_ROOT" merge-base "$_base_branch" HEAD 2>/dev/null \

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -207,7 +207,15 @@ Fix these specific errors. Each line above is one distinct error from the test o
     elif [[ -z "$TEST_PASSED" ]]; then
         test_section="No test results yet (first iteration). Test command: $TEST_CMD"
     elif $TEST_PASSED; then
-        test_section="$TEST_OUTPUT"
+        if ! $_needs_full_context; then
+            # Iter 2+: tests pass — the relevant signal is gate feedback, not 60 lines of checkmarks.
+            local _test_summary
+            _test_summary="$(echo "$TEST_OUTPUT" | grep -E 'pass|All [0-9]+ tests passed' | tail -3 || true)"
+            test_section="TESTS PASSED.
+${_test_summary:-(see iteration-${ITERATION}.log for full output)}"
+        else
+            test_section="$TEST_OUTPUT"
+        fi
     elif ! $_needs_full_context && [[ -n "$error_summary_section" ]]; then
         # Iter 2+: structured errors available — demote full output, primary signal is the summary below
         test_section="TESTS FAILED — see Structured Error Summary below for specific errors.
@@ -501,15 +509,29 @@ ${_test_tail}
         RESUMED_TEST_OUTPUT=""
     fi
 
-    # Build cumulative progress summary showing all iterations' work
+    # Build cumulative progress summary showing all commits on the WIP branch.
+    # Use merge-base with the default branch (mirrors run_holistic_gate in sw-loop.sh:1873-1888)
+    # so the section spans ALL CI jobs on this branch, not just the current job's LOOP_START_COMMIT.
+    # Falls back to LOOP_START_COMMIT if merge-base is unavailable (local-only repo, no remote).
     local cumulative_section=""
-    if [[ -n "${LOOP_START_COMMIT:-}" ]] && [[ "$ITERATION" -gt 1 ]]; then
-        local cum_stat
-        cum_stat="$(git -C "$PROJECT_ROOT" diff --stat "${LOOP_START_COMMIT}..HEAD" 2>/dev/null | tail -1 || true)"
-        if [[ -n "$cum_stat" ]]; then
-            cumulative_section="## Cumulative Progress (all iterations combined)
+    if [[ "${ITERATION:-1}" -gt 1 ]]; then
+        local _base_branch _merge_base
+        _base_branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref origin/HEAD 2>/dev/null | sed 's|origin/||')"
+        # git rev-parse --abbrev-ref outputs 'origin/HEAD' verbatim (→ 'HEAD' after sed) when the
+        # ref doesn't exist (no remote). Treat 'HEAD' as the failure sentinel.
+        [[ -z "$_base_branch" || "$_base_branch" == "HEAD" ]] && _base_branch="main"
+        _merge_base="$(git -C "$PROJECT_ROOT" merge-base "origin/${_base_branch}" HEAD 2>/dev/null \
+            || git -C "$PROJECT_ROOT" merge-base "$_base_branch" HEAD 2>/dev/null \
+            || echo "${LOOP_START_COMMIT:-}")"
+        if [[ -n "$_merge_base" ]]; then
+            local cum_stat
+            cum_stat="$(git -C "$PROJECT_ROOT" diff --stat "${_merge_base}..HEAD" 2>/dev/null | head -40 || true)"
+            if [[ -n "$cum_stat" ]]; then
+                cumulative_section="## Cumulative Progress (full branch vs ${_base_branch})
 ${cum_stat}
+
 "
+            fi
         fi
     fi
 
@@ -537,8 +559,24 @@ ${resume_section}
 ## Your Goal
 ${prompt_goal}
 
-${pipeline_context_section}${cumulative_section}
-${task_section:+## Task Progress
+## Instructions
+1. Read the codebase and understand the current state
+2. Identify the highest-priority remaining work toward the goal
+3. Implement ONE meaningful chunk of progress
+4. Run tests if a test command exists: ${TEST_CMD:-"(none)"}
+5. Commit your work with a descriptive message
+6. When the goal is FULLY achieved, output exactly: LOOP_COMPLETE
+
+${error_summary_section:+$error_summary_section
+}${holistic_feedback_section:+$holistic_feedback_section
+}${quality_gate_detail_section:+$quality_gate_detail_section
+}${rejection_notice_section:+$rejection_notice_section
+}${audit_feedback_section:+$audit_feedback_section
+}${zero_progress_notice:+$zero_progress_notice
+}${stuckness_section:+$stuckness_section
+}${alt_strategy_section:+$alt_strategy_section
+}${iteration_guidance_section:+$iteration_guidance_section
+}${pipeline_context_section}${cumulative_section}${task_section:+## Task Progress
 $task_section
 
 }## Current Progress
@@ -550,29 +588,14 @@ ${git_log}
 ${recent_commits_section}## Test Results (Previous Iteration)
 ${test_section}
 
-${error_summary_section:+$error_summary_section
-}
-${iteration_guidance_section:+$iteration_guidance_section
-}
 ${memory_section:+## Memory Context
 $memory_section
-}
-${discovery_section:+## Cross-Pipeline Learnings
+}${discovery_section:+## Cross-Pipeline Learnings
 $discovery_section
-}
-${dora_section:+$dora_section
-}
-${intelligence_section:+$intelligence_section
-}
-${restart_section:+$restart_section
-}
-## Instructions
-1. Read the codebase and understand the current state
-2. Identify the highest-priority remaining work toward the goal
-3. Implement ONE meaningful chunk of progress
-4. Run tests if a test command exists: ${TEST_CMD:-"(none)"}
-5. Commit your work with a descriptive message
-6. When the goal is FULLY achieved, output exactly: LOOP_COMPLETE
+}${dora_section:+$dora_section
+}${intelligence_section:+$intelligence_section
+}${restart_section:+$restart_section
+}${audit_section}
 
 ## Context Efficiency
 - Batch independent tool calls in parallel — avoid sequential round-trips
@@ -581,22 +604,6 @@ ${restart_section:+$restart_section
 - Filter tool results with grep/jq before reasoning over them
 - Keep working memory lean — summarize completed steps, don't preserve full outputs
 
-${audit_section}
-
-${audit_feedback_section}
-
-${holistic_feedback_section}
-
-${quality_gate_detail_section:+$quality_gate_detail_section
-}
-${rejection_notice_section}
-
-${zero_progress_notice}
-
-${stuckness_section}
-
-${alt_strategy_section:+$alt_strategy_section
-}
 ## Rules
 - Focus on ONE task per iteration — do it well
 - Always commit with descriptive messages

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -3464,9 +3464,10 @@ test_compose_prompt_iter2_instructions_before_test_results() {
 
     rm -rf "$tmp_dir"
 
+    # || true prevents set -e / pipefail from aborting the suite when grep exits 1 (no match)
     local instr_line test_line
-    instr_line=$(echo "$output" | grep -n "^## Instructions" | head -1 | cut -d: -f1)
-    test_line=$(echo "$output" | grep -n "^## Test Results" | head -1 | cut -d: -f1)
+    instr_line=$(echo "$output" | grep -n "^## Instructions" | head -1 | cut -d: -f1 || true)
+    test_line=$(echo "$output" | grep -n "^## Test Results" | head -1 | cut -d: -f1 || true)
 
     if [[ -z "$instr_line" || -z "$test_line" ]]; then
         echo "Could not find ## Instructions (line ${instr_line:-?}) or ## Test Results (line ${test_line:-?}) in iter-2 prompt"
@@ -3551,9 +3552,11 @@ test_compose_prompt_iter2_cumulative_uses_merge_base() {
         return 1
     fi
 
-    # Per-file stats present — must be more than one file line
+    # Per-file stats present — must be more than one file line.
+    # grep -c exits 1 on no matches but still prints "0"; || echo 0 would produce "0\n0".
+    # Use || true and default separately to guarantee a single integer.
     local file_line_count
-    file_line_count=$(echo "$output" | grep -A 20 "Cumulative Progress (full branch vs" | grep -c "\.txt" || echo 0)
+    file_line_count=$(echo "$output" | grep -A 20 "Cumulative Progress (full branch vs" | grep -c "\.txt" || true)
     if [[ "${file_line_count:-0}" -lt 2 ]]; then
         echo "Expected at least 2 file lines in cumulative progress, got ${file_line_count:-0}"
         return 1

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -3439,6 +3439,129 @@ test_compose_prompt_emits_context_event() {
     fi
 }
 
+# ──────────────────────────────────────────────────────────────────────────────
+# 67. compose_prompt iter 2 — Instructions precedes Test Results
+# ──────────────────────────────────────────────────────────────────────────────
+test_compose_prompt_iter2_instructions_before_test_results() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cp-test-iter2-order.XXXXXX")
+
+    local stub_file="$tmp_dir/stubs.sh"
+    _write_compose_prompt_stubs "$stub_file"
+
+    local output
+    output=$(
+        # shellcheck disable=SC1090
+        source "$stub_file"
+        export ITERATION=2
+        export TEST_PASSED=true
+        export TEST_OUTPUT="TESTS PASSED"
+        unset _LOOP_ITERATION_LOADED
+        # shellcheck disable=SC1090
+        source "$SCRIPT_DIR/lib/loop-iteration.sh"
+        compose_prompt
+    ) 2>/dev/null || output=""
+
+    rm -rf "$tmp_dir"
+
+    local instr_line test_line
+    instr_line=$(echo "$output" | grep -n "^## Instructions" | head -1 | cut -d: -f1)
+    test_line=$(echo "$output" | grep -n "^## Test Results" | head -1 | cut -d: -f1)
+
+    if [[ -z "$instr_line" || -z "$test_line" ]]; then
+        echo "Could not find ## Instructions (line ${instr_line:-?}) or ## Test Results (line ${test_line:-?}) in iter-2 prompt"
+        return 1
+    fi
+
+    if [[ "$instr_line" -lt "$test_line" ]]; then
+        return 0
+    else
+        echo "## Instructions (line $instr_line) should appear before ## Test Results (line $test_line) in iter-2 prompt"
+        return 1
+    fi
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# 68. compose_prompt iter 2 cumulative progress uses merge-base (full branch)
+# ──────────────────────────────────────────────────────────────────────────────
+test_compose_prompt_iter2_cumulative_uses_merge_base() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cp-test-iter2-mergebase.XXXXXX")
+
+    # Two WIP commits on a branch from main.
+    # LOOP_START_COMMIT is set to the FIRST WIP commit (simulating a CI-job reset
+    # where only commit 2 is "in scope" for the current job). The cumulative section
+    # must show BOTH files because it uses merge-base, not LOOP_START_COMMIT.
+    local git_dir="$tmp_dir/repo"
+    mkdir -p "$git_dir"
+    git -C "$git_dir" init --quiet
+    git -C "$git_dir" config user.email "test@test.com"
+    git -C "$git_dir" config user.name "Test"
+    echo "init" > "$git_dir/init.txt"
+    git -C "$git_dir" add init.txt
+    git -C "$git_dir" commit -m "initial" --quiet
+    # Rename initial branch to 'main' so git merge-base "main" HEAD works on
+    # systems where init.defaultBranch is 'master' instead of 'main'.
+    git -C "$git_dir" branch -M main 2>/dev/null || true
+    # Branch off main so merge-base resolves to the initial commit (not HEAD)
+    git -C "$git_dir" checkout -b feature --quiet
+    # First WIP commit
+    echo "file1 content" > "$git_dir/file1.txt"
+    git -C "$git_dir" add file1.txt
+    git -C "$git_dir" commit -m "add file1" --quiet
+    local ci_job_start
+    ci_job_start=$(git -C "$git_dir" rev-parse HEAD)
+    # Sanity: if we can't determine the SHA, skip gracefully
+    [[ -z "$ci_job_start" ]] && { rm -rf "$tmp_dir"; echo "git rev-parse failed in test setup"; return 1; }
+    # Second WIP commit (what the current CI job added)
+    echo "file2 content" > "$git_dir/file2.txt"
+    git -C "$git_dir" add file2.txt
+    git -C "$git_dir" commit -m "add file2" --quiet
+
+    local stub_file="$tmp_dir/stubs.sh"
+    _write_compose_prompt_stubs "$stub_file"
+
+    local output
+    output=$(
+        # shellcheck disable=SC1090
+        source "$stub_file"
+        export ITERATION=2
+        export LOOP_START_COMMIT="$ci_job_start"
+        export PROJECT_ROOT="$git_dir"
+        unset _LOOP_ITERATION_LOADED
+        # shellcheck disable=SC1090
+        source "$SCRIPT_DIR/lib/loop-iteration.sh"
+        compose_prompt
+    ) 2>/dev/null || output=""
+
+    rm -rf "$tmp_dir"
+
+    if ! echo "$output" | grep -qF "Cumulative Progress (full branch vs"; then
+        echo "Expected 'Cumulative Progress (full branch vs ...)' heading in iter-2 prompt"
+        return 1
+    fi
+
+    if ! echo "$output" | grep -q "file1\.txt"; then
+        echo "Expected file1.txt in cumulative progress (merge-base must include commits before LOOP_START_COMMIT)"
+        return 1
+    fi
+
+    if ! echo "$output" | grep -q "file2\.txt"; then
+        echo "Expected file2.txt in cumulative progress"
+        return 1
+    fi
+
+    # Per-file stats present — must be more than one file line
+    local file_line_count
+    file_line_count=$(echo "$output" | grep -A 20 "Cumulative Progress (full branch vs" | grep -c "\.txt" || echo 0)
+    if [[ "${file_line_count:-0}" -lt 2 ]]; then
+        echo "Expected at least 2 file lines in cumulative progress, got ${file_line_count:-0}"
+        return 1
+    fi
+
+    return 0
+}
+
 main() {
     local filter="${1:-}"
 
@@ -3559,6 +3682,8 @@ main() {
         "test_compose_prompt_iter2_reference_trailer:Loop: compose_prompt iter 2 appends pipeline-artifacts reference trailer"
         "test_compose_prompt_iter1_no_reference_trailer:Loop: compose_prompt iter 1 does NOT include Reference trailer"
         "test_compose_prompt_emits_context_event:Loop: compose_prompt emits context.iteration_prompt event"
+        "test_compose_prompt_iter2_instructions_before_test_results:Loop: compose_prompt iter 2 — Instructions precedes Test Results"
+        "test_compose_prompt_iter2_cumulative_uses_merge_base:Loop: compose_prompt iter 2 cumulative progress uses merge-base (full branch vs main)"
         "test_watchdog_handler_removed:Phase4: _soft_timeout_handler function removed from sw-pipeline.sh"
         "test_watchdog_usr1_trap_removed:Phase4: trap USR1 for soft-timeout removed from sw-pipeline.sh"
         "test_watchdog_pid_var_removed:Phase4: _WATCHDOG_PID variable removed from sw-pipeline.sh"


### PR DESCRIPTION
Two fixes from issue #460 run: (1) hoist Instructions+gate-feedback to top of iter-2 prompt; (2) expand cumulative progress to full branch via merge-base. 105 tests pass.