### PR TITLE
fix(snapshot): always push local commits to WIP branch (#460)

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -1004,15 +1004,37 @@ jobs:
           git restore --staged '*.pem'          2>/dev/null || true
           git restore --staged '*.key'          2>/dev/null || true
 
-          if git diff --cached --quiet 2>/dev/null; then
-            echo "No resume-essentials changed — skipping snapshot push"
-            exit 0
+          # Write a failure note so the reason is visible on the branch and in artifacts.
+          # Placed before the diff check so it guarantees staged content on failure,
+          # ensuring the push always carries context about what went wrong.
+          EXIT_CODE="${{ steps.pipeline.outputs.exit_code }}"
+          if [[ "${EXIT_CODE}" != "0" ]]; then
+            LAST_STAGE=$(grep "current_stage:" .claude/pipeline-state.md 2>/dev/null | awk '{print $2}' || echo "unknown")
+            LOG_SNIP=$(tail -20 /tmp/pipeline.log 2>/dev/null | grep -iE "error|fail|assert" | head -5 || echo "(see pipeline log)")
+            mkdir -p .claude/pipeline-artifacts
+            printf '# Pipeline Failure Note\nRun: %s\nStage: %s\nLog:\n%s\n' \
+              "${{ github.run_id }}" "$LAST_STAGE" "$LOG_SNIP" \
+              > .claude/pipeline-artifacts/failure-note.md
+            git add -f .claude/pipeline-artifacts/failure-note.md 2>/dev/null || true
           fi
 
-          git -c user.email=shipwright-bot@users.noreply.github.com \
-              -c user.name='shipwright-bot' \
-              commit -m "chore: resume snapshot for #${ISSUE_NUMBER} (run ${{ github.run_id }}, pipeline=${OUTCOME}) [skip ci]" \
-              --no-verify || { echo "::warning::snapshot commit failed (non-fatal)"; exit 0; }
+          # Decouple "nothing new to commit" from "nothing to push": when the build
+          # loop's git_auto_commit succeeded, the working tree is clean and there is
+          # nothing new to stage — but local implementation commits still exist on the
+          # branch and must reach GitHub. Skipping the push here (the old exit 0) meant
+          # those commits were lost when the fresh runner exited.
+          SKIP_COMMIT=false
+          if git diff --cached --quiet 2>/dev/null; then
+            echo "No resume-essentials to commit — will still push any local commits"
+            SKIP_COMMIT=true
+          fi
+
+          if [[ "$SKIP_COMMIT" == "false" ]]; then
+            git -c user.email=shipwright-bot@users.noreply.github.com \
+                -c user.name='shipwright-bot' \
+                commit -m "chore: resume snapshot for #${ISSUE_NUMBER} (run ${{ github.run_id }}, pipeline=${OUTCOME}) [skip ci]" \
+                --no-verify || echo "::warning::snapshot commit failed (non-fatal)"
+          fi
 
           # Use GITHUBTOKEN (PAT with workflow scope) when available so pushes
           # that include workflow file changes are not rejected by the default

--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -1008,8 +1008,11 @@ jobs:
           # Placed before the diff check so it guarantees staged content on failure,
           # ensuring the push always carries context about what went wrong.
           EXIT_CODE="${{ steps.pipeline.outputs.exit_code }}"
-          if [[ "${EXIT_CODE}" != "0" ]]; then
-            LAST_STAGE=$(grep "current_stage:" .claude/pipeline-state.md 2>/dev/null | awk '{print $2}' || echo "unknown")
+          # Guard: only write a failure note when the pipeline actually ran and failed.
+          # An empty EXIT_CODE means the pipeline step was skipped (e.g. AUTH_SKIP=true);
+          # treating that as failure would create misleading snapshot commits.
+          if [[ -n "${EXIT_CODE}" && "${EXIT_CODE}" != "0" ]]; then
+            LAST_STAGE=$(grep -m1 '^current_stage:' .claude/pipeline-state.md 2>/dev/null | awk '{print $2}' || echo "unknown")
             LOG_SNIP=$(tail -20 /tmp/pipeline.log 2>/dev/null | grep -iE "error|fail|assert" | head -5 || echo "(see pipeline log)")
             mkdir -p .claude/pipeline-artifacts
             printf '# Pipeline Failure Note\nRun: %s\nStage: %s\nLog:\n%s\n' \


### PR DESCRIPTION
## Summary

- The snapshot step exited early with `exit 0` when nothing was staged, skipping the `git push` entirely
- When `git_auto_commit` in the build loop succeeded, the working tree was clean — so no staged diff was found and local implementation commits were silently abandoned on the runner
- Since each GHA run starts from a fresh environment, those commits were permanently lost

## Root Cause

```bash
# OLD — exits before the push when build loop committed cleanly
if git diff --cached --quiet; then
  echo "No resume-essentials changed — skipping snapshot push"
  exit 0   ← push never reached
fi
```

## Fix

Decouple "nothing to commit" from "nothing to push" via a `SKIP_COMMIT` flag. The PAT setup and `git push` now always run, flushing any local commits the build loop left on the WIP branch.

Also adds `failure-note.md` written to `.claude/pipeline-artifacts/` before the diff check — guarantees staged content on failure and surfaces the failure reason on the branch and in GHA artifacts without needing to read logs.

## Test plan
- [ ] `npm test` passes
- [ ] `./scripts/sw-pipeline-test.sh` passes
- [ ] Trigger a pipeline run, cancel mid-build — WIP branch should now contain implementation commits alongside the resume snapshot
- [ ] Trigger a failing pipeline — `failure-note.md` should appear in GHA artifacts

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)