### PR TITLE
fix(pipeline): anchor polluted-commit detect + capture build stdout to log

### DIFF
--- a/.github/workflows/shipwright-pipeline.yml
+++ b/.github/workflows/shipwright-pipeline.yml
@@ -564,12 +564,17 @@ jobs:
           if git ls-remote --heads --exit-code origin "$BRANCH" >/dev/null 2>&1; then
             git fetch --no-tags origin "$BRANCH" 2>/dev/null || true
             BRANCH_CONTENT=$(git log -5 --format='%s' "origin/$BRANCH" 2>/dev/null || echo "")
-            if echo "$BRANCH_CONTENT" | grep -qiE 'Invalid API key|authentication_error|API key expired|rate_limit_error|overloaded_error'; then
+            # Anchor the pattern to the start of the subject line. Claude-crash commits
+            # always begin with the error string; conventional-commit prefixed fixes
+            # (fix:, feat:, chore:, etc.) never do — so "fix: handle rate_limit_error
+            # in retry logic" no longer trips the polluted-branch deletion.
+            if echo "$BRANCH_CONTENT" | grep -qiE '^[[:space:]]*(Invalid API key|authentication_error|API key expired|rate_limit_error|overloaded_error)'; then
               POLLUTED_SUBJECT=$(echo "$BRANCH_CONTENT" \
-                | grep -iE 'Invalid API key|authentication_error|API key expired|rate_limit_error|overloaded_error' | head -1 || echo "unknown")
+                | grep -iE '^[[:space:]]*(Invalid API key|authentication_error|API key expired|rate_limit_error|overloaded_error)' | head -1 || echo "unknown")
               echo "::warning::Partial work branch appears polluted with API errors — deleting. Trigger commit subject: ${POLLUTED_SUBJECT}"
               git push origin --delete "$BRANCH" 2>/dev/null || true
             else
+              echo "::notice::WIP branch last 5 commit subjects look clean — resuming"
               USE_WIP=true
             fi
           fi

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -656,6 +656,18 @@ ${_build_recall_ctx}"
     fi
 
     local _token_log="${ARTIFACTS_DIR}/.claude-tokens-build.log"
+    local _build_log="${ARTIFACTS_DIR}/build.log"
+    # Pre-write a header line so the file exists even if `sw loop` is killed before
+    # writing anything to stdout (e.g., on a 5-hour job hard-timeout). The file is
+    # read by _resolve_stage_log_path() (pipeline-state.sh:566) when subsequent
+    # stages or post-mortems need the build output. Without this, hard timeouts
+    # leave the diagnostic "stage build produced no log" with nothing to show.
+    {
+        printf '=== build.log — issue %s — run %s — started %s ===\n' \
+            "${ISSUE_NUMBER:-?}" \
+            "${SHIPWRIGHT_PIPELINE_ID:-?}" \
+            "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    } > "$_build_log"
     export PIPELINE_JOB_ID="${PIPELINE_NAME:-pipeline-$$}"
     # Per-iteration cost sidecar (issue #87) — read by sw-loop.sh's record_iteration_cost.
     export ITER_COST_JSONL="${ARTIFACTS_DIR}/loop-iteration-costs.jsonl"
@@ -671,8 +683,15 @@ ${_build_recall_ctx}"
     export CI_JOB_START_EPOCH="${CI_JOB_START_EPOCH:-}"
     # Enable scope guard so safe_git_stage() blocks out-of-scope commits (T1.2)
     export SCOPE_GUARD_ENABLED="true"
-    sw loop "${loop_args[@]}" < /dev/null 2>"$_token_log" || {
-        local _loop_exit=$?
+    # Pipe stdout through `tee -a` so build.log grows incrementally — whatever the
+    # loop emitted before a SIGTERM kill survives on disk for post-mortems.
+    # `set +e` around the pipeline lets us read PIPESTATUS[0] for the loop's true
+    # exit code instead of tee's, without errexit aborting on a non-zero loop.
+    set +e
+    sw loop "${loop_args[@]}" < /dev/null 2>"$_token_log" | tee -a "$_build_log"
+    local _loop_exit=${PIPESTATUS[0]}
+    set -e
+    if [[ "$_loop_exit" -ne 0 ]]; then
         parse_claude_tokens "$_token_log"
 
         # Detect context exhaustion from progress file
@@ -691,7 +710,7 @@ ${_build_recall_ctx}"
 
         error "Build loop failed"
         return 1
-    }
+    fi
     parse_claude_tokens "$_token_log"
 
     # Read accumulated token counts from build loop (written by sw-loop.sh)

--- a/scripts/sw-lib-pipeline-stages-test.sh
+++ b/scripts/sw-lib-pipeline-stages-test.sh
@@ -664,6 +664,77 @@ echo "// auth" > src/auth.js
 git add src/auth.js 2>/dev/null || true
 git commit -m "feat: add auth" --allow-empty 2>/dev/null || true'
 
+# ─── Tests: stage_build — build.log capture ────────────────────────────────
+# Regression guard: stage_build must write ${ARTIFACTS_DIR}/build.log so
+# _resolve_stage_log_path() can surface the build output on post-mortem.
+# Before this fix, only stderr went to the token log and stdout vanished.
+print_test_section "stage_build build.log capture"
+
+# Reset state from prior tests
+rm -f "$ARTIFACTS_DIR/build.log" "$ARTIFACTS_DIR/.claude-tokens-build.log"
+
+# Mock sw that emits known stdout and stderr we can assert on
+mock_binary "sw" 'echo "MOCK_LOOP_STDOUT_MARKER iteration 1"
+echo "MOCK_LOOP_STDERR_MARKER" >&2
+echo "iteration 1 complete"
+exit 0'
+
+stage_build 2>/dev/null || true
+
+# build.log file must exist after stage_build runs
+if [[ -f "$ARTIFACTS_DIR/build.log" ]]; then
+    assert_pass "build.log: file exists after stage_build"
+else
+    assert_fail "build.log: file exists after stage_build" "expected $ARTIFACTS_DIR/build.log to exist"
+fi
+
+# Must contain the header line
+_header_line=$(head -1 "$ARTIFACTS_DIR/build.log" 2>/dev/null || echo "")
+if [[ "$_header_line" =~ ^===\ build\.log\ —\  ]]; then
+    assert_pass "build.log: header line present"
+else
+    assert_fail "build.log: header line present" "got: $_header_line"
+fi
+
+# Must capture mock loop stdout (the whole point of the fix)
+if grep -q "MOCK_LOOP_STDOUT_MARKER" "$ARTIFACTS_DIR/build.log" 2>/dev/null; then
+    assert_pass "build.log: captures sw loop stdout"
+else
+    assert_fail "build.log: captures sw loop stdout" "MOCK_LOOP_STDOUT_MARKER not found in build.log"
+fi
+
+# Stderr must NOT be in build.log (it goes to the token log)
+if grep -q "MOCK_LOOP_STDERR_MARKER" "$ARTIFACTS_DIR/build.log" 2>/dev/null; then
+    assert_fail "build.log: does not capture stderr" "MOCK_LOOP_STDERR_MARKER leaked into build.log"
+else
+    assert_pass "build.log: does not capture stderr"
+fi
+
+# Token log still gets stderr (existing behavior preserved)
+if [[ -f "$ARTIFACTS_DIR/.claude-tokens-build.log" ]] && \
+   grep -q "MOCK_LOOP_STDERR_MARKER" "$ARTIFACTS_DIR/.claude-tokens-build.log" 2>/dev/null; then
+    assert_pass "token log: stderr capture preserved"
+else
+    assert_fail "token log: stderr capture preserved" "expected MOCK_LOOP_STDERR_MARKER in token log"
+fi
+
+# Failure path: build.log must exist even when sw loop exits non-zero
+rm -f "$ARTIFACTS_DIR/build.log" "$ARTIFACTS_DIR/.claude-tokens-build.log"
+mock_binary "sw" 'echo "MOCK_LOOP_FAILURE_STDOUT"
+exit 1'
+stage_build 2>/dev/null || true
+if [[ -f "$ARTIFACTS_DIR/build.log" ]] && grep -q "MOCK_LOOP_FAILURE_STDOUT" "$ARTIFACTS_DIR/build.log" 2>/dev/null; then
+    assert_pass "build.log: captures stdout even on sw loop failure"
+else
+    assert_fail "build.log: captures stdout even on sw loop failure" "expected MOCK_LOOP_FAILURE_STDOUT in build.log after non-zero exit"
+fi
+
+# Restore original sw mock for downstream tests
+mock_binary "sw" 'mkdir -p src
+echo "// auth" > src/auth.js
+git add src/auth.js 2>/dev/null || true
+git commit -m "feat: add auth" --allow-empty 2>/dev/null || true'
+
 # ─── Tests: stage_build — ruflo_recall_similar_outcomes injection ────────────
 print_test_section "stage_build ruflo recall injection"
 

--- a/scripts/sw-postmortem-460-test.sh
+++ b/scripts/sw-postmortem-460-test.sh
@@ -1093,6 +1093,56 @@ else
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Polluted-detection anchoring — false-positive guard
+# Regression guard for the PR #517 widening (rate_limit_error, overloaded_error)
+# that allowed legitimate fix commits like "fix: handle rate_limit_error in retry
+# logic" to trigger WIP branch deletion. After this fix the regex requires the
+# error marker at the start of the subject line.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+print_test_header "polluted-detect — anchored pattern (false-positive guard)"
+
+POLLUTED_REGEX='^[[:space:]]*(Invalid API key|authentication_error|API key expired|rate_limit_error|overloaded_error)'
+
+# Workflow contains the anchored pattern (static check)
+_wf=".github/workflows/shipwright-pipeline.yml"
+if [[ -f "$_wf" ]] && grep -qF "$POLLUTED_REGEX" "$_wf"; then
+    assert_pass "polluted_regex_anchored: shipwright-pipeline.yml uses anchored polluted-detection pattern"
+else
+    assert_fail "polluted_regex_anchored: shipwright-pipeline.yml must contain anchored polluted-detection pattern" \
+        "Expected pattern '${POLLUTED_REGEX}' not found in $_wf — has PR #517 widening been re-introduced?"
+fi
+
+# False-positive cases: legitimate fix commits that contain the error words mid-subject
+for _subj in \
+    'fix: handle rate_limit_error in retry logic' \
+    'feat(api): improve overloaded_error retry' \
+    'chore: log API key expired event' \
+    'docs: document Invalid API key recovery' \
+    'test: cover authentication_error path'; do
+    if echo "$_subj" | grep -qiE "$POLLUTED_REGEX"; then
+        assert_fail "polluted_false_positive: subject must NOT match anchored polluted pattern" \
+            "Subject '$_subj' triggered polluted-deletion — this is the bug PR #517 introduced"
+    else
+        assert_pass "polluted_false_positive: '$_subj' correctly preserved"
+    fi
+done
+
+# True-positive cases: Claude-crash subjects that start with the error string
+for _subj in \
+    'Invalid API key · Please run /login' \
+    'authentication_error: token expired' \
+    'rate_limit_error: token bucket depleted' \
+    'overloaded_error: upstream throttled'; do
+    if echo "$_subj" | grep -qiE "$POLLUTED_REGEX"; then
+        assert_pass "polluted_true_positive: '$_subj' correctly matches"
+    else
+        assert_fail "polluted_true_positive: subject MUST match anchored polluted pattern" \
+            "Subject '$_subj' did not match — anchoring is too strict, real pollution will slip through"
+    fi
+done
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Two residual fixes from pipeline run 26068114437 that PR #611 did not address.

**Fix 1 — Anchor the polluted-commit detection regex** (`.github/workflows/shipwright-pipeline.yml`)
- PR #517 (2026-04-21) widened the polluted-detection from 3 credential markers to 5 by adding `rate_limit_error` and `overloaded_error` — without anchoring. Any legitimate fix-commit subject containing those words anywhere matched, force-deleting the WIP branch.
- With PR #611 landed, this was the **only remaining automated path** that could destroy a live WIP branch and trigger the exact regression PR #611 just fixed.
- Anchored the patterns with `^[[:space:]]*` so only commit subjects that START with the error string match. Added `::notice::` on the clean-branch path so future post-mortems can see the resume decision was made affirmatively.

**Fix 2 — Capture build stage stdout to `build.log`** (`scripts/lib/pipeline-stages-build.sh`)
- `stage_build` previously only captured stderr. Stdout vanished.
- On the 5-hour job timeout that killed run 26068114437's build, `log_stage` never ran and the post-failure diagnostic literally read `stage build produced no log at .../build.log`.
- Pre-write a header line so the file exists even on early termination. Pipe `sw loop` stdout through `tee -a` for incremental capture. Switch failure handling from `cmd || { ... }` to `set +e; cmd | tee; rc=\${PIPESTATUS[0]}; set -e` — pipe-aware, same logic.

## Why this PR matters

PR #611 stopped WIP branches from being auto-deleted on issue close. This PR ensures the only remaining auto-delete path (the polluted-commit check) can't misfire on a normal fix-commit subject, AND makes the next failure diagnosable from local artifacts instead of GitHub Activity API archaeology.

## What this does NOT do

- Does not change the DoD validator, scope guardrail, `compound_quality` wall-clock, or triage gate. Those are downstream of PR #611 and likely already behave correctly with state preserved.
- Does not address issue #460's code work. Once both PRs land, the issue can be re-labeled and the pipeline will resume at the last failed stage.
- Does not bring back the deleted cleanup workflow.

## Test plan

- [x] `bash scripts/sw-postmortem-460-test.sh` — 67/67 (was 57; 10 new cases: 1 workflow-file static guard, 5 false-positive guards, 4 true-positive checks)
- [x] `bash scripts/sw-lib-pipeline-stages-test.sh` — 153/153 (was 147; 6 new cases for build.log capture)
- [x] `bash scripts/sw-gha-pipeline-test.sh` — 74/74
- [x] `bash scripts/sw-pipeline-test.sh` — 128/128
- [x] `npm test` (full suite) — exit 0, no failures
- [x] Manual regex sanity check: `fix: handle rate_limit_error in retry logic` → preserved, `rate_limit_error: token bucket depleted` → matches
- [x] Code review (pr-review-toolkit:code-reviewer) — no MUST FIX, one NICE-TO-HAVE comment wording fix applied

## Files changed

| File | Lines | Purpose |
|------|-------|---------|
| `.github/workflows/shipwright-pipeline.yml` | +6/-2 | Anchor polluted-detect regex; `::notice::` on clean path |
| `scripts/lib/pipeline-stages-build.sh` | +21/-3 | Pre-write build.log header; tee stdout; PIPESTATUS-aware failure handling |
| `scripts/sw-postmortem-460-test.sh` | +50 | Polluted-detect false-positive + true-positive tests + static guard |
| `scripts/sw-lib-pipeline-stages-test.sh` | +71 | build.log capture tests (success + failure paths) |

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)