### PR TITLE
revert(compound-quality): remove targeted-file list and iteration cap (T2.1)

### DIFF
--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1476,26 +1476,11 @@ compound_rebuild_with_feedback() {
             ;;
     esac
 
-    # Bound iterations for targeted cycles — always cap regardless of outer MAX_ITERATIONS_OVERRIDE.
-    local _cq_max_iter=""
-    if [[ "$route" == "scope" ]]; then
-        _cq_max_iter="3"
-    elif [[ -n "$blocking_items" ]]; then
-        _cq_max_iter="5"
-    fi
-
-    # T2.1: Targeted-fix mode — extract affected files from findings for scoped prompt + bounded dispatch.
-    # Reduces worst-case per-cycle wall-clock from ~2h (45 iters full suite) to ~15m (5 iters scoped tests).
-    local targeted_files=""
-    targeted_files=$(_compound_quality_targeted_prompt "$feedback_file" "${_cq_max_iter:-5}" 2>/dev/null || true)
-
     if [[ -n "$blocking_items" ]]; then
         GOAL="$GOAL
 
 BLOCKING ISSUES — fix all of these before merge:
 $blocking_items
-${targeted_files:+
-${targeted_files}}
 
 Full review context:
 $feedback_content
@@ -1505,45 +1490,19 @@ ${route_instruction}"
         GOAL="$GOAL
 
 IMPORTANT — Compound quality review found issues (route: ${route}). Fix ALL of these:
-${targeted_files:+${targeted_files}
-}
 $feedback_content
 
 ${route_instruction}"
     fi
 
-    # Re-run self-healing build→test (bounded iterations for targeted cycles)
+    # Re-run self-healing build→test with findings injected into GOAL.
+    # The build loop's own scope guard and DoD enforcement govern the cycle —
+    # no iteration cap, no targeted-file list (both regressed scope enforcement).
     info "Rebuilding with quality feedback (route: ${route})..."
-    local _save_max_iter="${MAX_ITERATIONS_OVERRIDE:-}"
-    [[ -n "$_cq_max_iter" ]] && MAX_ITERATIONS_OVERRIDE="$_cq_max_iter"
     local _rebuild_rc=0
     self_healing_build_test || _rebuild_rc=$?
-    MAX_ITERATIONS_OVERRIDE="$_save_max_iter"
     GOAL="$original_goal"
     return "$_rebuild_rc"
-}
-
-# _compound_quality_targeted_prompt — Extract affected files from a findings file and
-# compose a TARGETED FIX block listing exact files + iteration budget.
-# Usage: _compound_quality_targeted_prompt <feedback_file> [max_iterations]
-_compound_quality_targeted_prompt() {
-    local feedback_file="${1:-}"
-    local max_iter="${2:-5}"
-    [[ -f "$feedback_file" ]] || return 0
-
-    local affected_files
-    # Extract file paths: look for lines with path-like tokens (contains / or ends with known extension)
-    affected_files=$(grep -oE '[a-zA-Z0-9_./-]+\.(sh|js|cjs|mjs|ts|tsx|py|go|rs|rb|swift|yaml|yml|json|md)' \
-        "$feedback_file" 2>/dev/null | sort -u | head -20 || true)
-    [[ -z "$affected_files" ]] && return 0
-
-    local file_count
-    file_count=$(printf '%s\n' "$affected_files" | wc -l | tr -d ' ')
-    local file_list
-    file_list=$(printf '%s\n' "$affected_files" | sed 's/^/  - /')
-
-    printf 'TARGETED FIX — %s file(s) cited in findings:\n%s\nModify ONLY these files. Iteration budget for this cycle: %s max. Do NOT refactor unrelated code.\n' \
-        "$file_count" "$file_list" "$max_iter"
 }
 
 # Removes negative-review-cycle*.md files from ARTIFACTS_DIR.

--- a/scripts/sw-postmortem-460-test.sh
+++ b/scripts/sw-postmortem-460-test.sh
@@ -2,7 +2,7 @@
 # ╔═══════════════════════════════════════════════════════════════════════════╗
 # ║  sw-postmortem-460-test — Behavioral tests for pipeline hardening fixes  ║
 # ║  Covers: T1.1 daemon-config sidecar, T1.2 scope guardrail,               ║
-# ║          T1.3 DoD exclusion validator, T2.1 targeted-fix mode,            ║
+# ║          T1.3 DoD exclusion validator,                                    ║
 # ║          T2.2 stuckness snapshot, T2.4 scope-creep review,                ║
 # ║          T2.5 fingerprintContent hash correctness                         ║
 # ╚═══════════════════════════════════════════════════════════════════════════╝
@@ -281,42 +281,6 @@ rm -f "$ARTIFACTS_DIR/dod.md"
 validator_exit=0
 _validate_dod_no_excluded_paths "$ARTIFACTS_DIR/dod.md" 2>/dev/null || validator_exit=$?
 assert_exit_code "T1.3.e missing dod.md passes validator (fail-open)" "0" "$validator_exit"
-
-cleanup_env
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# T2.1 — compound_quality targeted-fix mode prompts
-# ═══════════════════════════════════════════════════════════════════════════════
-
-print_test_header "T2.1 — Compound quality TARGETED FIX prompt block"
-
-setup_env
-source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || true
-
-# _compound_quality_targeted_prompt should produce a TARGETED FIX block
-# when given a findings file with file-path references.
-ARTIFACTS_DIR="$TEST_TEMP_DIR/project/.claude/pipeline-artifacts"
-mkdir -p "$ARTIFACTS_DIR"
-source "$SCRIPT_DIR/lib/pipeline-stages.sh" 2>/dev/null || true
-# pipeline-intelligence.sh defines _compound_quality_targeted_prompt (T2.1)
-# It has complex runtime deps; source it with guards so missing vars are tolerated.
-PIPELINE_CONFIG="${PIPELINE_CONFIG:-}" \
-source "$SCRIPT_DIR/lib/pipeline-intelligence.sh" 2>/dev/null || true
-
-cat > "$TEST_TEMP_DIR/findings.txt" <<'EOF'
-[CRITICAL] scripts/lib/cost/share.sh:45 — null pointer dereference in cost merge
-[CRITICAL] scripts/sw-pipeline.sh:207 — execSync with shell interpolation
-EOF
-
-# Call the targeted prompt builder
-if declare -f _compound_quality_targeted_prompt >/dev/null 2>&1; then
-    targeted_prompt=$(_compound_quality_targeted_prompt "$TEST_TEMP_DIR/findings.txt" 2>/dev/null)
-    assert_contains "T2.1 prompt contains TARGETED FIX" "$targeted_prompt" "TARGETED FIX"
-    assert_contains "T2.1 prompt lists affected files" "$targeted_prompt" "scripts/lib/cost/share.sh"
-    assert_contains "T2.1 prompt includes iteration budget" "$targeted_prompt" "budget"
-else
-    assert_fail "T2.1 _compound_quality_targeted_prompt function not found — T2.1 not implemented"
-fi
 
 cleanup_env
 
@@ -928,21 +892,6 @@ else
 fi
 
 cleanup_env
-
-# ═══════════════════════════════════════════════════════════════════════════════
-# B1 — _cq_max_iter assigned before use (static ordering check)
-# ═══════════════════════════════════════════════════════════════════════════════
-
-print_test_header "B1 — _cq_max_iter assigned before use"
-
-_b1_file="$SCRIPT_DIR/lib/pipeline-intelligence.sh"
-_b1_assign_line=$(grep -n 'local _cq_max_iter' "$_b1_file" 2>/dev/null | head -1 | cut -d: -f1 || true)
-_b1_use_line=$(grep -n '_compound_quality_targeted_prompt.*_cq_max_iter' "$_b1_file" 2>/dev/null | head -1 | cut -d: -f1 || true)
-if [[ -n "$_b1_assign_line" && -n "$_b1_use_line" && "$_b1_assign_line" -lt "$_b1_use_line" ]]; then
-    assert_pass "B1: _cq_max_iter assigned (L${_b1_assign_line}) before use (L${_b1_use_line})"
-else
-    assert_fail "B1: _cq_max_iter ordering regressed (assign=${_b1_assign_line} use=${_b1_use_line})"
-fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # M7 — Fail-closed scope count check (behavioral)


### PR DESCRIPTION
## Summary

Reverts the T2.1 additions from PR #607 that regressed scope enforcement in the `compound_quality` rebuild path. Specifically:

- Removes `_compound_quality_targeted_prompt` function (regex-based file extraction from findings)
- Removes the `targeted_files` injection into the rebuild GOAL
- Removes the `_cq_max_iter` iteration cap (3 for scope route, 5 for blocking items)
- Removes the now-moot T2.1 and B1 tests

All other PR #607 hardening (H1-H3, M5, M6, M7, L8, L-1/L-2, M-1/M-2) is preserved.

## Why

Empirical evidence from the issue #460 pipeline run today (workflow `26053536425`) showed T2.1's optimization was a regression:

1. **Scope override via regex extraction.** The regex `[a-zA-Z0-9_./-]+\.(sh|js|cjs|...)` extracted *every* file path mentioned in review findings, including out-of-scope helper files. It then listed them to the agent as a `TARGETED FIX` block — explicit marching orders that the agent followed over the `route='scope'` "revert, don't fix" instruction.

2. **Iteration cap starved convergence.** Capping rebuild iterations at 3 or 5 meant the agent didn't have enough budget to actually fix review findings, especially when its attention was misdirected to out-of-scope files by the regex extraction.

### Concrete evidence

- `709f69a` modified `.claude/helpers/{statusline,github-safe}.js` — out of scope for the cost-breakdown feature — because both files were mentioned in the review and the regex listed them.
- `95028d1` ran inside compound_quality cycle 1 for 44 minutes and only changed `.claude/pipeline-status.json` by 7 lines. The agent burned its budget without fixing any real finding.
- The critical FNV-435 truncation bug in `.claude/helpers/intelligence.cjs:128` (which our own test suite has a regression check for) was identified by review but remained unfixed across two compound_quality cycles.

## What's next

A separate design proposal will document an alternative approach for the original T2.1 intent (focus compound_quality on relevant files) using an advisory "in-scope findings hint" mechanism that derives its file set from the intersection of design.md scope + findings — not from a regex over reviewer text. Scope enforcement remains sovereign; findings are informational, not directive.

## Test plan

- [x] `bash scripts/sw-postmortem-460-test.sh` — 51/51 pass (was 55; -4 for removed T2.1 and B1 tests)
- [x] `bash scripts/sw-intelligence-test.sh` — 17/17 pass
- [x] `bash -n scripts/lib/pipeline-intelligence.sh` — syntax clean
- [ ] CI green on macos-latest and ubuntu-latest

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)