### PR TITLE
fix(intelligence): BigInt FNV-1a 64-bit hash + machine-readable @audit-suppress directive

### DIFF
--- a/.claude/helpers/github-safe.js
+++ b/.claude/helpers/github-safe.js
@@ -25,6 +25,7 @@
 // commands. See ALLOWED_COMMANDS below for the additional allowlist gate.
 // Any static analyzer flagging this import as command-injection-prone
 // should be treated as a false positive: there is no shell on this code path.
+// @audit-suppress audit_1776853149979 -- execFileSync uses execve directly (shell:false); argv-only; no metacharacter interpolation; see ALLOWED_COMMANDS gate below
 import { execFileSync } from 'child_process'; // eslint-disable-line -- safe: argv-only, shell:false
 import { writeFileSync, unlinkSync } from 'fs';
 import { tmpdir } from 'os';

--- a/.claude/helpers/intelligence.cjs
+++ b/.claude/helpers/intelligence.cjs
@@ -120,16 +120,18 @@ function deduplicateById(entries) {
 function fingerprintContent(text) {
   if (typeof text !== 'string' || text.length === 0) return '0';
   const norm = text.replace(/\s+/g, ' ').trim().toLowerCase();
-  // Two 32-bit hashes with different primes + seeds give us a 64-bit-equivalent
-  // fingerprint. Avoid masking the 64-bit FNV prime into 32 bits — its low
-  // 32 bits is 435, which collapses Math.imul into near-trivial hashing.
-  let h1 = 0x811c9dc5, h2 = 0xcbf29ce4;
+  // FNV-1a 64-bit using BigInt so the 64-bit prime stays 64-bit. Do NOT
+  // attempt to use the 64-bit prime with Math.imul or 32-bit bitwise ops:
+  // JS will silently truncate it to its low 32 bits (decimal 435) and
+  // destroy hash quality. BigInt preserves all 64 bits through XOR + multiply.
+  const FNV_PRIME = 0x100000001b3n;
+  const FNV_OFFSET = 0xcbf29ce484222325n;
+  const MASK64 = 0xffffffffffffffffn;
+  let h = FNV_OFFSET;
   for (let i = 0; i < norm.length; i++) {
-    const c = norm.charCodeAt(i);
-    h1 ^= c; h1 = Math.imul(h1, 0x01000193) >>> 0;
-    h2 ^= c; h2 = Math.imul(h2, 0x85ebca77) >>> 0;
+    h = ((h ^ BigInt(norm.charCodeAt(i))) * FNV_PRIME) & MASK64;
   }
-  return `${h1.toString(16)}_${h2.toString(16)}_${norm.length}`;
+  return `${h.toString(16)}_${norm.length}`;
 }
 
 function deduplicateByContent(entries) {

--- a/.claude/helpers/statusline.js
+++ b/.claude/helpers/statusline.js
@@ -13,7 +13,7 @@ const path = require('path');
 // every invocation now passes argv arrays through execve directly, so there
 // is no shell to interpret metacharacters. Keep this comment to explain why
 // `execSync` is intentionally absent.
-const { execFileSync } = require('child_process');
+const { execFileSync } = require('child_process'); // @audit-suppress audit_1776853149979 -- execFileSync uses execve directly (shell:false); argv-only; no metacharacter interpolation
 
 // Configuration
 const CONFIG = {

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -944,7 +944,7 @@ _audit_suppress_check() {
     _excerpt=$(sed -n "${_start},${_line}p" "$_file" 2>/dev/null || true)
     [[ -z "$_excerpt" ]] && return 0
     local _hit
-    _hit=$(echo "$_excerpt" | grep -oE '@audit-suppress[[:space:]]+[A-Za-z0-9_]{8,}[[:space:]]+--[[:space:]]+.+$' | tail -1)
+    _hit=$(echo "$_excerpt" | grep -oE '@audit-suppress[[:space:]]+[A-Za-z0-9_]{8,}[[:space:]]+--[[:space:]]+.+$' | tail -1 || true)
     [[ -z "$_hit" ]] && return 0
     local _id _reason
     _id=$(echo "$_hit" | sed -E 's/^@audit-suppress[[:space:]]+([A-Za-z0-9_]+)[[:space:]]+--[[:space:]]+.*$/\1/')
@@ -952,7 +952,7 @@ _audit_suppress_check() {
     echo "${_id}|${_reason}"
 }
 
-# Append a suppression record to the sidecar audit log. Idempotent best-effort.
+# Append a suppression record to the sidecar audit log. Best-effort (not deduplicated).
 _audit_suppress_record() {
     local _file="$1"
     local _line="$2"
@@ -971,7 +971,7 @@ _audit_suppress_record() {
     # Validate existing is JSON array; reset if corrupt.
     echo "$_existing" | jq -e 'type == "array"' >/dev/null 2>&1 || _existing="[]"
     local _tmp
-    _tmp=$(mktemp)
+    _tmp=$(mktemp "${TMPDIR:-/tmp}/audit-suppress.XXXXXX")
     echo "$_existing" | jq \
         --arg f "$_file" \
         --arg l "$_line" \

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -921,6 +921,68 @@ EOF
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
+# @audit-suppress directive parser.
+#
+# Grammar:
+#   @audit-suppress <id> -- <reason>
+#   - <id>:    [A-Za-z0-9_]{8,}  (convention: audit_<unix-ms-timestamp>)
+#   - <reason>: free text to EOL, surfaced in suppression sidecar.
+#
+# Scope: matches when the directive appears on the same line as a flagged
+# pattern OR up to 3 lines above. This is intentionally narrow — it prevents
+# whole-file suppression-by-accident and forces the directive to sit next to
+# what it's justifying.
+#
+# Echoes "<id>|<reason>" on hit (one line). Empty on miss.
+# ──────────────────────────────────────────────────────────────────────────────
+_audit_suppress_check() {
+    local _file="$1"
+    local _line="$2"
+    [[ -z "$_file" || ! -f "$_file" || -z "$_line" ]] && return 0
+    local _start=$(( _line > 3 ? _line - 3 : 1 ))
+    local _excerpt
+    _excerpt=$(sed -n "${_start},${_line}p" "$_file" 2>/dev/null || true)
+    [[ -z "$_excerpt" ]] && return 0
+    local _hit
+    _hit=$(echo "$_excerpt" | grep -oE '@audit-suppress[[:space:]]+[A-Za-z0-9_]{8,}[[:space:]]+--[[:space:]]+.+$' | tail -1)
+    [[ -z "$_hit" ]] && return 0
+    local _id _reason
+    _id=$(echo "$_hit" | sed -E 's/^@audit-suppress[[:space:]]+([A-Za-z0-9_]+)[[:space:]]+--[[:space:]]+.*$/\1/')
+    _reason=$(echo "$_hit" | sed -E 's/^@audit-suppress[[:space:]]+[A-Za-z0-9_]+[[:space:]]+--[[:space:]]+(.*)$/\1/')
+    echo "${_id}|${_reason}"
+}
+
+# Append a suppression record to the sidecar audit log. Idempotent best-effort.
+_audit_suppress_record() {
+    local _file="$1"
+    local _line="$2"
+    local _pattern="$3"
+    local _id="$4"
+    local _reason="$5"
+    local _sup_dir="${ARTIFACTS_DIR:-.claude/pipeline-artifacts}"
+    local _sup_file="${_sup_dir}/compound-quality-suppressions.json"
+    mkdir -p "$_sup_dir" 2>/dev/null || true
+    local _existing
+    if [[ -f "$_sup_file" ]]; then
+        _existing=$(cat "$_sup_file" 2>/dev/null || echo "[]")
+    else
+        _existing="[]"
+    fi
+    # Validate existing is JSON array; reset if corrupt.
+    echo "$_existing" | jq -e 'type == "array"' >/dev/null 2>&1 || _existing="[]"
+    local _tmp
+    _tmp=$(mktemp)
+    echo "$_existing" | jq \
+        --arg f "$_file" \
+        --arg l "$_line" \
+        --arg p "$_pattern" \
+        --arg id "$_id" \
+        --arg r "$_reason" \
+        '. + [{"file":$f,"line":($l|tonumber),"pattern":$p,"suppressed_by":{"id":$id,"reason":$r}}]' \
+        > "$_tmp" 2>/dev/null && mv "$_tmp" "$_sup_file" || rm -f "$_tmp"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
 # 7. Source Code Security Scan
 # Grep-based vulnerability pattern matching on changed files.
 # ──────────────────────────────────────────────────────────────────────────────
@@ -998,6 +1060,20 @@ XSSEOF
             while IFS= read -r match; do
                 [[ -z "$match" ]] && continue
                 local line_num="${match%%:*}"
+                # @audit-suppress directive check — if the matched line carries
+                # (or is preceded within 3 lines by) a structured suppression
+                # directive, record it in the audit sidecar and skip the
+                # blocking finding. This turns the previously-implicit
+                # "trust the SAST confidence tier" defense into an explicit
+                # contract that survives refactors and is enforceable by tests.
+                local _suppress_hit
+                _suppress_hit=$(_audit_suppress_check "$file" "$line_num")
+                if [[ -n "$_suppress_hit" ]]; then
+                    local _sup_id="${_suppress_hit%%|*}"
+                    local _sup_reason="${_suppress_hit#*|}"
+                    _audit_suppress_record "$file" "$line_num" "command_injection" "$_sup_id" "$_sup_reason"
+                    continue
+                fi
                 finding_count=$((finding_count + 1))
                 local current
                 current=$(cat "$tmp_findings")

--- a/scripts/sw-intelligence-test.sh
+++ b/scripts/sw-intelligence-test.sh
@@ -628,8 +628,8 @@ test_audit_suppress_directive_recognized() {
         return
     fi
 
-    # Source just the two helper functions by extracting them — avoids
-    # pulling in the rest of the file's globals.
+    # Source the whole pipeline-intelligence.sh in a subshell — we only call
+    # the two helper functions but sourcing the full file is simplest and correct.
     local fixture_dir="$TEST_TEMP_DIR/audit-suppress-fixture"
     mkdir -p "$fixture_dir"
     local artifacts_dir="$fixture_dir/.claude/pipeline-artifacts"

--- a/scripts/sw-intelligence-test.sh
+++ b/scripts/sw-intelligence-test.sh
@@ -598,12 +598,140 @@ test_fingerprint_content_not_truncated() {
                 assert_fail "fingerprintContent threw error" "$fp_result"
             elif [[ "$fp_result" == "0" || -z "$fp_result" ]]; then
                 assert_fail "fingerprintContent returned zero/empty" "hash appears broken — check FNV-1a prime"
+            elif [[ "$fp_result" =~ ^[0-9a-f]+_[0-9]+$ ]]; then
+                # New format: 64-bit BigInt FNV-1a hex + length. Canonical FNV-1a-64
+                # of "hello world" is 0x779a65e7023cd2e7 — verify exact match.
+                if [[ "$fp_result" == "779a65e7023cd2e7_11" ]]; then
+                    assert_pass "fingerprintContent('hello world') matches canonical FNV-1a-64: $fp_result"
+                else
+                    assert_fail "fingerprintContent('hello world') does not match canonical FNV-1a-64" \
+                        "expected 779a65e7023cd2e7_11, got $fp_result"
+                fi
             else
-                assert_pass "fingerprintContent returns non-zero value: $fp_result"
+                assert_fail "fingerprintContent output format unexpected" \
+                    "expected <hex>_<len>, got $fp_result"
             fi
         fi
     else
         assert_fail "intelligence.cjs not found at: $intelligence_cjs" ""
+    fi
+}
+
+test_audit_suppress_directive_recognized() {
+    reset_test
+    # Regression: @audit-suppress <id> -- <reason> directive must suppress
+    # command-injection findings AND route them to the suppression sidecar.
+    local pipeline_intel_sh
+    pipeline_intel_sh="$SCRIPT_DIR/lib/pipeline-intelligence.sh"
+    if [[ ! -f "$pipeline_intel_sh" ]]; then
+        assert_fail "pipeline-intelligence.sh not found at: $pipeline_intel_sh" ""
+        return
+    fi
+
+    # Source just the two helper functions by extracting them — avoids
+    # pulling in the rest of the file's globals.
+    local fixture_dir="$TEST_TEMP_DIR/audit-suppress-fixture"
+    mkdir -p "$fixture_dir"
+    local artifacts_dir="$fixture_dir/.claude/pipeline-artifacts"
+    mkdir -p "$artifacts_dir"
+
+    # Fixture 1: suppressed import (directive on same line)
+    cat > "$fixture_dir/safe.js" <<'SAFE'
+#!/usr/bin/env node
+const { execFileSync } = require('child_process'); // @audit-suppress audit_test_1234 -- argv-only execve path; no shell
+SAFE
+
+    # Fixture 2: suppressed import (directive on preceding line)
+    cat > "$fixture_dir/safe-above.js" <<'SAFEABOVE'
+#!/usr/bin/env node
+// @audit-suppress audit_test_5678 -- justified by upstream allow-list gate
+const { execFileSync } = require('child_process');
+SAFEABOVE
+
+    # Fixture 3: un-suppressed (must still flag)
+    cat > "$fixture_dir/unsafe.js" <<'UNSAFE'
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+UNSAFE
+
+    # Run helpers in a subshell with controlled ARTIFACTS_DIR
+    local check_safe check_safe_above check_unsafe
+    check_safe=$(ARTIFACTS_DIR="$artifacts_dir" bash -c "source '$pipeline_intel_sh' >/dev/null 2>&1; _audit_suppress_check '$fixture_dir/safe.js' 2")
+    check_safe_above=$(ARTIFACTS_DIR="$artifacts_dir" bash -c "source '$pipeline_intel_sh' >/dev/null 2>&1; _audit_suppress_check '$fixture_dir/safe-above.js' 3")
+    check_unsafe=$(ARTIFACTS_DIR="$artifacts_dir" bash -c "source '$pipeline_intel_sh' >/dev/null 2>&1; _audit_suppress_check '$fixture_dir/unsafe.js' 2")
+
+    if [[ "$check_safe" == "audit_test_1234|argv-only execve path; no shell" ]]; then
+        assert_pass "directive on same line recognized: $check_safe"
+    else
+        assert_fail "directive on same line not recognized" "got: '$check_safe'"
+    fi
+
+    if [[ "$check_safe_above" == "audit_test_5678|justified by upstream allow-list gate" ]]; then
+        assert_pass "directive on preceding line recognized: $check_safe_above"
+    else
+        assert_fail "directive on preceding line not recognized" "got: '$check_safe_above'"
+    fi
+
+    if [[ -z "$check_unsafe" ]]; then
+        assert_pass "un-suppressed import correctly not matched as suppressed"
+    else
+        assert_fail "un-suppressed import wrongly matched" "got: '$check_unsafe'"
+    fi
+
+    # Sidecar write — record a finding and verify JSON shape
+    ARTIFACTS_DIR="$artifacts_dir" bash -c "source '$pipeline_intel_sh' >/dev/null 2>&1; _audit_suppress_record '$fixture_dir/safe.js' 2 'command_injection' 'audit_test_1234' 'argv-only execve path; no shell'"
+
+    local sidecar="$artifacts_dir/compound-quality-suppressions.json"
+    if [[ ! -f "$sidecar" ]]; then
+        assert_fail "suppression sidecar not written" "expected: $sidecar"
+        return
+    fi
+
+    local recorded_id recorded_reason recorded_pattern
+    recorded_id=$(jq -r '.[0].suppressed_by.id // empty' "$sidecar" 2>/dev/null || true)
+    recorded_reason=$(jq -r '.[0].suppressed_by.reason // empty' "$sidecar" 2>/dev/null || true)
+    recorded_pattern=$(jq -r '.[0].pattern // empty' "$sidecar" 2>/dev/null || true)
+
+    if [[ "$recorded_id" == "audit_test_1234" && "$recorded_pattern" == "command_injection" && "$recorded_reason" == "argv-only execve path; no shell" ]]; then
+        assert_pass "suppression sidecar records id, pattern, and reason"
+    else
+        assert_fail "suppression sidecar contents wrong" \
+            "id=$recorded_id pattern=$recorded_pattern reason=$recorded_reason"
+    fi
+}
+
+test_audit_suppress_load_bearing_comments_present() {
+    reset_test
+    # Enforces that the two known load-bearing @audit-suppress directives
+    # exist. If a future contributor (or autonomous loop) deletes them, this
+    # test fails — it IS the enforcement. See issue #605 review for context.
+    local repo_root
+    repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+    local statusline_js="$repo_root/.claude/helpers/statusline.js"
+    local github_safe_js="$repo_root/.claude/helpers/github-safe.js"
+
+    if [[ ! -f "$statusline_js" ]]; then
+        assert_fail "statusline.js not found at: $statusline_js" ""
+        return
+    fi
+    if [[ ! -f "$github_safe_js" ]]; then
+        assert_fail "github-safe.js not found at: $github_safe_js" ""
+        return
+    fi
+
+    if grep -qE '@audit-suppress[[:space:]]+audit_1776853149979[[:space:]]+--' "$statusline_js"; then
+        assert_pass "statusline.js carries @audit-suppress audit_1776853149979"
+    else
+        assert_fail "statusline.js MISSING @audit-suppress audit_1776853149979" \
+            "this directive is load-bearing — see #605 review"
+    fi
+
+    if grep -qE '@audit-suppress[[:space:]]+audit_1776853149979[[:space:]]+--' "$github_safe_js"; then
+        assert_pass "github-safe.js carries @audit-suppress audit_1776853149979"
+    else
+        assert_fail "github-safe.js MISSING @audit-suppress audit_1776853149979" \
+            "this directive is load-bearing — see #605 review"
     fi
 }
 
@@ -655,6 +783,8 @@ main() {
         "test_intelligence_enabled_path_install:PATH install does not disable intelligence"
         "test_intelligence_cache_when_repo_dir_is_install_root:INTELLIGENCE_CACHE correct when REPO_DIR pre-set to install root"
         "test_fingerprint_content_not_truncated:fingerprintContent FNV-1a prime not truncated to 435"
+        "test_audit_suppress_directive_recognized:@audit-suppress directive suppresses SAST findings and records to sidecar"
+        "test_audit_suppress_load_bearing_comments_present:statusline.js and github-safe.js carry @audit-suppress audit_1776853149979"
     )
 
     for entry in "${tests[@]}"; do

--- a/scripts/sw-postmortem-460-test.sh
+++ b/scripts/sw-postmortem-460-test.sh
@@ -387,34 +387,30 @@ if [[ -f "$INTELLIGENCE_CJS" ]]; then
                 assert_pass "T2.5 fingerprintContent('hello world') returns non-zero value: $FP_RESULT"
             fi
 
-            # Regression: if multiplier were 435 instead of 0x01000193, hash would differ
-            # Run with the CORRECT multiplier to get the expected value, then verify same
+            # Regression: verify match against canonical 64-bit FNV-1a reference.
+            # If the prime were truncated to 435, the hash would not match.
             CORRECT_FP=$(node -e "
-                // FNV-1a 32 with correct prime 0x01000193
+                // FNV-1a 64-bit BigInt reference (canonical).
+                const FNV_PRIME = 0x100000001b3n;
+                const FNV_OFFSET = 0xcbf29ce484222325n;
+                const MASK64 = 0xffffffffffffffffn;
                 function fpCorrect(s) {
-                    let h1 = 0x811c9dc5 >>> 0;
-                    let h2 = 0x811c9dc5 >>> 0;
-                    for (let i = 0; i < s.length; i++) {
-                        const c = s.charCodeAt(i);
-                        h1 ^= c;
-                        h1 = (Math.imul(h1, 0x01000193) >>> 0);
-                        h2 ^= c;
-                        h2 = (Math.imul(h2, 0x01000193) >>> 0);
+                    const norm = s.replace(/\s+/g, ' ').trim().toLowerCase();
+                    let h = FNV_OFFSET;
+                    for (let i = 0; i < norm.length; i++) {
+                        h = ((h ^ BigInt(norm.charCodeAt(i))) * FNV_PRIME) & MASK64;
                     }
-                    return (h1 ^ h2).toString(16);
+                    return h.toString(16) + '_' + norm.length;
                 }
                 process.stdout.write(fpCorrect('hello world'));
             " 2>/dev/null) || CORRECT_FP="ERROR"
 
-            # They should match (both use the correct prime)
-            # Note: if the implementation uses the truncated 435, they would NOT match
             if [[ "$FP_RESULT" != "ERROR" && "$CORRECT_FP" != "ERROR" ]]; then
                 if [[ "$FP_RESULT" == "$CORRECT_FP" ]]; then
-                    assert_pass "T2.5 fingerprintContent matches reference implementation (prime not truncated)"
+                    assert_pass "T2.5 fingerprintContent matches canonical FNV-1a-64 reference: $FP_RESULT"
                 else
-                    # Don't fail if algorithms differ slightly — just verify it's not the known-bad 435
-                    # The key regression test is that the output is stable and non-trivial
-                    assert_pass "T2.5 fingerprintContent returns stable non-trivial value (algorithm variant OK)"
+                    assert_fail "T2.5 fingerprintContent does not match canonical FNV-1a-64 reference" \
+                        "expected $CORRECT_FP, got $FP_RESULT"
                 fi
             fi
         fi


### PR DESCRIPTION
## Summary

- **Part 1 — BigInt FNV-1a hash**: Replaces the fragile two-prime 32-bit split in `fingerprintContent` (`.claude/helpers/intelligence.cjs`) with canonical 64-bit FNV-1a using BigInt. The old design had an inline apology comment warning that one careless edit would silently truncate the 64-bit prime to 32 bits (decimal 435), destroying hash quality. The new implementation uses `0x100000001b3n` / `0xcbf29ce484222325n` so the prime can never be truncated. Output format changes from `h1_h2_len` → `hex_len`; fingerprints are in-memory dedup keys only, never persisted, so the format break is invisible to consumers.
- **Part 2 — machine-readable @audit-suppress directive**: Adds `_audit_suppress_check()` / `_audit_suppress_record()` to `pipeline-intelligence.sh`. When a matched line (or any of the 3 lines above it) carries `// @audit-suppress <id> -- <reason>`, the SAST skips adding it to the blocking findings list and writes an audit record to `compound-quality-suppressions.json` instead. Inline directives added to `statusline.js` and `github-safe.js` — if an autonomous loop agent deletes them, the new enforcement test in `sw-intelligence-test.sh` fails loudly instead of producing a quiet confidence-tier flap.

## Test plan

- [x] `bash scripts/sw-intelligence-test.sh` — 25/25 pass (includes 2 new tests: `test_audit_suppress_directive_recognized`, `test_audit_suppress_load_bearing_comments_present`)
- [x] `bash scripts/sw-postmortem-460-test.sh` — 72/72 pass (T2.5 updated to BigInt reference impl)
- [x] `npm test` — full suite green
- [x] Manual: `node -e "const {fingerprintContent}=require('./.claude/helpers/intelligence.cjs'); console.log(fingerprintContent('hello world'))"` → `779a65e7023cd2e7_11`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)