### PR TITLE
fix(build-prompt): surface gate failures, clean rules, strip DoD checkboxes

### DIFF
--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -477,7 +477,7 @@ ${_ctx}
     local dod_section=""
     if [[ -n "${DOD_FILE:-}" && -f "$DOD_FILE" ]]; then
         local _dod_raw
-        _dod_raw="$(sed 's/^- \[.\] /- /; s/^  - \[.\] /  - /' "$DOD_FILE" 2>/dev/null || true)"
+        _dod_raw="$(sed 's/^\([[:space:]]*\)- \[.\] /\1- /' "$DOD_FILE" 2>/dev/null || true)"
         if [[ -n "$_dod_raw" ]]; then
             dod_section="## Definition of Done
 ${_dod_raw}

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -477,12 +477,12 @@ ${_ctx}
     local dod_section=""
     if [[ -n "${DOD_FILE:-}" && -f "$DOD_FILE" ]]; then
         local _dod_raw
-        _dod_raw="$(cat "$DOD_FILE" 2>/dev/null || true)"
+        _dod_raw="$(sed 's/^- \[.\] /- /; s/^  - \[.\] /  - /' "$DOD_FILE" 2>/dev/null || true)"
         if [[ -n "$_dod_raw" ]]; then
-            dod_section="## Definition of Done — your work must satisfy ALL of these
+            dod_section="## Definition of Done
 ${_dod_raw}
 
-Treat unchecked items as outstanding requirements. The DoD will be evaluated against the cumulative branch diff at the end of each iteration.
+The DoD is evaluated automatically against the cumulative branch diff at the end of each iteration.
 "
         fi
     fi
@@ -621,11 +621,8 @@ $discovery_section
 - Keep working memory lean — summarize completed steps, don't preserve full outputs
 
 ## Rules
-- Focus on ONE task per iteration — do it well
 - Always commit with descriptive messages
-- If tests fail, fix them before ending
 - If stuck on the same issue for 2+ iterations, try a different approach
-- Do NOT output LOOP_COMPLETE unless the goal is genuinely achieved
 ${reference_trailer}
 PROMPT
 

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -1939,21 +1939,24 @@ else
 fi
 
 # Test: compose_rejection_notice_section handles GATES_PASSED_NO_SIGNAL branch
-if grep -A10 '^compose_rejection_notice_section()' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'GATES_PASSED_NO_SIGNAL'; then
+if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
+        grep -q 'GATES_PASSED_NO_SIGNAL'; then
     assert_pass "compose_rejection_notice_section() handles GATES_PASSED_NO_SIGNAL branch"
 else
     assert_fail "compose_rejection_notice_section() handles GATES_PASSED_NO_SIGNAL branch"
 fi
 
 # Test: quality gates passed hint injected into prompt (not rejection notice)
-if grep -A20 'GATES_PASSED_NO_SIGNAL.*true' "$SCRIPT_DIR/sw-loop.sh" | grep -qi 'quality.*gates.*passed\|gates.*passed'; then
+if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
+        grep -qi 'quality.*gates.*passed\|gates.*passed'; then
     assert_pass "GATES_PASSED_NO_SIGNAL branch emits quality gates passed hint"
 else
     assert_fail "GATES_PASSED_NO_SIGNAL branch emits quality gates passed hint"
 fi
 
-# Test: COMPLETION_REJECTED path unchanged (rejection notice still present)
-if grep -A5 '^compose_rejection_notice_section()' "$SCRIPT_DIR/sw-loop.sh" | grep -q 'COMPLETION_REJECTED'; then
+# Test: COMPLETION_REJECTED path present in rejection notice function
+if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
+        grep -q 'COMPLETION_REJECTED'; then
     assert_pass "compose_rejection_notice_section() still handles COMPLETION_REJECTED path"
 else
     assert_fail "compose_rejection_notice_section() still handles COMPLETION_REJECTED path"
@@ -3297,6 +3300,40 @@ if echo "$_lp_no_gh_out" | grep -qiE "command not found|gh_comment_issue"; then
     assert_fail "SW_LOG_PROMPTS github no-helpers: no command-not-found error"
 else
     assert_pass "SW_LOG_PROMPTS github no-helpers: no command-not-found error"
+fi
+
+# ─── Test: compose_rejection_notice_section includes QUALITY_GATE_REASONS ─────
+if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
+        grep -q 'QUALITY_GATE_REASONS'; then
+    assert_pass "compose_rejection_notice_section() surfaces QUALITY_GATE_REASONS"
+else
+    assert_fail "compose_rejection_notice_section() must include QUALITY_GATE_REASONS in rejection notice"
+fi
+
+# ─── Test: Rules section has no more than 2 items (duplicates removed) ────────
+_rules_raw=$(awk '/^## Rules$/{found=1; next} found && /^\$\{reference_trailer\}/{exit} found{print}' \
+    "$SCRIPT_DIR/lib/loop-iteration.sh" 2>/dev/null || true)
+_rules_count=$(printf '%s\n' "$_rules_raw" | grep -c '^- ' 2>/dev/null || true)
+_rules_count="${_rules_count:-0}"
+if [[ "$_rules_count" -le 2 ]]; then
+    assert_pass "Rules section has at most 2 items (duplicates removed)"
+else
+    assert_fail "Rules section must have at most 2 items — found ${_rules_count}" \
+        "Remove rules that duplicate Instructions"
+fi
+
+# ─── Test: DoD section strips checkbox markers before display ─────────────────
+if grep '_dod_raw=' "$SCRIPT_DIR/lib/loop-iteration.sh" | grep -q 'sed'; then
+    assert_pass "dod_section strips checkbox markers via sed before display"
+else
+    assert_fail "dod_section must strip '- [ ]' / '- [x]' markers via sed before injecting into prompt"
+fi
+
+# ─── Test: DoD section does not say 'unchecked items' ─────────────────────────
+if ! grep -A10 'dod_section=' "$SCRIPT_DIR/lib/loop-iteration.sh" | grep -q 'unchecked'; then
+    assert_pass "dod_section does not reference 'unchecked items'"
+else
+    assert_fail "dod_section must not say 'unchecked items' — DoD items are plain bullets"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -3322,11 +3322,25 @@ else
         "Remove rules that duplicate Instructions"
 fi
 
-# ─── Test: DoD section strips checkbox markers before display ─────────────────
-if grep '_dod_raw=' "$SCRIPT_DIR/lib/loop-iteration.sh" | grep -q 'sed'; then
-    assert_pass "dod_section strips checkbox markers via sed before display"
+# ─── Test: DoD sed expression strips checkboxes at any indentation level ──────
+_dod_sed_expr=$(grep '_dod_raw=' "$SCRIPT_DIR/lib/loop-iteration.sh" \
+    | grep -o "sed '[^']*'" 2>/dev/null | head -1 || true)
+if [[ -z "$_dod_sed_expr" ]]; then
+    assert_fail "dod_section must use sed to strip checkbox markers"
 else
-    assert_fail "dod_section must strip '- [ ]' / '- [x]' markers via sed before injecting into prompt"
+    _dod_result=$(eval "$_dod_sed_expr" 2>/dev/null <<'DOD_TEST_INPUT' || true
+- [ ] top level
+   - [x] indented
+- [x] checked
+- plain line
+DOD_TEST_INPUT
+)
+    if echo "$_dod_result" | grep -qE '\[.?\]'; then
+        assert_fail "DoD sed expression leaves checkbox markers in output (all indent levels)" \
+            "got: $(echo "$_dod_result" | grep -E '\[.?\]' | head -3)"
+    else
+        assert_pass "DoD sed expression strips checkboxes at all indentation levels"
+    fi
 fi
 
 # ─── Test: DoD section does not say 'unchecked items' ─────────────────────────

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2075,10 +2075,14 @@ GATE_DETAIL
 
 compose_rejection_notice_section() {
     if $COMPLETION_REJECTED; then
-        cat <<'REJECTION'
-## ⚠ Completion Rejected
-Your previous <<<LOOP:PASS>>> was REJECTED because quality gates did not pass.
-Review the audit feedback and test results above, fix the issues, then try again.
+        local _reasons="${QUALITY_GATE_REASONS:-}"
+        local _failed_line=""
+        [[ -n "$_reasons" ]] && _failed_line="
+Failed: ${_reasons}"
+        cat <<REJECTION
+## ⚠ Completion Rejected${_failed_line}
+Your previous <<<LOOP:PASS>>> was REJECTED.
+Fix the issues and test, then try again.
 Do NOT output <<<LOOP:PASS>>> until all quality checks pass.
 REJECTION
     elif [[ "${GATES_PASSED_NO_SIGNAL:-false}" == "true" ]]; then


### PR DESCRIPTION
## Summary

- **Quality gate reasons surfaced**: `compose_rejection_notice_section()` now includes `QUALITY_GATE_REASONS` (e.g. "definition of done not satisfied, tests failing") directly in the rejection notice, so agents and humans reading issue comments immediately see *which* gates failed instead of just "quality gates did not pass"
- **Rules section decluttered**: Removed 3 rules that duplicated Instructions (#3, #4, #6); kept only the 2 rules that aren't already stated elsewhere (commit messages, try different approach when stuck)
- **DoD display cleaned up**: Strips `- [ ]` / `- [x]` checkbox markers via `sed` before injecting the DoD into the prompt, so static plan.md checkboxes don't appear as perpetually unchecked items; updated framing to neutral language (no "unchecked items outstanding")
- **Tests improved**: Replaced fragile `grep -A10`/`-A20`/`-A5` pattern with `awk` function-body extraction so tests don't silently break when function bodies grow; added 4 new tests covering the above changes

## Test plan

- [ ] `bash scripts/sw-loop-test.sh` — all tests pass (303)
- [ ] `bash scripts/sw-lib-loop-iteration-test.sh` — all tests pass
- [ ] `bash scripts/sw-pipeline-test.sh` — no regressions
- [ ] In a rejection scenario, the build prompt shows `Failed: <gate names>` under `## ⚠ Completion Rejected`
- [ ] DoD section in prompt shows plain bullets, no `[ ]` markers

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)