### PR TITLE
fix(pipeline): remediate #460 postmortem (F1-F15) + two audit passes

### DIFF
--- a/.claude/daemon-config.json
+++ b/.claude/daemon-config.json
@@ -22,7 +22,7 @@
   "pipeline_template": "autonomous",
   "auto_template": false,
   "last_optimization": {
-    "timestamp": "2026-03-26T23:57:43Z",
+    "timestamp": "2026-03-30T10:49:38Z",
     "adjustments": "merge stage recommended (deploy freq 0.0/week); "
   }
 }

--- a/docs/issue-template-shipwright.md
+++ b/docs/issue-template-shipwright.md
@@ -1,0 +1,42 @@
+# Shipwright Issue Template
+
+Use this template when creating issues that will be processed by the Shipwright autonomous pipeline.
+Good issue quality directly reduces wasted pipeline iterations.
+
+---
+
+## Template
+
+```
+# Title: <imperative verb-first, 60-char max>
+
+## Problem
+<1-3 sentences. What's wrong / missing / why now.>
+
+## Behavior change (acceptance criteria)
+- [ ] <observable behavior 1 — testable without a human>
+- [ ] <observable behavior 2>
+- [ ] <observable behavior 3>
+
+## Out of scope
+- <what this issue is NOT solving>
+
+## How to verify (autonomous)
+<Commands the pipeline can run to confirm — `npm test`, `bash scripts/sw-X-test.sh`,
+specific assertions. No "I'll smoke test on the PR" — that's manual scope.>
+
+## Toggles / config (if any)
+- Env var: `SHIPWRIGHT_X` (default: ...)
+- Config: `daemon-config.json` key `...`
+
+## Related
+- Prior PRs: #...
+- Related issues: #...
+```
+
+## Key rules for Shipwright-compatible issues
+
+1. **No manual-only DoD items.** "I'll smoke test on the PR" blocks the autonomous loop forever. Use `npm test` or `bash scripts/sw-X-test.sh` instead.
+2. **Acceptance criteria must be testable by a script.** If you can't write a command that checks it, it belongs in the PR description.
+3. **Number your criteria once.** Avoid duplicate numbering (1/2/3 appearing twice with different content).
+4. **Keep scope tight.** Mixed scopes cause the plan stage to invent DoD items that don't match the issue.

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -452,7 +452,24 @@ sanitize_secrets() {
     # Redact GitHub OAuth tokens (ghp_, gho_, ghu_, ghs_, ghr_ — 5 known prefixes)
     # Length-bound: GitHub tokens are minimum 36 base62 chars [A-Za-z0-9], no underscores
     text="$(echo "$text" | sed -E 's/gh[pousr]_[A-Za-z0-9]{36,255}/gh_***REDACTED***/g')"
+    # Redact GitHub fine-grained PATs (github_pat_ prefix, ≥60 base62+underscore chars)
+    text="$(echo "$text" | sed -E 's/github_pat_[A-Za-z0-9_]{60,}/github_pat_***REDACTED***/g')"
     echo "$text"
+}
+
+# Portable SHA-1 hash of stdin — macOS (shasum) and Linux (sha1sum / openssl).
+# Returns a 40-char hex digest, or a unique no-hasher sentinel to disable dedup.
+# Usage: echo "data" | _compute_sha1
+_compute_sha1() {
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 1 | awk '{print $1}'
+    elif command -v sha1sum >/dev/null 2>&1; then
+        sha1sum | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha1 -hex | awk '{print $NF}'
+    else
+        printf 'no-hasher-%s-%s' "$PPID" "$(date +%s 2>/dev/null || echo 0)"
+    fi
 }
 
 # ─── Git Bookkeeping Exclusions ──────────────────────────────────

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -449,8 +449,9 @@ sanitize_secrets() {
     text="$(echo "$text" | sed 's/sk-[a-zA-Z0-9_-]*/sk-***REDACTED***/g')"
     # Redact Bearer tokens
     text="$(echo "$text" | sed 's/Bearer [a-zA-Z0-9_.-]*/Bearer ***REDACTED***/g')"
-    # Redact oauth tokens (gh_...)
-    text="$(echo "$text" | sed 's/gh_[a-zA-Z0-9_]*/gh_***REDACTED***/g')"
+    # Redact GitHub OAuth tokens (ghp_, gho_, ghu_, ghs_, ghr_ — 5 known prefixes)
+    # Length-bound: GitHub tokens are minimum 36 base62 chars [A-Za-z0-9], no underscores
+    text="$(echo "$text" | sed -E 's/gh[pousr]_[A-Za-z0-9]{36,255}/gh_***REDACTED***/g')"
     echo "$text"
 }
 

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -472,6 +472,15 @@ _compute_sha1() {
     fi
 }
 
+# Validates a git ref/branch name against a safe allowlist pattern.
+# Exits 1 if the ref is unsafe, so callers can: _validate_ref "$BASE_BRANCH" || BASE_BRANCH=main
+_validate_ref() {
+    local ref="${1:-}"
+    [[ "$ref" =~ ^[A-Za-z0-9._/-]+$ ]] && return 0
+    warn "_validate_ref: unsafe ref '${ref}' — refusing to use as git argument"
+    return 1
+}
+
 # ─── Git Bookkeeping Exclusions ──────────────────────────────────
 # Two categories of files excluded from loop progress/diff tracking:
 #

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -472,10 +472,28 @@ _compute_sha1() {
     fi
 }
 
-# Validates a git ref/branch name against a safe allowlist pattern.
+# Validates a git ref/branch name against safe-ref rules.
 # Exits 1 if the ref is unsafe, so callers can: _validate_ref "$BASE_BRANCH" || BASE_BRANCH=main
+# Rejects leading dashes (option-injection vector for git commands), `..` path
+# traversal sequences, and anything else `git check-ref-format` flags. Falls back to
+# a tight charset regex when git is unavailable in the environment.
 _validate_ref() {
     local ref="${1:-}"
+    [[ -z "$ref" ]] && { warn "_validate_ref: empty ref"; return 1; }
+    # Hard reject: leading dash, embedded "..", whitespace, or git-ref reserved chars.
+    case "$ref" in
+        -*|*..*|*' '*|*$'\t'*|*$'\n'*|*'~'*|*'^'*|*':'*|*'?'*|*'*'*|*'['*|*'\\'*)
+            warn "_validate_ref: unsafe ref '${ref}' (option/traversal/reserved char) — refusing"
+            return 1
+            ;;
+    esac
+    if command -v git >/dev/null 2>&1; then
+        # Authoritative check: git's own ref-format validator (branch form).
+        git check-ref-format --branch "$ref" >/dev/null 2>&1 && return 0
+        warn "_validate_ref: git check-ref-format rejected '${ref}'"
+        return 1
+    fi
+    # No git available — fall back to a conservative charset check.
     [[ "$ref" =~ ^[A-Za-z0-9._/-]+$ ]] && return 0
     warn "_validate_ref: unsafe ref '${ref}' — refusing to use as git argument"
     return 1

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -595,7 +595,7 @@ ${cum_stat}
     local _ptmp
     _ptmp=$(mktemp "${TMPDIR:-/tmp}/sw-prompt.XXXXXX")
     cat > "$_ptmp" <<PROMPT
-You are an autonomous coding agent. $(scope_label) of ${MAX_ITERATIONS} max iterations.
+You are an autonomous coding agent. $(scope_label 2>/dev/null || echo "Build Iteration ${ITERATION:-?}") of ${MAX_ITERATIONS} max iterations.
 ${resume_section}
 ## Your Goal
 ${prompt_goal}

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -561,12 +561,41 @@ ${cum_stat}
 - Full build context: \`${_adir}/build-context.md\`"
     fi
 
+    # v2 prompt template — gated behind SHIPWRIGHT_PROMPT_V2=1
+    if [[ "${SHIPWRIGHT_PROMPT_V2:-0}" == "1" ]]; then
+        # Source the template module if not already loaded
+        local _tpl_dir
+        _tpl_dir="$(dirname "${BASH_SOURCE[0]}")"
+        if [[ -f "${_tpl_dir}/loop-prompt-template.sh" ]] && ! declare -f render_task_header >/dev/null 2>&1; then
+            # shellcheck source=./loop-prompt-template.sh
+            source "${_tpl_dir}/loop-prompt-template.sh" 2>/dev/null || true
+        fi
+        if declare -f render_task_header >/dev/null 2>&1; then
+            local _v2_adir="${ARTIFACTS_DIR:-.claude/pipeline-artifacts}"
+            local _v2_prompt
+            _v2_prompt=$(
+                render_task_header "${prompt_goal:-${GOAL:-}}" "$(scope_label 2>/dev/null || echo 'Build')" "${MAX_ITERATIONS:-10}"
+                render_dynamic_state \
+                    "${test_section:-No previous test results}" \
+                    "${git_log:-No recent commits}" \
+                    "${gate_findings_section:-}" \
+                    "${dod_section:-}"
+                if declare -f render_design_findings >/dev/null 2>&1; then
+                    render_design_findings "${_v2_adir}"
+                fi
+                render_static_reference "${_v2_adir}"
+            )
+            echo "$_v2_prompt"
+            return 0
+        fi
+    fi
+
     # Bash 3.2 compat: heredoc inside $() is rejected by bash 3.2.
     # Write to a temp file, measure with wc -c, cat and remove.
     local _ptmp
     _ptmp=$(mktemp "${TMPDIR:-/tmp}/sw-prompt.XXXXXX")
     cat > "$_ptmp" <<PROMPT
-You are an autonomous coding agent on iteration ${ITERATION}/${MAX_ITERATIONS} of a continuous loop.
+You are an autonomous coding agent. $(scope_label) of ${MAX_ITERATIONS} max iterations.
 ${resume_section}
 ## Your Goal
 ${prompt_goal}
@@ -753,7 +782,7 @@ run_claude_iteration() {
                 else
                     truncated="$redacted"
                 fi
-                body="### Build Prompt — Iteration ${ITERATION}
+                body="### Build Prompt — $(scope_label)
 
 <details><summary>Prompt (${prompt_chars} chars, redacted)</summary>
 

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -782,7 +782,13 @@ run_claude_iteration() {
                 else
                     truncated="$redacted"
                 fi
-                body="### Build Prompt — $(scope_label)
+                local _scope_label
+                if type scope_label >/dev/null 2>&1; then
+                    _scope_label="$(scope_label 2>/dev/null || echo "Build Iteration ${ITERATION:-?}")"
+                else
+                    _scope_label="Build Iteration ${ITERATION:-?}"
+                fi
+                body="### Build Prompt — ${_scope_label}
 
 <details><summary>Prompt (${prompt_chars} chars, redacted)</summary>
 

--- a/scripts/lib/loop-prompt-template.sh
+++ b/scripts/lib/loop-prompt-template.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Loop prompt template v2 — task-first structure.
+# Activated by SHIPWRIGHT_PROMPT_V2=1. Default: off (uses existing template).
+# All functions are pure: no side effects, no file writes, output to stdout.
+
+# Renders the TASK header section — always the first thing in the prompt.
+# Args: $1=goal_text $2=scope_label $3=max_iterations
+render_task_header() {
+    local goal="$1"
+    local label="${2:-Build Iteration 1}"
+    local max_iter="${3:-10}"
+    cat <<TASK_HEADER
+============================================================
+ SHIPWRIGHT TASK — ${label} (max ${max_iter} iterations)
+============================================================
+
+YOUR GOAL FOR THIS ITERATION:
+${goal}
+
+WHEN COMPLETE, COMMIT ALL CHANGES AND OUTPUT EXACTLY: LOOP_COMPLETE
+IF STUCK FOR 2+ ITERATIONS ON THE SAME PROBLEM, TRY A DIFFERENT APPROACH.
+
+TASK_HEADER
+}
+
+# Renders the dynamic state section — changes each iteration.
+# Args: $1=test_summary $2=git_log $3=quality_findings $4=dod_status
+render_dynamic_state() {
+    local test_summary="${1:-No previous test results}"
+    local git_log="${2:-No recent commits}"
+    local quality_findings="${3:-}"
+    local dod_status="${4:-}"
+    cat <<DYNAMIC
+============================================================
+ DYNAMIC STATE (changes every iteration)
+============================================================
+
+## Test Results (Previous Iteration)
+${test_summary}
+
+## Recent Git Activity
+${git_log}
+DYNAMIC
+
+    if [[ -n "$quality_findings" ]]; then
+        echo ""
+        echo "## Quality-Gate Findings"
+        echo "$quality_findings"
+    fi
+
+    if [[ -n "$dod_status" ]]; then
+        echo ""
+        echo "## Definition of Done (auto items only)"
+        echo "$dod_status"
+    fi
+    echo ""
+}
+
+# Renders the static reference section — stable across iterations.
+# Args: $1=artifacts_dir
+render_static_reference() {
+    local adir="${1:-.claude/pipeline-artifacts}"
+    cat <<STATIC
+============================================================
+ STATIC REFERENCE (read on demand — do not re-read if already known)
+============================================================
+
+Pre-summarized above where relevant. Files available in workspace:
+  - ${adir}/plan.md         — feature plan and implementation steps
+  - ${adir}/design.md       — full ADR with interface contracts and edge cases
+  - ${adir}/dod.md          — Definition of Done checklist
+  - ${adir}/build-context.md — accumulated decisions from previous iterations
+
+Do NOT re-read static reference unless dynamic state cites a specific section.
+For wide repo searches: use targeted Grep → Read with offset/limit.
+
+## Context Efficiency
+- Batch independent tool calls in parallel — avoid sequential round-trips
+- Use targeted file reads (offset/limit) instead of reading entire large files
+- Delegate large searches to subagents — only import the summary
+- Filter tool results with grep/jq before reasoning over them
+
+## Rules
+- Always commit with descriptive messages
+- If stuck on the same issue for 2+ iterations, try a different approach
+STATIC
+}
+
+# Renders design-stage key findings inline.
+# Args: $1=artifacts_dir
+render_design_findings() {
+    local adir="${1:-.claude/pipeline-artifacts}"
+    local findings_file="${adir}/design-findings.json"
+
+    echo ""
+    echo "============================================================"
+    echo " DESIGN KEY FINDINGS (actionable issues from ADR)"
+    echo "============================================================"
+    echo ""
+
+    if [[ ! -f "$findings_file" ]]; then
+        echo "(no design findings recorded for this issue)"
+        return 0
+    fi
+
+    local count
+    count=$(jq 'length' "$findings_file" 2>/dev/null || echo 0)
+    if [[ "$count" -eq 0 ]]; then
+        echo "(no design findings recorded for this issue)"
+        return 0
+    fi
+
+    # Render each finding with severity indicator
+    jq -r '.[] | "  • [\(.severity // "info" | ascii_upcase)] \(.finding)" + if .file then " (\(.file)" + if .line then ":\(.line)" else "" end + ")" else "" end' \
+        "$findings_file" 2>/dev/null | head -10
+}

--- a/scripts/lib/pipeline-github.sh
+++ b/scripts/lib/pipeline-github.sh
@@ -81,13 +81,28 @@ gh_post_progress() {
         -f body="$body" --jq '.id' 2>/dev/null) || true
     if [[ -n "$result" && "$result" != "null" ]]; then
         PROGRESS_COMMENT_ID="$result"
+        # Persist to disk so nested contexts and shell restarts can restore it
+        if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
+            mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
+            echo "$result" > "${ARTIFACTS_DIR}/progress-comment.id" 2>/dev/null || true
+        fi
     fi
 }
 
 # Update an existing progress comment by ID
 # Usage: gh_update_progress <body>
 gh_update_progress() {
-    [[ "$GH_AVAILABLE" != "true" || -z "$PROGRESS_COMMENT_ID" ]] && return 0
+    [[ "$GH_AVAILABLE" != "true" ]] && return 0
+    # Restore from disk if env var was lost (shell restart / nested context)
+    if [[ -z "${PROGRESS_COMMENT_ID:-}" && -n "${ARTIFACTS_DIR:-}" ]]; then
+        local _saved_id
+        _saved_id=$(cat "${ARTIFACTS_DIR}/progress-comment.id" 2>/dev/null | tr -d '[:space:]' || true)
+        if [[ -n "$_saved_id" ]]; then
+            PROGRESS_COMMENT_ID="$_saved_id"
+            warn "heartbeat: restored PROGRESS_COMMENT_ID=${PROGRESS_COMMENT_ID} from disk" 2>/dev/null || true
+        fi
+    fi
+    [[ -z "${PROGRESS_COMMENT_ID:-}" ]] && return 0
     local body="$1"
     _timeout 30 gh api "repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${PROGRESS_COMMENT_ID}" \
         -X PATCH -f body="$body" >/dev/null 2>&1 || true

--- a/scripts/lib/pipeline-github.sh
+++ b/scripts/lib/pipeline-github.sh
@@ -85,8 +85,9 @@ gh_post_progress() {
         # M2: atomic tmp+mv write prevents concurrent readers from seeing truncated content.
         if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
             mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
-            local _id_tmp="${ARTIFACTS_DIR}/progress-comment.id.tmp"
-            echo "$result" > "$_id_tmp" && mv "$_id_tmp" "${ARTIFACTS_DIR}/progress-comment.id" 2>/dev/null || true
+            local _id_tmp
+            _id_tmp=$(mktemp "${ARTIFACTS_DIR}/progress-comment.id.XXXXXX" 2>/dev/null) || _id_tmp="${ARTIFACTS_DIR}/progress-comment.id.tmp.$$"
+            printf '%s\n' "$result" > "$_id_tmp" && mv "$_id_tmp" "${ARTIFACTS_DIR}/progress-comment.id" || rm -f "$_id_tmp"
         fi
     fi
 }

--- a/scripts/lib/pipeline-github.sh
+++ b/scripts/lib/pipeline-github.sh
@@ -81,10 +81,12 @@ gh_post_progress() {
         -f body="$body" --jq '.id' 2>/dev/null) || true
     if [[ -n "$result" && "$result" != "null" ]]; then
         PROGRESS_COMMENT_ID="$result"
-        # Persist to disk so nested contexts and shell restarts can restore it
+        # Persist to disk so nested contexts and shell restarts can restore it.
+        # M2: atomic tmp+mv write prevents concurrent readers from seeing truncated content.
         if [[ -n "${ARTIFACTS_DIR:-}" ]]; then
             mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
-            echo "$result" > "${ARTIFACTS_DIR}/progress-comment.id" 2>/dev/null || true
+            local _id_tmp="${ARTIFACTS_DIR}/progress-comment.id.tmp"
+            echo "$result" > "$_id_tmp" && mv "$_id_tmp" "${ARTIFACTS_DIR}/progress-comment.id" 2>/dev/null || true
         fi
     fi
 }

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -650,7 +650,7 @@ pipeline_security_source_scan() {
     local finding_count=0
 
     local changed_files
-    changed_files=$(git diff --name-only "${base_branch}...HEAD" 2>/dev/null || true)
+    changed_files=$(git diff --name-only "${base_branch}...HEAD" -- 2>/dev/null || true)
     [[ -z "$changed_files" ]] && { echo "[]"; return 0; }
 
     local tmp_findings
@@ -704,7 +704,7 @@ SQLEOF
                 local current
                 current=$(cat "$tmp_findings")
                 echo "$current" | jq --arg f "$file" --arg l "$line_num" --arg p "xss" \
-                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","description":"Potential XSS via unsafe DOM manipulation"}]' \
+                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","confidence":"medium","description":"Potential XSS via unsafe DOM manipulation"}]' \
                     > "$tmp_findings" 2>/dev/null || true
             done <<XSSEOF
 $xss_matches
@@ -721,8 +721,20 @@ XSSEOF
                 finding_count=$((finding_count + 1))
                 local current
                 current=$(cat "$tmp_findings")
-                echo "$current" | jq --arg f "$file" --arg l "$line_num" --arg p "command_injection" \
-                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","description":"Potential command injection via unsafe execution"}]' \
+                # Determine confidence: low for bare import/require lines (nothing
+                # executable after the module name), high when shell-injection markers
+                # are present, medium otherwise.
+                # Security note: require bare-import form ONLY — `import subprocess;
+                # subprocess.run(x, shell=True)` must NOT downgrade to low.
+                local confidence="medium"
+                local match_text="${match#*:}"
+                if echo "$match_text" | grep -qE "^[[:space:]]*(import|require|from)[[:space:]]+[a-zA-Z0-9_./@'\"-]+[[:space:]]*$"; then
+                    confidence="low"
+                elif echo "$match_text" | grep -qE '\$\{|`|shell[[:space:]]*=[[:space:]]*[Tt]rue|exec[[:space:]]*\('; then
+                    confidence="high"
+                fi
+                echo "$current" | jq --arg f "$file" --arg l "$line_num" --arg p "command_injection" --arg c "$confidence" \
+                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","confidence":$c,"description":"Potential command injection via unsafe execution"}]' \
                     > "$tmp_findings" 2>/dev/null || true
             done <<CMDEOF
 $cmd_matches
@@ -740,7 +752,7 @@ CMDEOF
                 local current
                 current=$(cat "$tmp_findings")
                 echo "$current" | jq --arg f "$file" --arg l "$line_num" --arg p "hardcoded_secret" \
-                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","description":"Potential hardcoded secret or credential"}]' \
+                    '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"severity":"critical","confidence":"medium","description":"Potential hardcoded secret or credential"}]' \
                     > "$tmp_findings" 2>/dev/null || true
             done <<SECEOF
 $secret_matches
@@ -1107,9 +1119,28 @@ _extract_blocking_items() {
         done < <(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null || true)
     fi
     if [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]] && pipeline_artifact_is_current "$ARTIFACTS_DIR/security-source-scan.log"; then
-        while IFS= read -r line; do
-            _dedup_add_item "$line" "security-source" "$tmp_fps" "$tmp_items"
-        done < <(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true)
+        # Prefer the JSON artifact (confidence-tagged) when available; fall back to
+        # plain-text log which lacks confidence and is treated as medium confidence.
+        if [[ -f "$ARTIFACTS_DIR/security-source-scan.json" ]] && \
+           jq -e . "$ARTIFACTS_DIR/security-source-scan.json" >/dev/null 2>&1; then
+            # Route by confidence: high/medium → blocking, low → advisory only.
+            # (.confidence == null): conservative fallback for findings written before
+            # confidence tagging was introduced — treat as medium (blocking). Intentional.
+            while IFS= read -r line; do
+                [[ -z "$line" ]] && continue
+                _dedup_add_item "$line" "security-source" "$tmp_fps" "$tmp_items"
+            done < <(jq -r '.[] | select(.confidence == "high" or .confidence == "medium" or (.confidence == null)) | select(.severity == "critical" or .severity == "high" or .severity == "major") | "\(.file // "unknown"):\(.line // "?") \u2014 \(.description // "finding")"' \
+                "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null | grep -v '^null' || true)
+            # Low-confidence findings → advisory sidecar, NOT blocking
+            jq -r '.[] | select(.confidence == "low") | "ADVISORY: \(.file // "unknown"):\(.line // "?") \u2014 \(.description // "finding") [low confidence \u2014 verify before acting]"' \
+                "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null \
+                >> "${ARTIFACTS_DIR}/security-advisories.log" 2>/dev/null || true
+        else
+            # Fallback: plain-text log — treat all critical/high lines as medium confidence (blocking)
+            while IFS= read -r line; do
+                _dedup_add_item "$line" "security-source" "$tmp_fps" "$tmp_items"
+            done < <(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true)
+        fi
     fi
 
     # ── 3. negative-review.md — [Critical] lines only ──
@@ -1207,21 +1238,56 @@ _write_quality_feedback() {
         echo "## Review Findings"
         echo ""
 
-        # Security findings (npm audit via security-audit.log and source scan via security-source-scan.log)
-        local _show_sec=false
-        if [[ -f "$ARTIFACTS_DIR/security-audit.log" ]] && grep -qiE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null; then
-            _show_sec=true
-        fi
-        if [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]] && grep -qiE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null; then
-            _show_sec=true
-        fi
-        if $_show_sec; then
-            echo "### 🔴 PRIORITY: Security Findings (fix these first)"
-            [[ -f "$ARTIFACTS_DIR/security-audit.log" ]] && cat "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null || true
-            [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]] && cat "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true
-            echo ""
-            echo "Security issues MUST be resolved before any other changes."
-            echo ""
+        # Security findings: split by confidence when JSON artifact is available.
+        if [[ -f "$ARTIFACTS_DIR/security-source-scan.json" ]] && \
+           jq -e 'length > 0' "$ARTIFACTS_DIR/security-source-scan.json" >/dev/null 2>&1; then
+            # Blocking: high confidence + medium (medium treated as blocking — conservative)
+            local _sec_blocking _sec_advisory
+            _sec_blocking=$(jq -r \
+                '.[] | select(.confidence == "high" or .confidence == "medium") | "  - \(.file // "unknown"):\(.line // "?") — \(.description // "finding") [confidence: \(.confidence)]"' \
+                "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null || true)
+            _sec_advisory=$(jq -r \
+                '.[] | select(.confidence == "low") | "  - \(.file // "unknown"):\(.line // "?") — \(.description // "finding") [low confidence — verify before acting]"' \
+                "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null || true)
+            # Also include npm audit (always blocking)
+            if [[ -f "$ARTIFACTS_DIR/security-audit.log" ]] && grep -qiE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null; then
+                if [[ -z "$_sec_blocking" ]]; then
+                    _sec_blocking=$(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null || true)
+                else
+                    _sec_blocking="${_sec_blocking}"$'\n'"$(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null || true)"
+                fi
+            fi
+            if [[ -n "$_sec_blocking" ]]; then
+                echo "### 🔴 BLOCKING: Security Findings (must fix before merge)"
+                echo "$_sec_blocking"
+                echo ""
+                echo "These security issues MUST be resolved before merge."
+                echo ""
+            fi
+            if [[ -n "$_sec_advisory" ]]; then
+                echo "### ⚠️ ADVISORIES: Low-Confidence Security Findings (review, may be false positives)"
+                echo "$_sec_advisory"
+                echo ""
+                echo "These are single-source, low-confidence findings. Investigate but do not treat as blocking."
+                echo ""
+            fi
+        else
+            # Fallback: raw log dump when JSON not available
+            local _show_sec=false
+            if [[ -f "$ARTIFACTS_DIR/security-audit.log" ]] && grep -qiE 'critical|high' "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null; then
+                _show_sec=true
+            fi
+            if [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]] && grep -qiE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null; then
+                _show_sec=true
+            fi
+            if $_show_sec; then
+                echo "### 🔴 PRIORITY: Security Findings (fix these first)"
+                [[ -f "$ARTIFACTS_DIR/security-audit.log" ]] && cat "$ARTIFACTS_DIR/security-audit.log" 2>/dev/null || true
+                [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]] && cat "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true
+                echo ""
+                echo "Security issues MUST be resolved before any other changes."
+                echo ""
+            fi
         fi
 
         # Adversarial review narrative
@@ -1715,6 +1781,7 @@ ${_cascade_test_tail}"
     local _cycles_executed=0
     while [[ "$cycle" -lt "$max_cycles" ]]; do
         cycle=$((cycle + 1))
+        COMPOUND_QUALITY_CYCLE=$cycle
         local all_passed=true
 
         echo ""
@@ -2148,7 +2215,41 @@ All quality checks clean:
         if [[ "$cycle" -lt "$max_cycles" ]]; then
             warn "Quality checks failed — rebuilding with feedback (cycle $((cycle + 1))/${max_cycles})"
 
-            if ! compound_rebuild_with_feedback "$((cycle + 1))"; then
+            # Cycles 2+ use smoke test to save time; only cycle 1 runs full suite
+            local _cq_test_cmd="${TEST_CMD:-npm test}"
+            local _smoke_from="${SHIPWRIGHT_CQ_SMOKE_FROM_CYCLE:-2}"
+            if [[ "$cycle" -ge "$_smoke_from" ]]; then
+                if [[ -f "package.json" ]] && jq -e '.scripts["test:smoke"]' package.json >/dev/null 2>&1; then
+                    _cq_test_cmd="npm run test:smoke"
+                    info "Compound quality cycle ${cycle}: using smoke test (not full suite)"
+                else
+                    info "Compound quality cycle ${cycle}: test:smoke not defined — using full test suite"
+                fi
+            fi
+
+            # Short-circuit: if failures are identical to previous cycle, abort early
+            if [[ "$cycle" -ge 2 && -f "${ARTIFACTS_DIR}/last-failure-set.sha" ]]; then
+                local _cur_hash _prev_hash
+                _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
+                _cur_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                    | sort | { command -v shasum >/dev/null 2>&1 && shasum -a 1 | awk '{print $1}'; } \
+                    || grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                    | sort | sha1sum 2>/dev/null | awk '{print $1}' \
+                    || echo "")
+                if [[ -n "$_cur_hash" && "$_cur_hash" == "$_prev_hash" ]]; then
+                    warn "Compound quality: identical failures to previous cycle — aborting (no progress possible)"
+                    _cycles_executed=$cycle
+                    break
+                fi
+            fi
+            # Record current failure set hash for next cycle's short-circuit check
+            { grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                | sort | { command -v shasum >/dev/null 2>&1 && shasum -a 1 | awk '{print $1}'; } \
+                || grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                | sort | sha1sum 2>/dev/null | awk '{print $1}'; } \
+                > "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null || true
+
+            if ! TEST_CMD="$_cq_test_cmd" compound_rebuild_with_feedback "$((cycle + 1))"; then
                 error "Rebuild with feedback failed"
                 log_stage "compound_quality" "Rebuild failed on cycle ${cycle}"
                 return 1

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1146,11 +1146,19 @@ _extract_blocking_items() {
                 "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null \
                 >> "${ARTIFACTS_DIR}/security-advisories.log" 2>/dev/null || true
         else
-            # JSON unavailable or invalid — do NOT route plain-text log into BLOCKING.
-            # Routing all log lines as blocking when confidence is unknown was the
-            # pre-F7 behavior that caused the #460 false-positive regression. Fail-closed:
-            # warn and write to advisory sidecar only.
-            warn "security-source-scan: JSON artifact missing/invalid — skipping injection into GOAL (advisory only)"
+            # JSON unavailable or invalid — inject a synthetic BLOCKING item so the
+            # security gate stays closed. A scanner crash or build race must never
+            # cause the gate to disappear silently (fail-OPEN). Operators will see
+            # this finding and must re-run the pipeline to generate a valid scan.
+            local _synthetic_fp="SCANNER_ARTIFACT_MISSING:security-source-scan.json"
+            if ! grep -qxF "$_synthetic_fp" "$tmp_fps" 2>/dev/null; then
+                printf '%s\n' "$_synthetic_fp" >> "$tmp_fps"
+                printf '%s [source: %s]\n' \
+                    "SCANNER_ARTIFACT_MISSING: security-source-scan.json unavailable — re-run pipeline to generate fresh scan results" \
+                    "security-source (synthetic)" >> "$tmp_items"
+            fi
+            # Also warn and write to advisory sidecar for diagnostics.
+            warn "security-source-scan: JSON artifact missing/invalid — injecting synthetic BLOCKING item (gate closed)"
             if [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]]; then
                 while IFS= read -r line; do
                     [[ -z "$line" ]] && continue
@@ -2236,7 +2244,7 @@ All quality checks clean:
             # Cycles 2+ use smoke test to save time; only cycle 1 runs full suite
             local _cq_test_cmd="${TEST_CMD:-npm test}"
             local _smoke_from="${SHIPWRIGHT_CQ_SMOKE_FROM_CYCLE:-2}"
-            if [[ "$cycle" -ge "$_smoke_from" ]]; then
+            if [[ "$cycle" -ge "$_smoke_from" && "$cycle" -lt "$max_cycles" ]]; then
                 if [[ -f "package.json" ]] && jq -e '.scripts["test:smoke"]' package.json >/dev/null 2>&1; then
                     _cq_test_cmd="npm run test:smoke"
                     info "Compound quality cycle ${cycle}: using smoke test (not full suite)"
@@ -2253,7 +2261,7 @@ All quality checks clean:
             if [[ "$cycle" -ge 2 && -f "${ARTIFACTS_DIR}/last-failure-set.sha" ]]; then
                 local _cur_hash _prev_hash _fail_line_count
                 _fail_line_count=$(grep -cE '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
-                    "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null || echo "0")
+                    "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null) || _fail_line_count=0
                 _fail_line_count="${_fail_line_count:-0}"
                 if [[ "$_fail_line_count" -gt 0 ]]; then
                     _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
@@ -2271,7 +2279,7 @@ All quality checks clean:
             # Record current failure set hash for next cycle's short-circuit check
             { local _record_count
               _record_count=$(grep -cE '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
-                  "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null || echo "0")
+                  "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null) || _record_count=0
               if [[ "${_record_count:-0}" -gt 0 ]]; then
                   grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
                       "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -721,14 +721,24 @@ XSSEOF
                 finding_count=$((finding_count + 1))
                 local current
                 current=$(cat "$tmp_findings")
-                # Determine confidence: low for bare import/require lines (nothing
-                # executable after the module name), high when shell-injection markers
-                # are present, medium otherwise.
-                # Security note: require bare-import form ONLY — `import subprocess;
-                # subprocess.run(x, shell=True)` must NOT downgrade to low.
+                # Determine confidence: low for pure import/require declarations (nothing
+                # executable), high when injection markers are present, medium otherwise.
+                # Two-step check: (1) line starts with an import form, AND (2) has no
+                # inline execution markers (semicolons, shell=True, direct calls).
+                # This correctly downgrades `import { execFileSync } from 'child_process'`
+                # (ES6 named import — no execution) while keeping
+                # `import subprocess; subprocess.run(x, shell=True)` at high.
                 local confidence="medium"
                 local match_text="${match#*:}"
-                if echo "$match_text" | grep -qE "^[[:space:]]*(import|require|from)[[:space:]]+[a-zA-Z0-9_./@'\"-]+[[:space:]]*$"; then
+                local _is_import_decl=false
+                if echo "$match_text" | grep -qE \
+                    "^[[:space:]]*(import[[:space:]({\"\']|from[[:space:]]+[A-Za-z_]|const[[:space:]]+|var[[:space:]]+|let[[:space:]]+)"; then
+                    if ! echo "$match_text" | grep -qE \
+                        "[;]|\.(exec|run|spawn|system|call|Popen)[[:space:]]*\(|eval[[:space:]]*\(|shell[[:space:]]*=[[:space:]]*[Tt]rue"; then
+                        _is_import_decl=true
+                    fi
+                fi
+                if [[ "$_is_import_decl" == "true" ]]; then
                     confidence="low"
                 elif echo "$match_text" | grep -qE '\$\{|`|shell[[:space:]]*=[[:space:]]*[Tt]rue|exec[[:space:]]*\('; then
                     confidence="high"
@@ -1136,10 +1146,18 @@ _extract_blocking_items() {
                 "$ARTIFACTS_DIR/security-source-scan.json" 2>/dev/null \
                 >> "${ARTIFACTS_DIR}/security-advisories.log" 2>/dev/null || true
         else
-            # Fallback: plain-text log — treat all critical/high lines as medium confidence (blocking)
-            while IFS= read -r line; do
-                _dedup_add_item "$line" "security-source" "$tmp_fps" "$tmp_items"
-            done < <(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true)
+            # JSON unavailable or invalid — do NOT route plain-text log into BLOCKING.
+            # Routing all log lines as blocking when confidence is unknown was the
+            # pre-F7 behavior that caused the #460 false-positive regression. Fail-closed:
+            # warn and write to advisory sidecar only.
+            warn "security-source-scan: JSON artifact missing/invalid — skipping injection into GOAL (advisory only)"
+            if [[ -f "$ARTIFACTS_DIR/security-source-scan.log" ]]; then
+                while IFS= read -r line; do
+                    [[ -z "$line" ]] && continue
+                    echo "ADVISORY (no-json-fallback): $line" \
+                        >> "${ARTIFACTS_DIR}/security-advisories.log" 2>/dev/null || true
+                done < <(grep -iE 'critical|high' "$ARTIFACTS_DIR/security-source-scan.log" 2>/dev/null || true)
+            fi
         fi
     fi
 
@@ -2227,27 +2245,39 @@ All quality checks clean:
                 fi
             fi
 
-            # Short-circuit: if failures are identical to previous cycle, abort early
+            # Short-circuit: if failures are identical to previous cycle, abort early.
+            # Guard: only compare when there are actual failure lines — SHA-1 of empty
+            # input is a constant hash, which would fire a false short-circuit on
+            # missing/empty test-results.log (infrastructure failure masking as
+            # "identical failures, no progress possible").
             if [[ "$cycle" -ge 2 && -f "${ARTIFACTS_DIR}/last-failure-set.sha" ]]; then
-                local _cur_hash _prev_hash
-                _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
-                _cur_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
-                    | sort | { command -v shasum >/dev/null 2>&1 && shasum -a 1 | awk '{print $1}'; } \
-                    || grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
-                    | sort | sha1sum 2>/dev/null | awk '{print $1}' \
-                    || echo "")
-                if [[ -n "$_cur_hash" && "$_cur_hash" == "$_prev_hash" ]]; then
-                    warn "Compound quality: identical failures to previous cycle — aborting (no progress possible)"
-                    _cycles_executed=$cycle
-                    break
+                local _cur_hash _prev_hash _fail_line_count
+                _fail_line_count=$(grep -cE '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
+                    "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null || echo "0")
+                _fail_line_count="${_fail_line_count:-0}"
+                if [[ "$_fail_line_count" -gt 0 ]]; then
+                    _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
+                    _cur_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
+                        "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                        | sort | _compute_sha1 || echo "")
+                    if [[ -n "$_cur_hash" && "$_cur_hash" == "$_prev_hash" \
+                          && "$_cur_hash" != no-hasher-* ]]; then
+                        warn "Compound quality: identical failures to previous cycle — aborting (no progress possible)"
+                        _cycles_executed=$cycle
+                        break
+                    fi
                 fi
             fi
             # Record current failure set hash for next cycle's short-circuit check
-            { grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
-                | sort | { command -v shasum >/dev/null 2>&1 && shasum -a 1 | awk '{print $1}'; } \
-                || grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
-                | sort | sha1sum 2>/dev/null | awk '{print $1}'; } \
-                > "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null || true
+            { local _record_count
+              _record_count=$(grep -cE '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
+                  "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null || echo "0")
+              if [[ "${_record_count:-0}" -gt 0 ]]; then
+                  grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' \
+                      "${ARTIFACTS_DIR}/test-results.log" 2>/dev/null \
+                      | sort | _compute_sha1
+              fi
+            } > "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null || true
 
             if ! TEST_CMD="$_cq_test_cmd" compound_rebuild_with_feedback "$((cycle + 1))"; then
                 error "Rebuild with feedback failed"

--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -1015,6 +1015,10 @@ run_dod_audit() {
     local audit_output="# DoD Audit Results\n\n"
 
     while IFS= read -r line; do
+        # Skip [~] lines — these are manual items deferred in autonomous mode
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[~\] ]]; then
+            continue
+        fi
         if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*\[[[:space:]]\] ]]; then
             total=$((total + 1))
             local item="${line#*] }"
@@ -1071,6 +1075,15 @@ run_dod_audit() {
 
     echo -e "$audit_output\n\n**Score: ${passed}/${total} passed**" > "$ARTIFACTS_DIR/dod-audit.md"
 
+    # Append skipped count if classification sidecar exists
+    local _skipped_count=0
+    if [[ -f "${ARTIFACTS_DIR}/dod-classification.json" ]]; then
+        _skipped_count=$(jq -r '.skipped_manual // 0' "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || echo 0)
+    fi
+    if [[ "$_skipped_count" -gt 0 ]]; then
+        echo -e "\n_${_skipped_count} item(s) skipped (require human verification)_" >> "$ARTIFACTS_DIR/dod-audit.md"
+    fi
+
     # Stamp markdown with current commit SHA
     local _dod_sha
     _dod_sha=$(_pipeline_head_sha)
@@ -1080,6 +1093,18 @@ run_dod_audit() {
         { printf 'created_at_commit: %s\n' "$_dod_sha"; cat "$ARTIFACTS_DIR/dod-audit.md"; } > "$_dod_tmp" && mv "$_dod_tmp" "$ARTIFACTS_DIR/dod-audit.md" || rm -f "$_dod_tmp"
     fi
 
+    # If all items were skipped (all manual), pass with a warning
+    if [[ "$total" -eq 0 ]]; then
+        local _skipped_c=0
+        [[ -f "${ARTIFACTS_DIR}/dod-classification.json" ]] && \
+            _skipped_c=$(jq -r '.skipped_manual // 0' "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || echo 0)
+        if [[ "$_skipped_c" -gt 0 ]]; then
+            warn "DoD audit: all ${_skipped_c} items are manual — skipped in autonomous mode (passing)"
+            return 0
+        fi
+        warn "DoD audit: no items found in dod.md"
+        return 0
+    fi
     if [[ "$failed" -gt 0 ]]; then
         warn "DoD audit: ${passed}/${total} passed, ${failed} failed"
         return 1

--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -1099,6 +1099,12 @@ run_dod_audit() {
         [[ -f "${ARTIFACTS_DIR}/dod-classification.json" ]] && \
             _skipped_c=$(jq -r '.skipped_manual // 0' "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || echo 0)
         if [[ "$_skipped_c" -gt 0 ]]; then
+            local _total_items
+            _total_items=$(grep -cE '^\s*-\s*\[' "$ARTIFACTS_DIR/dod-audit.md" 2>/dev/null || echo "0") || _total_items=0
+            if [[ "$_skipped_c" -ge "$_total_items" && "$_total_items" -gt 0 ]]; then
+                error "DoD audit: all ${_total_items} item(s) classified as manual — at least one item must be auto-verified"
+                return 1
+            fi
             warn "DoD audit: all ${_skipped_c} items are manual — skipped in autonomous mode (passing)"
             return 0
         fi

--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -1093,19 +1093,22 @@ run_dod_audit() {
         { printf 'created_at_commit: %s\n' "$_dod_sha"; cat "$ARTIFACTS_DIR/dod-audit.md"; } > "$_dod_tmp" && mv "$_dod_tmp" "$ARTIFACTS_DIR/dod-audit.md" || rm -f "$_dod_tmp"
     fi
 
-    # If all items were skipped (all manual), pass with a warning
+    # If all items were skipped (all manual), pass with a warning.
+    # Counts come from dod-classification.json (which knows the ORIGINAL DoD count
+    # before [~] stripping). Counting from dod-audit.md would zero out for an
+    # all-manual plan (since [~] items are dropped), defeating the guard.
     if [[ "$total" -eq 0 ]]; then
-        local _skipped_c=0
-        [[ -f "${ARTIFACTS_DIR}/dod-classification.json" ]] && \
+        local _skipped_c=0 _orig_total=0
+        if [[ -f "${ARTIFACTS_DIR}/dod-classification.json" ]]; then
             _skipped_c=$(jq -r '.skipped_manual // 0' "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || echo 0)
+            _orig_total=$(jq -r '.total // 0' "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || echo 0)
+        fi
+        if [[ "$_orig_total" -gt 0 && "$_skipped_c" -ge "$_orig_total" ]]; then
+            error "DoD audit: all ${_orig_total} item(s) classified as manual — at least one item must be auto-verified"
+            return 1
+        fi
         if [[ "$_skipped_c" -gt 0 ]]; then
-            local _total_items
-            _total_items=$(grep -cE '^\s*-\s*\[' "$ARTIFACTS_DIR/dod-audit.md" 2>/dev/null || echo "0") || _total_items=0
-            if [[ "$_skipped_c" -ge "$_total_items" && "$_total_items" -gt 0 ]]; then
-                error "DoD audit: all ${_total_items} item(s) classified as manual — at least one item must be auto-verified"
-                return 1
-            fi
-            warn "DoD audit: all ${_skipped_c} items are manual — skipped in autonomous mode (passing)"
+            warn "DoD audit: ${_skipped_c} items are manual — skipped in autonomous mode (passing)"
             return 0
         fi
         warn "DoD audit: no items found in dod.md"

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -883,6 +883,37 @@ stage_test() {
       warn "Failed to write test-results.status.json — downstream consumers will fall back to log parsing"
     fi
 
+    # Portable SHA-1 hash of stdin — works on macOS (shasum) and Linux (sha1sum/shasum).
+    _compute_sha1() {
+        if command -v shasum >/dev/null 2>&1; then
+            shasum -a 1 | awk '{print $1}'
+        elif command -v sha1sum >/dev/null 2>&1; then
+            sha1sum | awk '{print $1}'
+        elif command -v openssl >/dev/null 2>&1; then
+            openssl dgst -sha1 -hex | awk '{print $NF}'
+        else
+            # No hasher available — return a unique sentinel to disable dedup
+            printf 'no-hasher-%s-%s' "$PPID" "$(date +%s 2>/dev/null || echo 0)"
+        fi
+    }
+
+    # Extracts per-suite failure summaries from a test log.
+    # Looks for suite headers (sw-*-test.sh lines) and failure markers (✗, ●, FAIL).
+    _summarize_test_failures() {
+        local test_log="$1"
+        local max_lines="${2:-40}"
+        [[ ! -f "$test_log" ]] && return 0
+        awk '
+            /sw-[a-z]+-test\.sh/ { suite = $0; gsub(/^[[:space:]]+|[[:space:]]+$/, "", suite) }
+            /^[[:space:]]*(FAIL|✗|●|×)[[:space:]]/ && suite != "" {
+                print "  • " suite " — " $0
+            }
+            /[0-9]+ of [0-9]+ tests? failed/ && suite != "" {
+                print "  " suite ": " $0
+            }
+        ' "$test_log" 2>/dev/null | head -"$max_lines"
+    }
+
     if [[ "$test_exit" -eq 0 ]]; then
         success "Tests passed"
     else
@@ -895,23 +926,49 @@ stage_test() {
         fi
         echo "$relevant_output"
 
-        # Post failure to GitHub with more context
+        # Post failure to GitHub with actionable summary (not full log dump)
         if [[ -n "$ISSUE_NUMBER" ]]; then
             local log_lines
-            log_lines=$(wc -l < "$test_log" 2>/dev/null || true)
+            log_lines=$(wc -l < "$test_log" 2>/dev/null || echo 0)
             log_lines="${log_lines:-0}"
-            local log_excerpt
-            if [[ "$log_lines" -lt 60 ]]; then
-                log_excerpt="$(cat "$test_log" 2>/dev/null | strip_ansi || true)"
-            else
-                log_excerpt="$(head -20 "$test_log" 2>/dev/null | strip_ansi || true)
-... (${log_lines} lines total, showing head + tail) ...
-$(tail -30 "$test_log" 2>/dev/null | strip_ansi || true)"
+
+            # Compute dedup hash from sorted failure names to detect identical consecutive failures
+            local _fail_hash _prev_hash
+            _fail_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "$test_log" 2>/dev/null \
+                | sort | _compute_sha1 || echo "")
+            _prev_hash=""
+            if [[ -n "${ARTIFACTS_DIR:-}" && -f "${ARTIFACTS_DIR}/last-failure-set.sha" ]]; then
+                _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
             fi
-            gh_comment_issue "$ISSUE_NUMBER" "❌ **Tests failed** (exit code: $test_exit, ${log_lines} lines)
+
+            local _gh_body
+            if [[ -n "$_fail_hash" && "$_fail_hash" == "$_prev_hash" ]]; then
+                # Same failures as previous cycle — abbreviated notice
+                _gh_body="↺ **Same test failures as previous cycle** (exit code: $test_exit, ${log_lines} lines)
+
+No new failures introduced. See previous comment for details."
+            else
+                # New or changed failures — show actionable summary
+                local _failure_summary
+                _failure_summary=$(_summarize_test_failures "$test_log" 30)
+                if [[ -z "$_failure_summary" ]]; then
+                    # Fallback: last 20 lines of relevant output
+                    _failure_summary=$(echo "$relevant_output" | tail -20)
+                fi
+                _gh_body="❌ **Tests failed** (exit code: $test_exit, ${log_lines} lines)
+
 \`\`\`
-${log_excerpt}
+${_failure_summary}
 \`\`\`"
+            fi
+
+            # Save current hash for next cycle dedup
+            if [[ -n "${ARTIFACTS_DIR:-}" && -n "$_fail_hash" ]]; then
+                mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
+                echo "$_fail_hash" > "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null || true
+            fi
+
+            gh_comment_issue "$ISSUE_NUMBER" "$_gh_body"
         fi
         # Store failed test result in ruflo for flakiness tracking
         if declare -f ruflo_store >/dev/null 2>&1 && \

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -883,20 +883,6 @@ stage_test() {
       warn "Failed to write test-results.status.json — downstream consumers will fall back to log parsing"
     fi
 
-    # Portable SHA-1 hash of stdin — works on macOS (shasum) and Linux (sha1sum/shasum).
-    _compute_sha1() {
-        if command -v shasum >/dev/null 2>&1; then
-            shasum -a 1 | awk '{print $1}'
-        elif command -v sha1sum >/dev/null 2>&1; then
-            sha1sum | awk '{print $1}'
-        elif command -v openssl >/dev/null 2>&1; then
-            openssl dgst -sha1 -hex | awk '{print $NF}'
-        else
-            # No hasher available — return a unique sentinel to disable dedup
-            printf 'no-hasher-%s-%s' "$PPID" "$(date +%s 2>/dev/null || echo 0)"
-        fi
-    }
-
     # Extracts per-suite failure summaries from a test log.
     # Looks for suite headers (sw-*-test.sh lines) and failure markers (✗, ●, FAIL).
     _summarize_test_failures() {

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -918,17 +918,25 @@ stage_test() {
             log_lines=$(wc -l < "$test_log" 2>/dev/null || echo 0)
             log_lines="${log_lines:-0}"
 
-            # Compute dedup hash from sorted failure names to detect identical consecutive failures
-            local _fail_hash _prev_hash
-            _fail_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "$test_log" 2>/dev/null \
-                | sort | _compute_sha1 || echo "")
-            _prev_hash=""
-            if [[ -n "${ARTIFACTS_DIR:-}" && -f "${ARTIFACTS_DIR}/last-failure-set.sha" ]]; then
-                _prev_hash=$(cat "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null | tr -d '[:space:]' || true)
+            # Compute dedup hash from sorted failure names to detect identical
+            # consecutive GitHub comments. Uses its own state file (NOT the one
+            # compound_quality uses for cycle short-circuit, which lives at
+            # last-failure-set.sha — shared writes would cross-contaminate the
+            # cycle dedup logic). Gated on positive failure count: SHA-1 of empty
+            # stdin is a constant, which would falsely match unrelated infra failures.
+            local _fail_hash="" _prev_hash="" _stage_test_count
+            _stage_test_count=$(grep -cE '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "$test_log" 2>/dev/null) || _stage_test_count=0
+            _stage_test_count="${_stage_test_count:-0}"
+            if [[ "$_stage_test_count" -gt 0 ]]; then
+                _fail_hash=$(grep -E '^[[:space:]]*(FAIL|✗|●|×)[[:space:]]' "$test_log" 2>/dev/null \
+                    | sort | _compute_sha1 || echo "")
+            fi
+            if [[ -n "${ARTIFACTS_DIR:-}" && -f "${ARTIFACTS_DIR}/stage-test-last-comment.sha" ]]; then
+                _prev_hash=$(cat "${ARTIFACTS_DIR}/stage-test-last-comment.sha" 2>/dev/null | tr -d '[:space:]' || true)
             fi
 
             local _gh_body
-            if [[ -n "$_fail_hash" && "$_fail_hash" == "$_prev_hash" ]]; then
+            if [[ -n "$_fail_hash" && "$_fail_hash" == "$_prev_hash" && "$_fail_hash" != no-hasher-* ]]; then
                 # Same failures as previous cycle — abbreviated notice
                 _gh_body="↺ **Same test failures as previous cycle** (exit code: $test_exit, ${log_lines} lines)
 
@@ -948,10 +956,10 @@ ${_failure_summary}
 \`\`\`"
             fi
 
-            # Save current hash for next cycle dedup
+            # Save current hash for next stage_test comment dedup (separate from compound_quality)
             if [[ -n "${ARTIFACTS_DIR:-}" && -n "$_fail_hash" ]]; then
                 mkdir -p "$ARTIFACTS_DIR" 2>/dev/null || true
-                echo "$_fail_hash" > "${ARTIFACTS_DIR}/last-failure-set.sha" 2>/dev/null || true
+                echo "$_fail_hash" > "${ARTIFACTS_DIR}/stage-test-last-comment.sha" 2>/dev/null || true
             fi
 
             gh_comment_issue "$ISSUE_NUMBER" "$_gh_body"

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -397,7 +397,23 @@ A checkbox list of discrete tasks that can be tracked:
 How to verify the implementation works.
 
 ### Definition of Done
-Checklist of completion criteria.
+Checklist of completion criteria. EVERY item MUST end with a verification tag:
+
+  {auto:tests}       — verified by \`npm test\` or a specific test script
+  {auto:lint}        — verified by \`shellcheck\` / \`eslint\` / equivalent
+  {auto:diff}        — verified by inspecting the cumulative branch diff
+  {auto:build}       — verified by \`npm run build\` or workflow assertion
+  {auto:other:CMD}   — verified by running CMD and checking exit/output
+  {manual}           — requires a human (WILL BE SKIPPED in autonomous pipeline mode)
+
+RULES:
+1. Prefer auto: tags. A {manual} item in autonomous mode = SKIPPED, not FAILED.
+2. NEVER phrase an auto item as "manual verification" — it will block the loop.
+3. If you cannot define a verification command, put it in the PR description instead.
+4. Maximum 10 items. Each must be independently verifiable.
+5. Example: - [ ] \`npm test\` exits 0 with all 339 tests passing {auto:tests}
+6. Example: - [ ] \`scripts/sw-cost-share-test.sh\` exits 0 {auto:other:bash scripts/sw-cost-share-test.sh}
+7. Example: - [ ] PR description includes architecture diagram {manual}
 "
 
     # Inject skill prompts — prefer AI-powered plan, fallback to adaptive, then static
@@ -730,6 +746,72 @@ CC_TASKS_EOF
         return "$_rc"
     }
     _validate_dod_md "$ARTIFACTS_DIR/dod.md" || return 1
+
+    # Classify DoD items as "auto" or "manual" for autonomous pipeline mode.
+    # Items tagged {manual} or matching human-verification heuristics are rewritten
+    # as [~] lines that the DoD audit skips in autonomous mode.
+    _classify_dod_item() {
+        local line="$1"
+        # Explicit tag wins
+        if echo "$line" | grep -qE '\{auto:'; then echo "auto"; return; fi
+        if echo "$line" | grep -qE '\{manual\}'; then echo "manual"; return; fi
+        # Heuristic for untagged items (legacy + LLM forgot to tag)
+        # Exclude lines that contain a backtick-quoted command — these are auto items.
+        if echo "$line" | grep -qE '`(npm|bash|yarn|pnpm|make|node|sh|python|go)[[:space:]]'; then
+            echo "auto"; return
+        fi
+        if echo "$line" | grep -qiE 'manual|smoke[[:space:]]+test|by[[:space:]]+hand|human[[:space:]]+verif|visually[[:space:]]|ux[[:space:]]+review|stakeholder|screenshot|demo[[:space:]]+to'; then
+            echo "manual"
+        else
+            echo "auto"
+        fi
+    }
+
+    # In autonomous pipeline mode, rewrite {manual} DoD items as [~] (skipped).
+    # Writes dod-classification.json sidecar for downstream consumers.
+    _apply_dod_classification() {
+        local dod_file="$1"
+        [[ ! -s "$dod_file" ]] && return 0
+        # Only reclassify in autonomous mode
+        local _source="${SHIPWRIGHT_SOURCE:-session}"
+        if [[ "$_source" != "pipeline" && "$_source" != "daemon" ]]; then
+            return 0
+        fi
+
+        local _tmp_dod _tmp_json
+        _tmp_dod=$(mktemp "${TMPDIR:-/tmp}/sw-dod-class.XXXXXX")
+        _tmp_json=$(mktemp "${TMPDIR:-/tmp}/sw-dod-json.XXXXXX")
+        trap 'rm -f "$_tmp_dod" "$_tmp_json"' RETURN
+        echo '[]' > "$_tmp_json"
+        local _total=0 _skipped=0
+
+        while IFS= read -r line; do
+            if echo "$line" | grep -qE '^[[:space:]]*-[[:space:]]'; then
+                _total=$(( _total + 1 ))
+                local _class
+                _class=$(_classify_dod_item "$line")
+                if [[ "$_class" == "manual" ]]; then
+                    _skipped=$(( _skipped + 1 ))
+                    # Rewrite as [~] skipped marker
+                    line=$(echo "$line" | sed 's/^[[:space:]]*-[[:space:]]*/- [~] /')
+                    line="${line} (skipped: requires human verification)"
+                fi
+            fi
+            echo "$line" >> "$_tmp_dod"
+        done < "$dod_file"
+
+        mv "$_tmp_dod" "$dod_file" || rm -f "$_tmp_dod"
+
+        # Write classification sidecar
+        echo "{\"total\":${_total},\"auto\":$((_total - _skipped)),\"skipped_manual\":${_skipped}}" \
+            > "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+
+        if [[ "$_skipped" -gt 0 ]]; then
+            info "DoD: ${_skipped}/${_total} items marked as manual-only — will be skipped in autonomous audit"
+        fi
+    }
+
+    _apply_dod_classification "$ARTIFACTS_DIR/dod.md"
 
     # ── Plan Validation Gate ──
     # Ask Claude to validate the plan before proceeding

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -802,8 +802,13 @@ CC_TASKS_EOF
 
         mv "$_tmp_dod" "$dod_file" || rm -f "$_tmp_dod"
 
-        # Write classification sidecar
-        echo "{\"total\":${_total},\"auto\":$((_total - _skipped)),\"skipped_manual\":${_skipped}}" \
+        # Write classification sidecar via jq --argjson to avoid string interpolation
+        local _auto=$(( _total - _skipped ))
+        jq -n \
+            --argjson total "$_total" \
+            --argjson auto "$_auto" \
+            --argjson skipped_manual "$_skipped" \
+            '{"total":$total,"auto":$auto,"skipped_manual":$skipped_manual}' \
             > "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
 
         if [[ "$_skipped" -gt 0 ]]; then

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -802,14 +802,19 @@ CC_TASKS_EOF
 
         mv "$_tmp_dod" "$dod_file" || rm -f "$_tmp_dod"
 
-        # Write classification sidecar via jq --argjson to avoid string interpolation
+        # Write classification sidecar via jq --argjson to avoid string interpolation.
+        # Atomic: write to the pre-allocated _tmp_json then mv into place — a failing
+        # or interrupted jq must not leave a partial dod-classification.json that
+        # downstream consumers might mistakenly trust.
         local _auto=$(( _total - _skipped ))
-        jq -n \
+        if jq -n \
             --argjson total "$_total" \
             --argjson auto "$_auto" \
             --argjson skipped_manual "$_skipped" \
             '{"total":$total,"auto":$auto,"skipped_manual":$skipped_manual}' \
-            > "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+            > "$_tmp_json" 2>/dev/null; then
+            mv "$_tmp_json" "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+        fi
 
         if [[ "$_skipped" -gt 0 ]]; then
             info "DoD: ${_skipped}/${_total} items marked as manual-only — will be skipped in autonomous audit"

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -808,13 +808,14 @@ CC_TASKS_EOF
         # or interrupted jq must not leave a partial dod-classification.json that
         # downstream consumers might mistakenly trust.
         local _auto=$(( _total - _skipped ))
-        jq -n \
+        if jq -n \
             --argjson total "$_total" \
             --argjson auto "$_auto" \
             --argjson skipped_manual "$_skipped" \
             '{"total":$total,"auto":$auto,"skipped_manual":$skipped_manual}' \
-            > "$_tmp_json" 2>/dev/null \
-        && mv "$_tmp_json" "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+            > "$_tmp_json" 2>/dev/null; then
+            mv "$_tmp_json" "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+        fi
         rm -f "$_tmp_json" 2>/dev/null || true
 
         if [[ "$_skipped" -gt 0 ]]; then

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -408,7 +408,7 @@ Checklist of completion criteria. EVERY item MUST end with a verification tag:
 
 RULES:
 1. Prefer auto: tags. A {manual} item in autonomous mode = SKIPPED, not FAILED.
-2. NEVER phrase an auto item as "manual verification" — it will block the loop.
+2. NEVER phrase an auto item as \"manual verification\" — it will block the loop.
 3. If you cannot define a verification command, put it in the PR description instead.
 4. Maximum 10 items. Each must be independently verifiable.
 5. Example: - [ ] \`npm test\` exits 0 with all 339 tests passing {auto:tests}
@@ -779,9 +779,10 @@ CC_TASKS_EOF
         fi
 
         local _tmp_dod _tmp_json
-        _tmp_dod=$(mktemp "${TMPDIR:-/tmp}/sw-dod-class.XXXXXX")
-        _tmp_json=$(mktemp "${TMPDIR:-/tmp}/sw-dod-json.XXXXXX")
-        trap 'rm -f "$_tmp_dod" "$_tmp_json"' RETURN
+        # Explicit mktemp with fallback — avoids using a RETURN trap, which leaks into
+        # the parent function scope in bash and fires again with out-of-scope locals.
+        _tmp_dod=$(mktemp "${TMPDIR:-/tmp}/sw-dod-class.XXXXXX") || return 0
+        _tmp_json=$(mktemp "${TMPDIR:-/tmp}/sw-dod-json.XXXXXX") || { rm -f "$_tmp_dod"; return 0; }
         echo '[]' > "$_tmp_json"
         local _total=0 _skipped=0
 
@@ -800,21 +801,21 @@ CC_TASKS_EOF
             echo "$line" >> "$_tmp_dod"
         done < "$dod_file"
 
-        mv "$_tmp_dod" "$dod_file" || rm -f "$_tmp_dod"
+        mv "$_tmp_dod" "$dod_file" 2>/dev/null || rm -f "$_tmp_dod" 2>/dev/null || true
 
         # Write classification sidecar via jq --argjson to avoid string interpolation.
         # Atomic: write to the pre-allocated _tmp_json then mv into place — a failing
         # or interrupted jq must not leave a partial dod-classification.json that
         # downstream consumers might mistakenly trust.
         local _auto=$(( _total - _skipped ))
-        if jq -n \
+        jq -n \
             --argjson total "$_total" \
             --argjson auto "$_auto" \
             --argjson skipped_manual "$_skipped" \
             '{"total":$total,"auto":$auto,"skipped_manual":$skipped_manual}' \
-            > "$_tmp_json" 2>/dev/null; then
-            mv "$_tmp_json" "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
-        fi
+            > "$_tmp_json" 2>/dev/null \
+        && mv "$_tmp_json" "${ARTIFACTS_DIR}/dod-classification.json" 2>/dev/null || true
+        rm -f "$_tmp_json" 2>/dev/null || true
 
         if [[ "$_skipped" -gt 0 ]]; then
             info "DoD: ${_skipped}/${_total} items marked as manual-only — will be skipped in autonomous audit"

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -34,6 +34,8 @@ PIPELINE_RUN_EPOCH="${PIPELINE_RUN_EPOCH:-0}"
 OUTER_STAGE="${OUTER_STAGE:-}"   # set when inside a nested execution context (e.g. compound rebuild)
 OUTER_STAGE_START_COMMIT="${OUTER_STAGE_START_COMMIT:-}"  # HEAD at compound_quality entry (for diff-base accuracy)
 INNER_STAGE="${INNER_STAGE:-}"   # the nested stage being executed (build/test/review)
+COMPOUND_QUALITY_CYCLE="${COMPOUND_QUALITY_CYCLE:-1}"  # current compound_quality cycle number (1-based)
+SELF_HEAL_COUNT="${SELF_HEAL_COUNT:-0}"                # build iterations completed (0 = first run)
 
 save_artifact() {
     local name="$1" content="$2"
@@ -48,6 +50,32 @@ get_stage_status() {
 
 set_outer_stage() { OUTER_STAGE="$1"; INNER_STAGE=""; write_state; }
 clear_outer_stage() { OUTER_STAGE=""; INNER_STAGE=""; write_state; }
+
+# Returns a human-readable label for the current execution scope.
+# Examples:
+#   Top-level:               "Build Iteration 1"
+#   Inside compound_quality: "Compound Quality 2 — Build Iteration 3"
+scope_label() {
+    local outer="${OUTER_STAGE:-}"
+    local inner="${INNER_STAGE:-}"
+    # Bash 3.2 compat: use awk for capitalization instead of ${var^}
+    local build_iter
+    build_iter=$(( ${SELF_HEAL_COUNT:-0} + 1 ))
+    local cq_cycle="${COMPOUND_QUALITY_CYCLE:-1}"
+
+    if [[ -n "$outer" ]]; then
+        # e.g. "compound_quality" -> "Compound Quality"
+        local outer_pretty
+        outer_pretty=$(echo "$outer" | tr '_' ' ' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) substr($i,2)}} 1')
+        local inner_pretty="${inner:-build}"
+        inner_pretty=$(echo "$inner_pretty" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+        echo "${outer_pretty} ${cq_cycle} — ${inner_pretty} Iteration ${build_iter}"
+    else
+        local top_pretty="${inner:-Build}"
+        top_pretty=$(echo "$top_pretty" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+        echo "${top_pretty} Iteration ${build_iter}"
+    fi
+}
 
 set_stage_status() {
     local stage_id="$1" status="$2"
@@ -549,6 +577,27 @@ get_stage_self_awareness_hint() {
     fi
 }
 
+# Resolves the log file path for a stage, handling both underscore and hyphen forms.
+# stage_id may use underscores (compound_quality) but log files may use hyphens (compound-quality.log).
+_resolve_stage_log_path() {
+    local stage_id="$1"
+    local underscore_form="${ARTIFACTS_DIR}/${stage_id}.log"
+    local hyphen_form="${ARTIFACTS_DIR}/${stage_id//_/-}.log"
+    if [[ -f "$underscore_form" ]]; then
+        echo "$underscore_form"
+    elif [[ -f "$hyphen_form" ]]; then
+        echo "$hyphen_form"
+    else
+        # Glob fallback: find any matching log file
+        local globbed
+        globbed=$(ls "${ARTIFACTS_DIR}/${stage_id}"*.log 2>/dev/null | head -1 || true)
+        if [[ -n "$globbed" ]]; then
+            echo "$globbed"
+        fi
+        # Returns empty string if no log found
+    fi
+}
+
 mark_stage_failed() {
     local stage_id="$1"
     record_stage_end "$stage_id"
@@ -585,13 +634,24 @@ mark_stage_failed() {
             gh_comment_issue "$ISSUE_NUMBER" "❌ Pipeline failed at stage **${stage_id}** after ${timing}.
 
 \`\`\`
-$(tail -5 "$ARTIFACTS_DIR/${stage_id}"*.log 2>/dev/null || echo 'No log available')
+$( \
+    _log_path=$(_resolve_stage_log_path "${stage_id:-unknown}"); \
+    if [[ -n "$_log_path" ]]; then \
+        tail -5 "$_log_path" 2>/dev/null || echo 'Log file unreadable'; \
+    else \
+        printf 'Diagnostic: stage %s produced no log at %s/{%s,%s}.log\n' \
+            "${stage_id:-unknown}" "${ARTIFACTS_DIR}" \
+            "${stage_id:-unknown}" "${stage_id//_/-}"; \
+        printf 'Check: ARTIFACTS_DIR=%s, last-stderr.log for process output\n' "${ARTIFACTS_DIR}"; \
+    fi \
+)
 \`\`\`"
         fi
 
         # Notify tracker (Linear/Jira) of stage failure
         local error_context
-        error_context=$(tail -5 "$ARTIFACTS_DIR/${stage_id}"*.log 2>/dev/null || echo "No log")
+        _ec_log=$(_resolve_stage_log_path "${stage_id:-unknown}"); \
+        error_context=$(tail -5 "${_ec_log:-/dev/null}" 2>/dev/null || echo "No log")
         "$SCRIPT_DIR/sw-tracker.sh" notify "stage_failed" "$ISSUE_NUMBER" \
             "${stage_id}|${error_context}" 2>/dev/null || true
 
@@ -602,7 +662,8 @@ $(tail -5 "$ARTIFACTS_DIR/${stage_id}"*.log 2>/dev/null || echo 'No log availabl
     # Update GitHub Check Run for this stage
     if [[ "${NO_GITHUB:-false}" != "true" ]] && type gh_checks_stage_update >/dev/null 2>&1; then
         local fail_summary
-        fail_summary=$(tail -3 "$ARTIFACTS_DIR/${stage_id}"*.log 2>/dev/null | head -c 500 || echo "Stage $stage_id failed")
+        _fs_log=$(_resolve_stage_log_path "${stage_id:-unknown}"); \
+        fail_summary=$(tail -3 "${_fs_log:-/dev/null}" 2>/dev/null | head -c 500 || echo "Stage $stage_id failed")
         gh_checks_stage_update "$stage_id" "completed" "failure" "$fail_summary" 2>/dev/null || true
     fi
 
@@ -822,6 +883,7 @@ write_state() {
         fi
         update_pipeline_status "$_job_id" "$PIPELINE_STATUS" "$CURRENT_STAGE" "" "$_dur_secs" 2>/dev/null || true
     fi
+
 }
 
 resume_state() {

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -642,9 +642,10 @@ $( \
 \`\`\`"
         fi
 
-        # Notify tracker (Linear/Jira) of stage failure
-        local error_context
-        _ec_log=$(_resolve_stage_log_path "${stage_id:-unknown}"); \
+        # Notify tracker (Linear/Jira) of stage failure.
+        # `|| _ec_log=""` so set -e doesn't abort mark_stage_failed when no log found.
+        local error_context _ec_log
+        _ec_log=$(_resolve_stage_log_path "${stage_id:-unknown}") || _ec_log=""
         error_context=$(tail -5 "${_ec_log:-/dev/null}" 2>/dev/null || echo "No log")
         "$SCRIPT_DIR/sw-tracker.sh" notify "stage_failed" "$ISSUE_NUMBER" \
             "${stage_id}|${error_context}" 2>/dev/null || true
@@ -655,8 +656,8 @@ $( \
 
     # Update GitHub Check Run for this stage
     if [[ "${NO_GITHUB:-false}" != "true" ]] && type gh_checks_stage_update >/dev/null 2>&1; then
-        local fail_summary
-        _fs_log=$(_resolve_stage_log_path "${stage_id:-unknown}"); \
+        local fail_summary _fs_log
+        _fs_log=$(_resolve_stage_log_path "${stage_id:-unknown}") || _fs_log=""
         fail_summary=$(tail -3 "${_fs_log:-/dev/null}" 2>/dev/null | head -c 500 || echo "Stage $stage_id failed")
         gh_checks_stage_update "$stage_id" "completed" "failure" "$fail_summary" 2>/dev/null || true
     fi

--- a/scripts/lib/pipeline-state.sh
+++ b/scripts/lib/pipeline-state.sh
@@ -588,13 +588,7 @@ _resolve_stage_log_path() {
     elif [[ -f "$hyphen_form" ]]; then
         echo "$hyphen_form"
     else
-        # Glob fallback: find any matching log file
-        local globbed
-        globbed=$(ls "${ARTIFACTS_DIR}/${stage_id}"*.log 2>/dev/null | head -1 || true)
-        if [[ -n "$globbed" ]]; then
-            echo "$globbed"
-        fi
-        # Returns empty string if no log found
+        return 1
     fi
 }
 
@@ -868,7 +862,7 @@ write_state() {
         printf 'progress_comment_id: %s\n' "${PROGRESS_COMMENT_ID:-}"
         printf 'stages:\n'
         printf '%s' "${stages_yaml}"
-        printf -- '---\n\n'
+        printf -- '---\n'
         printf '## Log\n'
         printf '%s\n' "$LOG_ENTRIES"
     } > "$tmp_state"

--- a/scripts/sw-e2e-system-test.sh
+++ b/scripts/sw-e2e-system-test.sh
@@ -109,7 +109,7 @@ mkdir -p "$log_dir" 2>/dev/null || true
 echo "cwd=$(pwd) use_json=$use_json args=$raw_args" >> "$log_dir/mock-claude.log"
 
 if [[ "$use_json" == "true" ]]; then
-    if echo "$prompt" | grep -qi "autonomous coding agent on iteration"; then
+    if echo "$prompt" | grep -qiE "autonomous coding agent([.] | on iteration)"; then
         # Loop mode: create files, then output JSON with LOOP_COMPLETE.
         repo_root=""
         repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)

--- a/scripts/sw-lib-pipeline-intelligence-test.sh
+++ b/scripts/sw-lib-pipeline-intelligence-test.sh
@@ -1081,4 +1081,65 @@ else
         "guard at line ${_guard_line:-?}, set_outer_stage at line ${_set_outer_line:-?} — must be guard < set_outer_stage"
 fi
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# H2: JSON-absent fail-closed — security-source-scan.json missing → BLOCKING item
+# When security-source-scan.log exists but security-source-scan.json is absent or
+# invalid, _extract_blocking_items must inject a synthetic SCANNER_ARTIFACT_MISSING
+# blocking item so the gate stays closed (fail-closed, not fail-open).
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "H2: JSON-absent fail-closed for security-source-scan"
+
+# Restore the real _extract_blocking_items — earlier tests stub it with { echo ""; }
+# to isolate compound_rebuild_with_feedback. Clear the load guard and re-source the lib.
+unset -f _extract_blocking_items 2>/dev/null || true
+_PIPELINE_INTELLIGENCE_LOADED=""
+source "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null
+
+rm -f "$ARTIFACTS_DIR/security-source-scan.json" "$ARTIFACTS_DIR/security-source-scan.log" \
+      "$ARTIFACTS_DIR/security-audit.log" "$ARTIFACTS_DIR/adversarial-review.json" \
+      "$ARTIFACTS_DIR/adversarial-review.md" "$ARTIFACTS_DIR/negative-review.md" \
+      "$ARTIFACTS_DIR/dod-audit.md" "$ARTIFACTS_DIR/classified-findings.json" \
+      "$ARTIFACTS_DIR/security-advisories.log"
+
+# Create a security-source-scan.log without a corresponding .json artifact
+printf '# security scan log\nCRITICAL: src/app.sh:5 — potential secret\n' \
+    > "$ARTIFACTS_DIR/security-source-scan.log"
+
+# Confirm .json is absent
+_h2_blocking=$(_extract_blocking_items)
+
+_h2_has_missing=$(echo "$_h2_blocking" | grep -c "SCANNER_ARTIFACT_MISSING" 2>/dev/null || true)
+_h2_has_missing="${_h2_has_missing:-0}"
+assert_gt \
+    "H2: SCANNER_ARTIFACT_MISSING blocking item emitted when security-source-scan.json absent" \
+    "${_h2_has_missing:-0}" "0"
+
+# Verify the finding appears in the blocking output (non-empty output means it is blocking)
+if [[ -n "$_h2_blocking" ]]; then
+    assert_pass "H2: _extract_blocking_items output is non-empty (finding is blocking, not advisory-only)"
+else
+    assert_fail "H2: _extract_blocking_items output is non-empty (finding is blocking, not advisory-only)" \
+        "got empty output — SCANNER_ARTIFACT_MISSING was not promoted to blocking"
+fi
+
+# Verify advisory sidecar does NOT contain the blocking item (it's in blocking, not advisory)
+_h2_advisory=$(cat "$ARTIFACTS_DIR/security-advisories.log" 2>/dev/null || true)
+_h2_in_advisory=$(echo "$_h2_advisory" | grep -c "SCANNER_ARTIFACT_MISSING" 2>/dev/null || true)
+_h2_in_advisory="${_h2_in_advisory:-0}"
+assert_eq \
+    "H2: SCANNER_ARTIFACT_MISSING is NOT placed in advisory sidecar (it is blocking)" \
+    "0" "${_h2_in_advisory:-0}"
+
+# Also test: when security-source-scan.log is absent, no synthetic item injected
+rm -f "$ARTIFACTS_DIR/security-source-scan.log" "$ARTIFACTS_DIR/security-advisories.log"
+_h2_no_log_blocking=$(_extract_blocking_items)
+_h2_no_log_missing=$(echo "$_h2_no_log_blocking" | grep -c "SCANNER_ARTIFACT_MISSING" 2>/dev/null || true)
+_h2_no_log_missing="${_h2_no_log_missing:-0}"
+assert_eq \
+    "H2: SCANNER_ARTIFACT_MISSING not injected when security-source-scan.log is also absent" \
+    "0" "${_h2_no_log_missing:-0}"
+
+rm -f "$ARTIFACTS_DIR/security-source-scan.json" "$ARTIFACTS_DIR/security-source-scan.log" \
+      "$ARTIFACTS_DIR/security-advisories.log"
+
 print_test_results

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -3626,6 +3626,37 @@ else
         "got: $_vr_normal_result"
 fi
 
+# ─── C1 pre-run marker cleanup (regression guard) ────────────────────────────
+# launch_multi_agent MUST remove stale .agent-*-abort-reason / .agent-*-complete
+# markers BEFORE setup_worktrees runs. Without this, a crashed prior run leaves
+# .agent-N-abort-reason in $LOG_DIR; wait_for_multi_completion reads it on the
+# first poll of the new run and false-aborts before agents have started.
+_lma_body=$(awk '/^launch_multi_agent\(\)/{p=1} p{print} p && /^\}$/{exit}' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null || true)
+_lma_cleanup_line=$(echo "$_lma_body" | grep -n 'abort-reason' | head -1 | cut -d: -f1 || echo "0")
+_lma_setup_line=$(echo "$_lma_body" | grep -n 'setup_worktrees' | head -1 | cut -d: -f1 || echo "0")
+if [[ "${_lma_cleanup_line:-0}" -gt 0 && "${_lma_cleanup_line:-0}" -lt "${_lma_setup_line:-9999}" ]]; then
+    assert_pass "C1_pre_run_marker_cleanup: launch_multi_agent removes stale abort-reason markers BEFORE setup_worktrees"
+else
+    assert_fail "C1_pre_run_marker_cleanup: launch_multi_agent must clean .agent-*-abort-reason before setup_worktrees" \
+        "cleanup at line ${_lma_cleanup_line}, setup at line ${_lma_setup_line} (within function body)"
+fi
+
+# ─── loop-iteration: ALL scope_label callers must be guarded ──────────────────
+# Codex P1 was about line 786 in caabd4a, but lines 577 and 598 also call
+# $(scope_label). All must have a fallback because sw-loop.sh does NOT source
+# pipeline-state.sh (which defines scope_label).
+_unguarded_scope_label=$(grep -n '\$(scope_label)' "$SCRIPT_DIR/lib/loop-iteration.sh" 2>/dev/null \
+    | grep -v '|| echo' \
+    | wc -l | tr -d '[:space:]' || echo "0")
+if [[ "${_unguarded_scope_label:-0}" -eq 0 ]]; then
+    assert_pass "loop_iteration_all_scope_label_guarded: every \$(scope_label) call has || echo fallback"
+else
+    _unguarded_lines=$(grep -n '\$(scope_label)' "$SCRIPT_DIR/lib/loop-iteration.sh" 2>/dev/null \
+        | grep -v '|| echo' | head -3 || true)
+    assert_fail "loop_iteration_all_scope_label_guarded: \$(scope_label) must always be guarded with || echo fallback" \
+        "found ${_unguarded_scope_label} unguarded call(s): ${_unguarded_lines}"
+fi
+
 # ─── pipeline-stages-intake.sh atomic jq write review-fix (Copilot #7) ─────────
 # Verify the jq write goes to _tmp_json AND there's an mv from _tmp_json into the
 # final dod-classification.json path.

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -3341,6 +3341,154 @@ assert_contains "real GitHub token should be redacted" \
 _assert_not_contains "token value should not be present after redaction" \
     "$_ss_token_result" "ghp_AaBbCcDd"
 
+# ─── sanitize_secrets: fine-grained PAT redaction (C5) ──────────────────────
+echo -e "${DIM}  sanitize_secrets: fine-grained PAT coverage (C5)${RESET}"
+
+# Fine-grained PATs (github_pat_ prefix, ≥60 chars) must be redacted
+_ss_fgpat_result="$(
+    source "$_ss_helpers" 2>/dev/null
+    sanitize_secrets "token: github_pat_11ABCDE0Y0abcdefghijkl_aBcDeFgHiJkLmNoPqRsTuVwXyZabcdefghijklmnop"
+)"
+assert_contains "fine-grained PAT should be redacted" \
+    "$_ss_fgpat_result" "REDACTED"
+_assert_not_contains "fine-grained PAT value should not appear after redaction" \
+    "$_ss_fgpat_result" "github_pat_11ABCDE"
+
+# Short github_pat_ strings (< 60 chars) must NOT be redacted (not real tokens)
+_ss_fgpat_short="$(
+    source "$_ss_helpers" 2>/dev/null
+    sanitize_secrets "github_pat_short"
+)"
+_assert_not_contains "short github_pat_ string should not be redacted" \
+    "$_ss_fgpat_short" "REDACTED"
+
+# Function names with gh_ prefix still preserved after C5 change
+_ss_fn2_result="$(
+    source "$_ss_helpers" 2>/dev/null
+    sanitize_secrets "gh_comment_issue gh_post_progress"
+)"
+assert_contains "function names still preserved after C5" \
+    "$_ss_fn2_result" "gh_comment_issue"
+
+# ─── F7 anchor fix (C2): ES6 named import must downgrade to low confidence ───
+echo -e "${DIM}  F7 anchor: ES6 named import confidence (C2)${RESET}"
+
+# Static: anchor regex in pipeline-intelligence.sh must use the two-step form
+if grep -qE '_is_import_decl' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null; then
+    assert_pass "F7_anchor_two_step: pipeline-intelligence.sh uses _is_import_decl two-step check"
+else
+    assert_fail "F7_anchor_two_step: pipeline-intelligence.sh must use _is_import_decl variable" \
+        "Expected two-step import detection; found old single-grep anchor"
+fi
+
+# Static: anchor must reject lines with semicolons (adversarial multi-statement)
+if grep -qE '"\[;\]"' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" \
+        || grep -qE '"\\[;\\]"' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" \
+        || grep -qP '"\[;\]"|\[;\]' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null \
+        || grep -q '"[;]"' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null; then
+    assert_pass "F7_anchor_semicolon_guard: semicolon guard present in anchor"
+else
+    # Check the actual guard differently
+    if grep -A8 '_is_import_decl' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" \
+            | grep -q ';\|semicolon' 2>/dev/null; then
+        assert_pass "F7_anchor_semicolon_guard: semicolon guard present in anchor"
+    else
+        assert_fail "F7_anchor_semicolon_guard: anchor must reject semicolons (multi-stmt lines)" \
+            "Expected ';' in the negative guard near _is_import_decl"
+    fi
+fi
+
+# Behavioral: simulate the import anchor logic with the exact motivating false-positive
+_f7_anchor_check() {
+    local match_text="$1"
+    local _is_import_decl=false
+    if echo "$match_text" | grep -qE \
+        "^[[:space:]]*(import[[:space:]({\"\']|from[[:space:]]+[A-Za-z_]|const[[:space:]]+|var[[:space:]]+|let[[:space:]]+)"; then
+        if ! echo "$match_text" | grep -qE \
+            "[;]|\.(exec|run|spawn|system|call|Popen)[[:space:]]*\(|eval[[:space:]]*\(|shell[[:space:]]*=[[:space:]]*[Tt]rue"; then
+            _is_import_decl=true
+        fi
+    fi
+    echo "$_is_import_decl"
+}
+
+# ES6 named import (the original #460 false positive) → must be low (import_decl=true)
+_f7_es6="$(  _f7_anchor_check "import { execFileSync } from 'child_process'")"
+if [[ "$_f7_es6" == "true" ]]; then
+    assert_pass "F7_anchor_es6_named_import: 'import { execFileSync } from child_process' detected as import decl (low confidence)"
+else
+    assert_fail "F7_anchor_es6_named_import: motivating false positive must be classified as import decl" \
+        "Expected _is_import_decl=true for ES6 named import; got false"
+fi
+
+# Adversarial: import with trailing execution — must NOT be import_decl
+_f7_adv="$( _f7_anchor_check "import subprocess; subprocess.run(user_input, shell=True)")"
+if [[ "$_f7_adv" == "false" ]]; then
+    assert_pass "F7_anchor_adversarial_multi_stmt: semicolon-separated execution stays at medium/high"
+else
+    assert_fail "F7_anchor_adversarial_multi_stmt: import+execution line must NOT be classified as import decl" \
+        "Expected _is_import_decl=false for multi-stmt adversarial input"
+fi
+
+# CommonJS destructured require → import decl
+_f7_cjs="$( _f7_anchor_check "const { exec } = require('child_process')")"
+if [[ "$_f7_cjs" == "true" ]]; then
+    assert_pass "F7_anchor_cjs_require: CommonJS const require() is import decl (low confidence)"
+else
+    assert_fail "F7_anchor_cjs_require: const require() must be import decl" \
+        "Expected _is_import_decl=true for const { x } = require(...)"
+fi
+
+# ─── C1: abort-reason reader wired in wait_for_multi_completion ───────────────
+echo -e "${DIM}  C1: abort-reason reader in wait_for_multi_completion${RESET}"
+
+if grep -q 'abort-reason' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null; then
+    _c1_reads=$(grep -c 'abort-reason' "$SCRIPT_DIR/sw-loop.sh" || true)
+    if [[ "${_c1_reads:-0}" -ge 2 ]]; then
+        assert_pass "C1_abort_reason_reader: abort-reason appears in both writer and reader contexts"
+    else
+        assert_fail "C1_abort_reason_reader: abort-reason must appear at least twice (writer + reader)" \
+            "Found only ${_c1_reads} occurrence(s) — reader missing"
+    fi
+else
+    assert_fail "C1_abort_reason_reader: abort-reason marker not found in sw-loop.sh" \
+        "Expected abort-reason writer and reader wiring"
+fi
+
+# Static: wait_for_multi_completion must read the marker and set LOOP_ABORT_FATAL
+_c1_body=$(awk '/^wait_for_multi_completion\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null || true)
+if echo "$_c1_body" | grep -q 'abort-reason' 2>/dev/null; then
+    assert_pass "C1_reader_in_wait_for_multi: wait_for_multi_completion checks abort-reason file"
+else
+    assert_fail "C1_reader_in_wait_for_multi: wait_for_multi_completion must read abort-reason file" \
+        "Expected abort-reason check inside wait_for_multi_completion() body"
+fi
+if echo "$_c1_body" | grep -q 'LOOP_ABORT_FATAL=true' 2>/dev/null; then
+    assert_pass "C1_loop_abort_fatal_set: wait_for_multi_completion sets LOOP_ABORT_FATAL=true on abort"
+else
+    assert_fail "C1_loop_abort_fatal_set: wait_for_multi_completion must set LOOP_ABORT_FATAL=true" \
+        "Expected LOOP_ABORT_FATAL=true inside wait_for_multi_completion abort-reason handler"
+fi
+
+# ─── C3: empty-input SHA dedup gate ──────────────────────────────────────────
+echo -e "${DIM}  C3: empty-input SHA dedup gate${RESET}"
+
+if grep -q '_fail_line_count' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null; then
+    assert_pass "C3_fail_count_guard: pipeline-intelligence.sh gates dedup on _fail_line_count"
+else
+    assert_fail "C3_fail_count_guard: dedup short-circuit must gate on failure line count > 0" \
+        "Expected _fail_line_count guard before hash comparison"
+fi
+
+# Static: SHA guard skips comparison when count=0 (no-hasher sentinel excluded)
+if grep -A5 '_fail_line_count' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" \
+        | grep -q 'gt 0' 2>/dev/null; then
+    assert_pass "C3_count_gt_zero: guard uses -gt 0 comparison"
+else
+    assert_fail "C3_count_gt_zero: dedup guard must check _fail_line_count -gt 0" \
+        "Expected [[ \$_fail_line_count -gt 0 ]] near dedup logic"
+fi
+
 # ─── Test: compose_rejection_notice_section includes QUALITY_GATE_REASONS ─────
 if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
         grep -q 'QUALITY_GATE_REASONS'; then

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -3303,6 +3303,44 @@ else
     assert_pass "SW_LOG_PROMPTS github no-helpers: no command-not-found error"
 fi
 
+# ─── sanitize_secrets regression: over-broad gh_ regex fix (F6) ───────────────
+# Load the real sanitize_secrets from helpers.sh for these tests.
+_ss_helpers="$SCRIPT_DIR/lib/helpers.sh"
+
+# Helper: negative assertion (not present in test-helpers.sh for this file)
+_assert_not_contains() {
+    local desc="$1" haystack="$2" needle="$3"
+    if printf '%s\n' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+        assert_fail "$desc" "output unexpectedly contains: $needle"
+    else
+        assert_pass "$desc"
+    fi
+}
+
+echo -e "${DIM}  sanitize_secrets: over-broad gh_ regex regression (F6)${RESET}"
+
+# Test: function names like gh_comment_issue must not be redacted
+_ss_fn_result="$(
+    source "$_ss_helpers" 2>/dev/null
+    sanitize_secrets "call gh_comment_issue and gh_post_progress on issue 460"
+)"
+assert_contains "sanitize should preserve gh_comment_issue function name" \
+    "$_ss_fn_result" "gh_comment_issue"
+assert_contains "sanitize should preserve gh_post_progress function name" \
+    "$_ss_fn_result" "gh_post_progress"
+_assert_not_contains "no redaction should occur for function names" \
+    "$_ss_fn_result" "REDACTED"
+
+# Test: real GitHub OAuth tokens must be redacted
+_ss_token_result="$(
+    source "$_ss_helpers" 2>/dev/null
+    sanitize_secrets "GITHUB_TOKEN=ghp_AaBbCcDd1234567890AbCdEfGhIjKlMnOpQrStUvWx"
+)"
+assert_contains "real GitHub token should be redacted" \
+    "$_ss_token_result" "REDACTED"
+_assert_not_contains "token value should not be present after redaction" \
+    "$_ss_token_result" "ghp_AaBbCcDd"
+
 # ─── Test: compose_rejection_notice_section includes QUALITY_GATE_REASONS ─────
 if awk '/^compose_rejection_notice_section\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" | \
         grep -q 'QUALITY_GATE_REASONS'; then

--- a/scripts/sw-loop-test.sh
+++ b/scripts/sw-loop-test.sh
@@ -3455,6 +3455,39 @@ else
         "Expected abort-reason writer and reader wiring"
 fi
 
+# C1 review-fix: worker must NOT touch .agent-N-complete when aborting, otherwise the
+# parent's completion check wins over the abort-reason check (Copilot review #4).
+_c1_noop_block=$(awk '/CONSECUTIVE_NOOP.*-ge 2/,/break$/' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null | head -20 || true)
+# Match an actual touch COMMAND (not a comment that mentions "touch .agent-N-complete")
+if echo "$_c1_noop_block" | grep -qE '^[[:space:]]*touch[[:space:]].*agent.*complete' 2>/dev/null; then
+    assert_fail "C1_no_complete_on_abort: worker must NOT touch .agent-N-complete during noop abort" \
+        "Found 'touch .agent-N-complete' COMMAND in NOOP abort block — would mask abort"
+else
+    assert_pass "C1_no_complete_on_abort: worker noop-abort block does not touch .agent-N-complete"
+fi
+
+# C1 review-fix: wait_for_multi_completion must check abort-reason BEFORE .agent-N-complete
+# (Copilot review #4). If complete wins, abort never registers.
+_c1_body_full=$(awk '/^wait_for_multi_completion\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null || true)
+_c1_abort_pos=$(echo "$_c1_body_full" | grep -n 'abort-reason' | head -1 | cut -d: -f1 || echo "9999")
+_c1_complete_pos=$(echo "$_c1_body_full" | grep -n '\.agent-${i}-complete' | head -1 | cut -d: -f1 || echo "0")
+if [[ "${_c1_abort_pos:-9999}" -lt "${_c1_complete_pos:-0}" ]]; then
+    assert_pass "C1_abort_before_complete: wait_for_multi_completion checks abort-reason before completion marker"
+else
+    assert_fail "C1_abort_before_complete: abort-reason check must come before .agent-N-complete check" \
+        "abort-reason at line ${_c1_abort_pos}, complete at line ${_c1_complete_pos} (within function body)"
+fi
+
+# C1 review-fix: main() must guard launch_multi_agent under set -e (Copilot review #3).
+# Without `|| true` or `if`, set -e exits before the LOOP_ABORT_FATAL check can fire.
+_c1_main=$(awk '/^main\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null || true)
+if echo "$_c1_main" | grep -qE 'launch_multi_agent[[:space:]]*\|\|[[:space:]]*true|if[[:space:]]+(!|launch_multi_agent)' 2>/dev/null; then
+    assert_pass "C1_main_set_e_guard: launch_multi_agent guarded against set -e in main()"
+else
+    assert_fail "C1_main_set_e_guard: launch_multi_agent must be guarded (|| true or if) so LOOP_ABORT_FATAL check fires" \
+        "Bare 'launch_multi_agent' under set -e exits before post-check"
+fi
+
 # Static: wait_for_multi_completion must read the marker and set LOOP_ABORT_FATAL
 _c1_body=$(awk '/^wait_for_multi_completion\(\)/,/^\}/' "$SCRIPT_DIR/sw-loop.sh" 2>/dev/null || true)
 if echo "$_c1_body" | grep -q 'abort-reason' 2>/dev/null; then
@@ -3487,6 +3520,120 @@ if grep -A5 '_fail_line_count' "$SCRIPT_DIR/lib/pipeline-intelligence.sh" \
 else
     assert_fail "C3_count_gt_zero: dedup guard must check _fail_line_count -gt 0" \
         "Expected [[ \$_fail_line_count -gt 0 ]] near dedup logic"
+fi
+
+# ─── R4 review-fix: all-manual DoD guard uses sidecar total, not post-strip count ──
+# Copilot review #8: counting from dod-audit.md after [~] items are stripped yields 0,
+# so the all-manual guard never fires. Must use dod-classification.json's `total`.
+if grep -A5 'all.*items.*classified as manual' "$SCRIPT_DIR/lib/pipeline-quality-checks.sh" 2>/dev/null \
+        | grep -q '_orig_total\|jq.*total' 2>/dev/null; then
+    assert_pass "R4_orig_total_from_sidecar: all-manual guard uses dod-classification.json total"
+else
+    # Check the broader context
+    if grep -B3 -A8 'classified as manual' "$SCRIPT_DIR/lib/pipeline-quality-checks.sh" 2>/dev/null \
+            | grep -q '\.total\|_orig_total' 2>/dev/null; then
+        assert_pass "R4_orig_total_from_sidecar: all-manual guard reads from sidecar JSON"
+    else
+        assert_fail "R4_orig_total_from_sidecar: all-manual guard must use dod-classification.json total" \
+            "Counting dod-audit.md after [~] strip yields 0; guard never fires"
+    fi
+fi
+
+# ─── stage_test review-fix: dedup file separated from compound_quality (Codex #2) ──
+# stage_test must NOT write last-failure-set.sha — that file belongs to compound_quality.
+# Cross-writes cause cycle N+1 to compare current failures against its own (mid-rebuild)
+# hash, falsely short-circuiting as "identical failures".
+if grep -qF 'stage-test-last-comment.sha' "$SCRIPT_DIR/lib/pipeline-stages-build.sh" 2>/dev/null; then
+    assert_pass "stage_test_dedup_separate: stage_test uses its own dedup file (stage-test-last-comment.sha)"
+else
+    assert_fail "stage_test_dedup_separate: stage_test must use a separate dedup file from compound_quality" \
+        "Expected stage-test-last-comment.sha (or similar non-shared path)"
+fi
+# And confirm it no longer WRITES last-failure-set.sha (comment references OK).
+# Match a redirect (>) or printf-into pattern, not a comment-only mention.
+_st_writes_shared=$(grep -E '(>|printf|tee)[^#]*last-failure-set\.sha' "$SCRIPT_DIR/lib/pipeline-stages-build.sh" 2>/dev/null \
+    | grep -v '^[[:space:]]*#' | wc -l | tr -d '[:space:]' || echo "0")
+if [[ "${_st_writes_shared:-0}" -eq 0 ]]; then
+    assert_pass "stage_test_no_compound_collision: pipeline-stages-build.sh does not write last-failure-set.sha"
+else
+    assert_fail "stage_test_no_compound_collision: stage_test must not write last-failure-set.sha (cycle dedup collision)" \
+        "Found ${_st_writes_shared} write(s) to last-failure-set.sha in pipeline-stages-build.sh"
+fi
+
+# ─── stage_test review-fix: empty-input SHA guard (same as C3 but in stage_test) ─
+# Codex blocker: stage_test hashes test_log; empty grep yields constant SHA, collides.
+if grep -B2 -A8 '_stage_test_count' "$SCRIPT_DIR/lib/pipeline-stages-build.sh" 2>/dev/null \
+        | grep -q 'gt 0' 2>/dev/null; then
+    assert_pass "stage_test_empty_sha_guard: dedup hash gated on failure count > 0"
+else
+    assert_fail "stage_test_empty_sha_guard: dedup hash must be gated on failure count > 0" \
+        "Empty grep input yields constant SHA-1 — false 'same failures' match on infra errors"
+fi
+
+# ─── loop-iteration scope_label review-fix: guarded against missing function (Codex P1) ──
+# scope_label is defined in pipeline-state.sh; sw-loop.sh doesn't source it, so the
+# command substitution returns 127 under set -e. Need a `type` check or fallback.
+_li_scope_block=$(grep -A2 'Build Prompt' "$SCRIPT_DIR/lib/loop-iteration.sh" 2>/dev/null | head -3 || true)
+if echo "$_li_scope_block" | grep -qE 'type scope_label|_scope_label' 2>/dev/null; then
+    assert_pass "loop_iteration_scope_label_guard: Build Prompt body guards scope_label with type check"
+elif grep -B3 'Build Prompt' "$SCRIPT_DIR/lib/loop-iteration.sh" 2>/dev/null | grep -q 'type scope_label' 2>/dev/null; then
+    assert_pass "loop_iteration_scope_label_guard: Build Prompt body guards scope_label with type check"
+else
+    assert_fail "loop_iteration_scope_label_guard: scope_label must be guarded (set -e + missing function = 127 exit)" \
+        "Expected 'type scope_label' check or fallback variable assignment before use in Build Prompt body"
+fi
+
+# ─── pipeline-state.sh _resolve_stage_log_path review-fix (Copilot #5) ─────────
+# Under set -e, _resolve_stage_log_path returns 1 on miss → mark_stage_failed exits.
+# Must be guarded with `|| _x_log=""` before tail.
+if grep -qE '_(ec|fs)_log=.*_resolve_stage_log_path.*\|\| _' "$SCRIPT_DIR/lib/pipeline-state.sh" 2>/dev/null; then
+    assert_pass "resolve_stage_log_path_set_e_guard: _resolve_stage_log_path call guarded with || fallback"
+else
+    assert_fail "resolve_stage_log_path_set_e_guard: callers must guard with || fallback against set -e" \
+        "Expected '_ec_log=\$(...) || _ec_log=\"\"' pattern in mark_stage_failed"
+fi
+
+# ─── _validate_ref review-fix: rejects leading dash and path traversal (Copilot #9) ─
+_vr_helper="$SCRIPT_DIR/lib/helpers.sh"
+_vr_dash_result="$(
+    source "$_vr_helper" 2>/dev/null
+    _validate_ref "--output=/etc/passwd" 2>&1 || echo "REJECTED"
+)"
+if echo "$_vr_dash_result" | grep -qF "REJECTED"; then
+    assert_pass "validate_ref_rejects_leading_dash: --output=/etc/passwd rejected"
+else
+    assert_fail "validate_ref_rejects_leading_dash: leading-dash refs must be rejected (option injection)" \
+        "got: $_vr_dash_result"
+fi
+_vr_traversal_result="$(
+    source "$_vr_helper" 2>/dev/null
+    _validate_ref "main..injected" 2>&1 || echo "REJECTED"
+)"
+if echo "$_vr_traversal_result" | grep -qF "REJECTED"; then
+    assert_pass "validate_ref_rejects_traversal: '..' sequences rejected"
+else
+    assert_fail "validate_ref_rejects_traversal: '..' sequences must be rejected (range injection)" \
+        "got: $_vr_traversal_result"
+fi
+_vr_normal_result="$(
+    source "$_vr_helper" 2>/dev/null
+    _validate_ref "main" >/dev/null 2>&1 && echo "OK" || echo "REJECTED"
+)"
+if echo "$_vr_normal_result" | grep -qF "OK"; then
+    assert_pass "validate_ref_accepts_normal: 'main' accepted"
+else
+    assert_fail "validate_ref_accepts_normal: normal branch names must be accepted" \
+        "got: $_vr_normal_result"
+fi
+
+# ─── pipeline-stages-intake.sh atomic jq write review-fix (Copilot #7) ─────────
+# Verify the jq write goes to _tmp_json AND there's an mv from _tmp_json into the
+# final dod-classification.json path.
+if grep -qE '^[[:space:]]*mv[[:space:]]+"\$_tmp_json".*dod-classification' "$SCRIPT_DIR/lib/pipeline-stages-intake.sh" 2>/dev/null; then
+    assert_pass "intake_dod_classification_atomic_write: dod-classification.json uses tmp+mv pattern"
+else
+    assert_fail "intake_dod_classification_atomic_write: dod-classification.json write must be atomic (tmp + mv)" \
+        "Expected 'mv \"\$_tmp_json\" .../dod-classification.json' after jq succeeds"
 fi
 
 # ─── Test: compose_rejection_notice_section includes QUALITY_GATE_REASONS ─────

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2749,8 +2749,10 @@ PROMPT
     # awk: key-driven parser handles insertions-only/deletions-only --shortstat output
     # where positional $4/$6 fields vary.
     _diff_lines=0
+    _diff_stat=""
     if [[ -n "${_iter_start_sha:-}" ]]; then
-        _diff_lines=$(git diff --shortstat "${_iter_start_sha}" HEAD 2>/dev/null \
+        _diff_stat=$(git diff --shortstat "${_iter_start_sha}" HEAD 2>/dev/null || true)
+        _diff_lines=$(echo "$_diff_stat" \
             | awk '{ins=0;del=0; for(i=1;i<=NF;i++){if($i~/insert/)ins=$(i-1); if($i~/delet/)del=$(i-1)} print ins+del}' \
             | head -1 || echo "0")
     fi
@@ -2758,6 +2760,10 @@ PROMPT
     # Guard: ensure numeric (strip whitespace/letters, default to 0)
     _diff_lines=$(echo "$_diff_lines" | tr -dc '0-9')
     [[ -z "$_diff_lines" ]] && _diff_lines=0
+    # Guard: binary-only diffs produce "N files changed" with no insert/delet tokens.
+    # awk yields 0 in that case, which false-positively looks like a no-op.
+    # If shortstat output is non-empty (something changed) but awk found nothing, count it as 1.
+    [[ "$_diff_lines" -eq 0 && -n "$_diff_stat" ]] && _diff_lines=1
 
     if [[ "$_new_commits" -gt 0 ]] || \
        { [[ "$_diff_lines" -ge 10 ]] && [[ "$_iter_seconds" -ge 60 ]]; }; then
@@ -2992,8 +2998,9 @@ cleanup_multi_agent() {
 
     tmux kill-window -t "$MULTI_WINDOW_NAME" 2>/dev/null || true
 
-    # Clean up completion markers
+    # Clean up completion markers and abort-reason markers
     rm -f "$LOG_DIR"/.agent-*-complete 2>/dev/null || true
+    rm -f "$LOG_DIR"/.agent-*-abort-reason 2>/dev/null || true
 }
 
 # ─── Main: Single-Agent Loop ─────────────────────────────────────────────────
@@ -3620,6 +3627,10 @@ main() {
         fi
         show_banner
         launch_multi_agent
+        if [[ "${LOOP_ABORT_FATAL:-false}" == "true" ]]; then
+            warn "Abort-fatal flag set by multi-agent worker — suppressing any restart"
+            STATUS="${STATUS:-failed}"
+        fi
         show_summary
     else
         run_loop_with_restarts

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2622,6 +2622,7 @@ RESET='\033[0m'
 cd "$WORK_DIR"
 ITERATION=0
 CONSECUTIVE_FAILURES=0
+CONSECUTIVE_NOOP=0
 
 echo -e "${CYAN}${BOLD}▸${RESET} Agent ${AGENT_NUM}/${TOTAL_AGENTS} starting in ${WORK_DIR}"
 
@@ -2638,6 +2639,7 @@ while [[ "$ITERATION" -lt "$MAX_ITERATIONS" ]]; do
     fi
 
     ITERATION=$(( ITERATION + 1 ))
+    _iter_start=$(date +%s 2>/dev/null || echo 0)
     echo -e "\n${CYAN}${BOLD}▸${RESET} Agent ${AGENT_NUM} — Iteration ${ITERATION}/${MAX_ITERATIONS}"
 
     # Pull latest from other agents
@@ -2734,13 +2736,37 @@ PROMPT
     _commits_after=$(git rev-list --count HEAD 2>/dev/null || echo 0)
     _new_commits=$(( _commits_after - _commits_before ))
 
-    # Circuit breaker: check for progress using commit count delta (not HEAD~1 diff,
-    # which is fooled by prior commits when the current iteration produces no changes)
-    if [[ "$_new_commits" -gt 0 ]]; then
+    # Iteration elapsed time (set _iter_start at top of loop body)
+    _iter_end=$(date +%s 2>/dev/null || echo 0)
+    _iter_seconds=$(( _iter_end - ${_iter_start:-_iter_end} ))
+
+    # No-op detection: track iterations with no meaningful progress
+    # A "real" iteration requires: >=1 commit, OR (>=10 diff lines AND >=60s elapsed)
+    _diff_lines=$(git diff --shortstat "HEAD@{1}" HEAD 2>/dev/null \
+        | awk '{print $4+$6}' | head -1 || true)
+    _diff_lines="${_diff_lines:-0}"
+    # Guard: ensure numeric (strip whitespace, default to 0)
+    _diff_lines=$(echo "$_diff_lines" | tr -d '[:space:]')
+    [[ -z "$_diff_lines" ]] && _diff_lines=0
+
+    if [[ "$_new_commits" -gt 0 ]] || \
+       { [[ "$_diff_lines" -ge 10 ]] && [[ "$_iter_seconds" -ge 60 ]]; }; then
         CONSECUTIVE_FAILURES=0
+        CONSECUTIVE_NOOP=0
     else
         CONSECUTIVE_FAILURES=$(( CONSECUTIVE_FAILURES + 1 ))
-        echo -e "  ${YELLOW}⚠${RESET} Low progress (${CONSECUTIVE_FAILURES}/3)"
+        CONSECUTIVE_NOOP=$(( ${CONSECUTIVE_NOOP:-0} + 1 ))
+        echo -e "  ${YELLOW}⚠${RESET} Low progress (${CONSECUTIVE_FAILURES}/3): ${_iter_seconds}s, ${_new_commits} commits, ${_diff_lines} diff lines"
+    fi
+
+    if [[ "${CONSECUTIVE_NOOP:-0}" -ge 2 ]]; then
+        echo -e "  ${RED}✗${RESET} No-op abort: ${CONSECUTIVE_NOOP} consecutive no-op iterations (${_iter_seconds}s, ${_new_commits} commits)"
+        # Write abort-reason file so the parent monitoring loop can detect this.
+        # LOOP_ABORT_FATAL cannot propagate from this worker subshell to the parent
+        # process — use a marker file instead.
+        echo "NOOP_ITERATIONS" > "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason" 2>/dev/null || true
+        touch "$LOG_DIR/.agent-${AGENT_NUM}-complete" 2>/dev/null || true
+        break
     fi
 
     if [[ "$CONSECUTIVE_FAILURES" -ge 3 ]]; then

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2684,9 +2684,11 @@ Focus on areas they haven't touched yet.
 PROMPT
 )"
 
-    # Capture commit count before Claude runs so Claude-initiated commits are included in delta
-    local _commits_before _commits_after _new_commits
+    # Capture commit count AND HEAD SHA before Claude runs so delta is iteration-scoped.
+    # C4: _iter_start_sha replaces HEAD@{1} (reflog-relative — wrong when HEAD didn't move).
+    local _commits_before _commits_after _new_commits _iter_start_sha
     _commits_before=$(git rev-list --count HEAD 2>/dev/null || echo 0)
+    _iter_start_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
 
     # Run Claude (output is JSON due to --output-format json in CLAUDE_FLAGS)
     local JSON_FILE="$LOG_DIR/agent-${AGENT_NUM}-iter-${ITERATION}.json"
@@ -2742,11 +2744,19 @@ PROMPT
 
     # No-op detection: track iterations with no meaningful progress
     # A "real" iteration requires: >=1 commit, OR (>=10 diff lines AND >=60s elapsed)
-    _diff_lines=$(git diff --shortstat "HEAD@{1}" HEAD 2>/dev/null \
-        | awk '{print $4+$6}' | head -1 || true)
+    # C4: compare against captured start SHA (not HEAD@{1} which is reflog-relative and
+    # wrong if HEAD didn't move — would compare against a prior iteration's position).
+    # awk: key-driven parser handles insertions-only/deletions-only --shortstat output
+    # where positional $4/$6 fields vary.
+    _diff_lines=0
+    if [[ -n "${_iter_start_sha:-}" ]]; then
+        _diff_lines=$(git diff --shortstat "${_iter_start_sha}" HEAD 2>/dev/null \
+            | awk '{ins=0;del=0; for(i=1;i<=NF;i++){if($i~/insert/)ins=$(i-1); if($i~/delet/)del=$(i-1)} print ins+del}' \
+            | head -1 || echo "0")
+    fi
     _diff_lines="${_diff_lines:-0}"
-    # Guard: ensure numeric (strip whitespace, default to 0)
-    _diff_lines=$(echo "$_diff_lines" | tr -d '[:space:]')
+    # Guard: ensure numeric (strip whitespace/letters, default to 0)
+    _diff_lines=$(echo "$_diff_lines" | tr -dc '0-9')
     [[ -z "$_diff_lines" ]] && _diff_lines=0
 
     if [[ "$_new_commits" -gt 0 ]] || \
@@ -2762,9 +2772,11 @@ PROMPT
     if [[ "${CONSECUTIVE_NOOP:-0}" -ge 2 ]]; then
         echo -e "  ${RED}✗${RESET} No-op abort: ${CONSECUTIVE_NOOP} consecutive no-op iterations (${_iter_seconds}s, ${_new_commits} commits)"
         # Write abort-reason file so the parent monitoring loop can detect this.
-        # LOOP_ABORT_FATAL cannot propagate from this worker subshell to the parent
-        # process — use a marker file instead.
-        echo "NOOP_ITERATIONS" > "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason" 2>/dev/null || true
+        # LOOP_ABORT_FATAL cannot propagate from this worker tmux-pane process to the
+        # parent — use a marker file instead. Atomic tmp+mv prevents partial reads.
+        echo "NOOP_ITERATIONS" > "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason.tmp" 2>/dev/null \
+            && mv "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason.tmp" \
+               "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason" 2>/dev/null || true
         touch "$LOG_DIR/.agent-${AGENT_NUM}-complete" 2>/dev/null || true
         break
     fi
@@ -2858,13 +2870,27 @@ launch_multi_agent() {
 
 wait_for_multi_completion() {
     while true; do
-        # Check if any agent signaled completion
+        # Check if any agent signaled completion or NOOP-abort
         for i in $(seq 1 "$AGENTS"); do
             if [[ -f "$LOG_DIR/.agent-${i}-complete" ]]; then
                 success "Agent $i signaled <<<LOOP:PASS>>>!"
                 STATUS="complete"
                 write_state
                 return 0
+            fi
+            # C1: read abort-reason marker written by no-op detection inside worker subshell.
+            # LOOP_ABORT_FATAL can't propagate across the tmux-pane process boundary, so
+            # the worker writes a marker file instead; this is the reader that closes the loop.
+            if [[ -f "$LOG_DIR/.agent-${i}-abort-reason" ]]; then
+                local _abort_reason
+                _abort_reason=$(cat "$LOG_DIR/.agent-${i}-abort-reason" 2>/dev/null | tr -d '[:space:]' || true)
+                if [[ "${_abort_reason:-}" == "NOOP_ITERATIONS" ]]; then
+                    warn "Agent $i aborted: ${_abort_reason} — suppressing restarts"
+                    LOOP_ABORT_FATAL=true
+                    STATUS="failed"
+                    write_state
+                    return 1
+                fi
             fi
         done
 

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2780,10 +2780,12 @@ PROMPT
         # Write abort-reason file so the parent monitoring loop can detect this.
         # LOOP_ABORT_FATAL cannot propagate from this worker tmux-pane process to the
         # parent — use a marker file instead. Atomic tmp+mv prevents partial reads.
+        # Do NOT touch .agent-N-complete here: completion = success in the parent's
+        # eyes, which would mask the abort and let restarts fire. The parent reads
+        # the abort-reason marker on its own polling cycle.
         echo "NOOP_ITERATIONS" > "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason.tmp" 2>/dev/null \
             && mv "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason.tmp" \
                "$LOG_DIR/.agent-${AGENT_NUM}-abort-reason" 2>/dev/null || true
-        touch "$LOG_DIR/.agent-${AGENT_NUM}-complete" 2>/dev/null || true
         break
     fi
 
@@ -2876,14 +2878,10 @@ launch_multi_agent() {
 
 wait_for_multi_completion() {
     while true; do
-        # Check if any agent signaled completion or NOOP-abort
+        # Check abort-reason marker FIRST. If a worker no-op-aborted AND another agent
+        # happens to legitimately complete in the same cycle, the abort takes precedence
+        # so restarts stay suppressed. Reading complete first would mask the abort.
         for i in $(seq 1 "$AGENTS"); do
-            if [[ -f "$LOG_DIR/.agent-${i}-complete" ]]; then
-                success "Agent $i signaled <<<LOOP:PASS>>>!"
-                STATUS="complete"
-                write_state
-                return 0
-            fi
             # C1: read abort-reason marker written by no-op detection inside worker subshell.
             # LOOP_ABORT_FATAL can't propagate across the tmux-pane process boundary, so
             # the worker writes a marker file instead; this is the reader that closes the loop.
@@ -2895,8 +2893,19 @@ wait_for_multi_completion() {
                     LOOP_ABORT_FATAL=true
                     STATUS="failed"
                     write_state
-                    return 1
+                    # Return 0 so callers under `set -e` continue to the LOOP_ABORT_FATAL
+                    # post-check. The flag is the authoritative signal; return code is advisory.
+                    return 0
                 fi
+            fi
+        done
+        # Then check completion markers
+        for i in $(seq 1 "$AGENTS"); do
+            if [[ -f "$LOG_DIR/.agent-${i}-complete" ]]; then
+                success "Agent $i signaled <<<LOOP:PASS>>>!"
+                STATUS="complete"
+                write_state
+                return 0
             fi
         done
 
@@ -3626,7 +3635,10 @@ main() {
             initialize_state
         fi
         show_banner
-        launch_multi_agent
+        # Guard against set -e: launch_multi_agent → wait_for_multi_completion may
+        # return non-zero on abort. The LOOP_ABORT_FATAL flag is the authoritative
+        # signal; `|| true` ensures the post-check always runs.
+        launch_multi_agent || true
         if [[ "${LOOP_ABORT_FATAL:-false}" == "true" ]]; then
             warn "Abort-fatal flag set by multi-agent worker — suppressing any restart"
             STATUS="${STATUS:-failed}"

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -2830,6 +2830,16 @@ MULTI_WINDOW_NAME=""
 launch_multi_agent() {
     info "Setting up multi-agent mode ($AGENTS agents)..."
 
+    # Pre-run cleanup: remove stale markers from any prior crashed run that
+    # did not reach cleanup_multi_agent. Without this, wait_for_multi_completion
+    # reads the prior run's abort-reason marker on its first poll and
+    # false-aborts before agents have even started. cleanup_multi_agent only
+    # fires at end-of-run, so OOM/SIGKILL/host-reboot leaves zombies behind.
+    if [[ -n "${LOG_DIR:-}" ]]; then
+        rm -f "$LOG_DIR"/.agent-*-abort-reason 2>/dev/null || true
+        rm -f "$LOG_DIR"/.agent-*-complete 2>/dev/null || true
+    fi
+
     # Setup worktrees
     setup_worktrees || { error "Failed to setup worktrees"; exit 1; }
 

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -2679,9 +2679,11 @@ pipeline_post_completion_cleanup() {
         "${ARTIFACTS_DIR}/skip-stage.txt" \
         "${ARTIFACTS_DIR}/human-message.txt" \
         "${ARTIFACTS_DIR}/model-routing.log" \
-        "${ARTIFACTS_DIR}/.plan-failure-sig.txt"; do
+        "${ARTIFACTS_DIR}/.plan-failure-sig.txt" \
+        "${ARTIFACTS_DIR}/progress-comment.id"; do
         [[ -f "$_f" ]] && rm -f "$_f" && cleaned=$((cleaned + 1)) || true
     done
+    rm -f "${STATE_DIR}/loop-logs"/.agent-*-abort-reason 2>/dev/null || true
 
     # 3. Clear stale pipeline state (mark as idle so next run starts clean)
     if [[ -f "$STATE_FILE" ]]; then


### PR DESCRIPTION
## Summary
- 15 pipeline mechanic fixes from the #460 postmortem (a884339): no-op detection, false-positive security routing, identical-failure dedup, scope labeling, prompt v2, smoke-suite fallback, DoD classification, redaction, atomic state propagation.
- 9 audit fixes (e1e967d): F6 fine-grained PATs, F7 anchor for ES6 named imports, F4 empty-input dedup gate, F9 HEAD@{1} replacement + abort-reason reader, H1 _compute_sha1 extraction, H2 fail-closed routing, M2/M3 atomic & jq writes.
- 13 second-pass audit fixes (06779bf): C1 wiring through main(), stale-marker cleanup on both worktree and pipeline paths, H2 SCANNER_ARTIFACT_MISSING synthetic blocking item, H3 final-cycle full-suite guarantee, R1 binary-diff awk guard, M7 _validate_ref helper, R4 all-manual DoD bypass closure.

## Tests
- `npm run test:smoke` — 24/24
- `bash scripts/sw-loop-test.sh` — 358/358
- `bash scripts/sw-lib-pipeline-intelligence-test.sh` — 125/125
- `bash scripts/sw-lib-pipeline-state-test.sh` — 107/107
- `bash scripts/sw-lib-pipeline-quality-checks-test.sh` — 66/66

**680 tests pass, 0 failures.**

## Test plan
- [x] All five test suites green locally on macOS
- [x] F6 redaction matrix covers ghp/gho/ghu/ghs/ghr + github_pat_ + preserved function names
- [x] F7 anchor verified empirically against `import { execFileSync } from 'child_process'` (motivating false positive → low) and `import subprocess; subprocess.run(x, shell=True)` (adversarial → medium/high)
- [x] C1 abort-reason marker has both writer (worker subshell) and reader (`wait_for_multi_completion` + `main()` post-launch)
- [x] H2 SCANNER_ARTIFACT_MISSING confirmed in BLOCKING section (not advisory) by behavioral tests
- [x] H3 final cycle confirmed to fall through to full suite (smoke skip clamped at `cycle < max_cycles`)
- [ ] CI smoke + full suite on Linux runner
- [ ] Dry-run pipeline on a sample issue to confirm no-op detection + abort-reason propagation work end-to-end

## Review focus
- `scripts/sw-loop.sh:3629-3636` — C1 main() wiring
- `scripts/lib/pipeline-intelligence.sh:1146-1163` — H2 fail-closed synthetic item
- `scripts/lib/pipeline-intelligence.sh:2247` — H3 final-cycle guard
- `scripts/lib/pipeline-intelligence.sh:716-740` — F7 two-step anchor
- `scripts/lib/helpers.sh:442-481` — F6 redaction + _compute_sha1 + _validate_ref

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)