### PR TITLE
fix(scope-label): use ITERATION counter; suppress absent outer stage label

### DIFF
--- a/scripts/lib/scope-label.sh
+++ b/scripts/lib/scope-label.sh
@@ -51,7 +51,7 @@ scope_label() {
     local inner="${INNER_STAGE:-}"
     # Bash 3.2 compat: use awk for capitalization instead of ${var^}
     local build_iter
-    if [[ -n "${ITERATION:-}" && "${ITERATION:-0}" -gt 0 ]]; then
+    if (( ${ITERATION:-0} > 0 )); then
         build_iter="${ITERATION}"
     else
         build_iter=$(( ${SELF_HEAL_COUNT:-0} + 1 ))

--- a/scripts/lib/scope-label.sh
+++ b/scripts/lib/scope-label.sh
@@ -41,27 +41,31 @@ _read_scope_state() {
 }
 
 # Returns a human-readable label for the current execution scope.
+# Inner defaults to "Build" when INNER_STAGE is unset.
+# Outer prefix is omitted when OUTER_STAGE is unset.
 # Examples:
-#   Top-level:               "Build Iteration 1"
+#   Top-level:               "Build Iteration 3"
 #   Inside compound_quality: "Compound Quality 2 — Build Iteration 3"
 scope_label() {
     local outer="${OUTER_STAGE:-}"
     local inner="${INNER_STAGE:-}"
     # Bash 3.2 compat: use awk for capitalization instead of ${var^}
     local build_iter
-    build_iter=$(( ${SELF_HEAL_COUNT:-0} + 1 ))
+    if [[ -n "${ITERATION:-}" && "${ITERATION:-0}" -gt 0 ]]; then
+        build_iter="${ITERATION}"
+    else
+        build_iter=$(( ${SELF_HEAL_COUNT:-0} + 1 ))
+    fi
     local cq_cycle="${COMPOUND_QUALITY_CYCLE:-1}"
 
+    local inner_pretty
+    inner_pretty=$(echo "${inner:-build}" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
+
     if [[ -n "$outer" ]]; then
-        # e.g. "compound_quality" -> "Compound Quality"
         local outer_pretty
         outer_pretty=$(echo "$outer" | tr '_' ' ' | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1)) substr($i,2)}} 1')
-        local inner_pretty="${inner:-build}"
-        inner_pretty=$(echo "$inner_pretty" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
         echo "${outer_pretty} ${cq_cycle} — ${inner_pretty} Iteration ${build_iter}"
     else
-        local top_pretty="${inner:-Build}"
-        top_pretty=$(echo "$top_pretty" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')
-        echo "${top_pretty} Iteration ${build_iter}"
+        echo "${inner_pretty} Iteration ${build_iter}"
     fi
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `scope_label` computed the iteration number as `SELF_HEAL_COUNT + 1`, which only increments during pipeline self-heal retries — not during regular loop iterations. The actual loop counter (`ITERATION`) was never consulted, so the title always displayed "Build Iteration 1".
- **Fix**: Prefer `ITERATION` when it is set and non-zero; fall back to `SELF_HEAL_COUNT + 1` for pipeline self-heal contexts where `ITERATION` is absent.
- **Label cleanup**: Outer stage prefix is omitted when `OUTER_STAGE` is unset. Inner label defaults to `"Build"` so a standalone loop shows `"Build Iteration N"` (unchanged UX), and a compound-quality run shows `"Compound Quality 2 — Build Iteration N"`.

## Test plan

- [ ] Run a multi-iteration `sw-loop` and confirm title increments: "Build Iteration 1", "Build Iteration 2", …
- [ ] Confirm compound_quality run still shows "Compound Quality N — Build Iteration N"
- [ ] `npm test` passes (existing `prc_scope_label_correctness` test covers the compound_quality fixture)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)