### PR TITLE
feat(scope-redaction): codify the out-of-scope agent edit invariant at all 6 prompt seams

### DIFF
--- a/scripts/lib/compound-audit.sh
+++ b/scripts/lib/compound-audit.sh
@@ -117,21 +117,38 @@ ${file_contents}
 "
     fi
 
+    # Seam (a): redact out-of-scope paths from diff, prev_findings, and file_contents_section
+    # before audit-prompt construction. This is upstream of intel.sh:_extract_blocking_items —
+    # audit findings feed _extract_blocking_items which feeds the GOAL string.
+    local _ca_scope_allowlist=""
+    _ca_scope_allowlist=$(_extract_scope_from_design 2>/dev/null || true)
+    local _ca_diff="$diff"
+    local _ca_prev="$prev_findings"
+    local _ca_fcs="$file_contents_section"
+    if [ -n "$_ca_scope_allowlist" ]; then
+        _ca_diff=$(_redact_paths_outside_scope "$diff" "$_ca_scope_allowlist" \
+            "compound_audit_diff" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$diff")
+        _ca_prev=$(_redact_paths_outside_scope "$prev_findings" "$_ca_scope_allowlist" \
+            "compound_audit_prev" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$prev_findings")
+        _ca_fcs=$(_redact_paths_outside_scope "$file_contents_section" "$_ca_scope_allowlist" \
+            "compound_audit_files" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$file_contents_section")
+    fi
+
     cat <<EOF
 ${specialization}
 
 ## Code Changes (cumulative diff)
 \`\`\`
-${diff}
+${_ca_diff}
 \`\`\`
 
 ## Implementation Plan/Spec
 ${plan_summary}
 
 ## Previously Found Issues (do NOT repeat these)
-${prev_findings}
+${_ca_prev}
 ${evidence_section}
-${file_contents_section}
+${_ca_fcs}
 ## Output Format
 Return ONLY valid JSON (no markdown, no explanation):
 {"findings":[{"severity":"critical|high|medium|low","category":"${agent_type}","file":"path/to/file","line":0,"description":"One sentence","evidence":"The specific code","suggestion":"How to fix"}]}

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -574,6 +574,169 @@ _git_bookkeeping_pathspecs() {
     done
 }
 
+# ─── Scope-redaction helpers (PR-B invariant) ───────────────────────────────
+#
+# Invariant: no file path token in any agent prompt may name a file outside the
+# design.md ```scope allow-list (except inside <out-of-scope-context> blocks).
+# Codified at prompt-construction time — detective guards (safe_git_stage) remain
+# as defense-in-depth but are not the primary enforcement mechanism.
+
+# _file_in_scope — Test whether a single file path is permitted by the scope allowlist.
+# Usage: _file_in_scope <file> <allowlist_newline_sep>
+# Returns 0 (in-scope / allowed) or 1 (out-of-scope).
+# When allowlist is empty, returns 0 (fail-open — warn-mode default).
+# Handles: literals, directory prefixes (entry ends /), single-star globs, double-star globs.
+# Do NOT reuse _compute_scope_violations — that is set-difference via comm and silently
+# no-ops on dir/glob entries (different contract).
+_file_in_scope() {
+    local file="$1" allowlist="$2" entry _pfx _sdir _spat _fdir _fbase
+    [ -z "$allowlist" ] && return 0
+    while IFS= read -r entry; do
+        [ -z "$entry" ] && continue
+        case "$entry" in
+            \#*) continue ;;
+            */)  case "$file" in "${entry}"*) return 0 ;; esac ;;
+            *\*\**) _pfx="${entry%%\*\**}"; case "$file" in "${_pfx}"*) return 0 ;; esac ;;
+            *\**)
+                # Single-star: must NOT cross directory boundaries (star ≠ /)
+                case "$entry" in
+                    */*) _sdir="${entry%/*}"; _spat="${entry##*/}" ;;
+                    *)   _sdir="";            _spat="$entry" ;;
+                esac
+                case "$file" in
+                    */*) _fdir="${file%/*}"; _fbase="${file##*/}" ;;
+                    *)   _fdir="";           _fbase="$file" ;;
+                esac
+                if [ "$_sdir" = "$_fdir" ]; then
+                    case "$_fbase" in $_spat) return 0 ;; esac
+                fi ;;
+            *) [ "$file" = "$entry" ] && return 0 ;;
+        esac
+    done <<< "$allowlist"
+    return 1
+}
+
+# _redact_paths_outside_scope — Replace out-of-scope file path tokens in text with
+# redaction sentinels. Preserves code-fence blocks and <out-of-scope-context> blocks verbatim.
+# Usage: result=$(_redact_paths_outside_scope "$text" "$allowlist" [seam] [cycle])
+# When allowlist is empty, returns text unchanged (fail-open / warn-mode default —
+# zero behaviour change for existing repos with no scope fence).
+# Side effects per redaction:
+#   - Appends a record to .claude/pipeline-artifacts/oos-redactions-cycle-N.json
+#   - Emits pipeline.prompt_path_redacted via emit_event
+_redact_paths_outside_scope() {
+    local text="$1"
+    local allowlist="$2"
+    local seam="${3:-unknown}"
+    local cycle="${4:-0}"
+
+    # Pass-through when allowlist empty (warn mode — zero behaviour change for existing repos)
+    if [ -z "$allowlist" ]; then
+        printf '%s' "$text"
+        return 0
+    fi
+
+    local token_counter=0
+    local in_fence=0
+    local in_oos_ctx=0
+    local sidecar_dir="${ARTIFACTS_DIR:-.claude/pipeline-artifacts}"
+    local sidecar_file="${sidecar_dir}/oos-redactions-cycle-${cycle}.json"
+    local allowlist_hash
+    allowlist_hash=$(printf '%s' "$allowlist" | md5sum 2>/dev/null | cut -d' ' -f1 \
+        || printf '%s' "$allowlist" | md5 2>/dev/null || echo "nohash")
+
+    [ ! -d "$sidecar_dir" ] && mkdir -p "$sidecar_dir"
+    [ ! -f "$sidecar_file" ] && printf '[]' > "$sidecar_file"
+
+    local line processed candidates raw_token candidate suffix sentinel replacement _tmp
+
+    while IFS= read -r line; do
+        # Track <out-of-scope-context> escape markers
+        case "$line" in
+            *'<out-of-scope-context>'*)  in_oos_ctx=1 ;;
+            *'</out-of-scope-context>'*) in_oos_ctx=0 ;;
+        esac
+
+        # Toggle code-fence state on ``` lines; emit verbatim and skip tokenizer
+        case "$line" in
+            '```'*)
+                if [ "$in_fence" -eq 1 ]; then in_fence=0; else in_fence=1; fi
+                printf '%s\n' "$line"
+                continue ;;
+        esac
+
+        # Preserve lines verbatim inside fences and escape markers
+        if [ "$in_fence" -eq 1 ] || [ "$in_oos_ctx" -eq 1 ]; then
+            printf '%s\n' "$line"
+            continue
+        fi
+
+        # Strip URLs before tokenizing so hostnames (example.com) aren't extracted as candidates.
+        # Use -E for portable extended-regex (BSD sed and GNU sed both support -E).
+        local _stripped_line
+        _stripped_line=$(printf '%s' "$line" \
+            | sed -E 's|https?://[^[:space:]]*||g; s|ftp://[^[:space:]]*||g; s|git@[^[:space:]]*||g' \
+            2>/dev/null || printf '%s' "$line")
+
+        # Extract file-path-shaped tokens: word-chars+dot+extension, optional :N or :N-M suffix
+        candidates=$(printf '%s' "$_stripped_line" \
+            | grep -oE '[A-Za-z0-9_./-]+\.[A-Za-z0-9]+(:[0-9]+(-[0-9]+)?)?' 2>/dev/null || true)
+
+        processed="$line"
+        while IFS= read -r raw_token; do
+            [ -z "$raw_token" ] && continue
+
+            # Strip line-number suffix before scope check
+            candidate="${raw_token%%:*}"
+
+            # Negative filters — skip URLs, absolute paths, lang-prefixed tokens, version strings
+            case "$candidate" in
+                http://*|https://*|ftp://*|git@*) continue ;;
+                //*|/*) continue ;;    # absolute or double-slash (URL path fragment after stripping)
+                Node:*|TypeScript:*|v[0-9]*) continue ;;
+                [0-9]*) continue ;;
+            esac
+
+            # Idempotency: skip already-redacted sentinels so running twice is a no-op
+            case "$raw_token" in
+                '[redacted:out-of-scope:'*) continue ;;
+            esac
+
+            # Scope check — nothing to do when in-scope
+            _file_in_scope "$candidate" "$allowlist" && continue
+
+            # Out of scope: assign a stable sentinel for this token
+            token_counter=$((token_counter + 1))
+            sentinel="[redacted:out-of-scope:TOKEN-${token_counter}]"
+            suffix="${raw_token#"$candidate"}"
+            replacement="${sentinel}${suffix}"
+
+            # Bash literal string substitution (// form; . and / are literal in bash globs)
+            processed="${processed//"$raw_token"/"$replacement"}"
+
+            # Append to sidecar manifest (requires jq; silently skips if absent)
+            if command -v jq >/dev/null 2>&1; then
+                _tmp="${sidecar_file}.tmp.$$"
+                jq -c --arg cycle "$cycle" --arg seam "$seam" \
+                    --arg tid "TOKEN-${token_counter}" \
+                    --arg orig "$candidate" --arg hash "$allowlist_hash" \
+                    '. + [{"cycle":($cycle|tonumber),"source_seam":$seam,"token_id":$tid,"original_path":$orig,"allowlist_snapshot_hash":$hash}]' \
+                    "$sidecar_file" > "$_tmp" 2>/dev/null && mv "$_tmp" "$sidecar_file" \
+                    || rm -f "$_tmp"
+            fi
+
+            # Emit telemetry event
+            declare -f emit_event >/dev/null 2>&1 && \
+                emit_event "pipeline.prompt_path_redacted" \
+                    "stage=${seam}" "file=${candidate}" "token=TOKEN-${token_counter}" \
+                    2>/dev/null || true
+
+        done <<< "$candidates"
+
+        printf '%s\n' "$processed"
+    done <<< "$text"
+}
+
 # Load daemon-config.json, merging the auto-tuned sidecar (~/.shipwright/optimization/tuned-config.json)
 # on top of the base config.  Sidecar carries auto-optimizer writes (intelligence flags, DORA
 # autotune values) so they do not pollute committed daemon-config.json on feature branches.

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -596,7 +596,22 @@ _file_in_scope() {
         case "$entry" in
             \#*) continue ;;
             */)  case "$file" in "${entry}"*) return 0 ;; esac ;;
-            *\*\**) _pfx="${entry%%\*\**}"; case "$file" in "${_pfx}"*) return 0 ;; esac ;;
+            *\*\**)
+                # Double-star: recursive match with optional prefix and suffix
+                # e.g. scripts/** → prefix="scripts/", suffix=""
+                #      **/*.ts  → prefix="",           suffix="*.ts"
+                _pfx="${entry%%\*\**}"
+                _sfx="${entry##*\*\*}"
+                case "$_sfx" in /*) _sfx="${_sfx#/}" ;; esac   # strip leading /
+                local _pmatch=1 _smatch=1
+                if [ -n "$_pfx" ]; then
+                    case "$file" in "${_pfx}"*) ;; *) _pmatch=0 ;; esac
+                fi
+                if [ -n "$_sfx" ]; then
+                    case "${file##*/}" in $_sfx) ;; *) _smatch=0 ;; esac
+                fi
+                [ "$_pmatch" -eq 1 ] && [ "$_smatch" -eq 1 ] && return 0
+                ;;
             *\**)
                 # Single-star: must NOT cross directory boundaries (star ≠ /)
                 case "$entry" in
@@ -678,9 +693,14 @@ _redact_paths_outside_scope() {
             | sed -E 's|https?://[^[:space:]]*||g; s|ftp://[^[:space:]]*||g; s|git@[^[:space:]]*||g' \
             2>/dev/null || printf '%s' "$line")
 
-        # Extract file-path-shaped tokens: word-chars+dot+extension, optional :N or :N-M suffix
+        # Extract file-path-shaped tokens.
+        # Two shapes:
+        #   1. Dotted extension:    foo/bar.sh:42   foo.ts
+        #   2. Extensionless slash: scripts/sw      src/main (must contain / to avoid noise)
+        # Combined via alternation; sort -u deduplicates overlapping matches.
         candidates=$(printf '%s' "$_stripped_line" \
-            | grep -oE '[A-Za-z0-9_./-]+\.[A-Za-z0-9]+(:[0-9]+(-[0-9]+)?)?' 2>/dev/null || true)
+            | grep -oE '([A-Za-z0-9_./-]+\.[A-Za-z0-9]+(:[0-9]+(-[0-9]+)?)?|[A-Za-z0-9_-]+(/[A-Za-z0-9_.@-]+)+)' \
+            2>/dev/null | sort -u || true)
 
         processed="$line"
         while IFS= read -r raw_token; do

--- a/scripts/lib/loop-iteration.sh
+++ b/scripts/lib/loop-iteration.sh
@@ -663,6 +663,20 @@ PROMPT
         "skipped_intelligence_static=$( [[ "$_needs_full_context" == false ]] && echo true || echo false )" \
         2>/dev/null || true
 
+    # Redact out-of-scope file path tokens from the assembled prompt before it reaches the agent.
+    # Seam (f): final assembly gate — broadest protection as it catches content from all upstream
+    # sources (error-summary, audit_feedback, intelligence_section, gate_findings, commits).
+    local _loop_scope_allowlist=""
+    _loop_scope_allowlist=$(_extract_scope_from_design 2>/dev/null || true)
+    if [ -n "$_loop_scope_allowlist" ]; then
+        local _prompt_content
+        _prompt_content=$(cat "$_ptmp")
+        _prompt_content=$(_redact_paths_outside_scope "$_prompt_content" "$_loop_scope_allowlist" \
+            "compose_prompt" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null \
+            || cat "$_ptmp")
+        printf '%s' "$_prompt_content" > "$_ptmp"
+    fi
+
     cat "$_ptmp"
     rm -f "$_ptmp"
 }

--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1681,6 +1681,17 @@ compound_rebuild_with_feedback() {
     local blocking_items
     blocking_items=$(_extract_blocking_items)
 
+    # Redact out-of-scope path tokens from blocking_items before any prompt injection.
+    # This is the load-bearing safety seam (d) — if a path is not in the prompt, the
+    # agent cannot open/edit it by name. Pass-through when scope_allowlist is empty
+    # (warn-mode default — zero behaviour change for repos without a scope fence).
+    local _scope_allowlist=""
+    _scope_allowlist=$(_extract_scope_from_design 2>/dev/null || true)
+    if [ -n "$_scope_allowlist" ]; then
+        blocking_items=$(_redact_paths_outside_scope "$blocking_items" "$_scope_allowlist" \
+            "compound_rebuild_blocking" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$blocking_items")
+    fi
+
     # Collect all findings (prioritized by classification)
     _write_quality_feedback "$route" "$feedback_file" "$blocking_items"
 
@@ -1723,6 +1734,13 @@ compound_rebuild_with_feedback() {
     }' RETURN
     local feedback_content
     feedback_content=$(cat "$feedback_file")
+
+    # Redact out-of-scope paths from feedback_content (second exposure — _write_quality_feedback
+    # re-includes blocking items under its own "## Blocking Issues" header).
+    if [ -n "$_scope_allowlist" ]; then
+        feedback_content=$(_redact_paths_outside_scope "$feedback_content" "$_scope_allowlist" \
+            "compound_rebuild_feedback" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$feedback_content")
+    fi
 
     local route_instruction=""
     case "$route" in

--- a/scripts/lib/pipeline-quality-checks.sh
+++ b/scripts/lib/pipeline-quality-checks.sh
@@ -796,6 +796,20 @@ run_adversarial_review() {
         adv_memory=$(intelligence_search_memory "adversarial review security findings for: ${GOAL:-}" "${HOME}/.shipwright/memory" 5 2>/dev/null) || true
     fi
 
+    # Seam (b): redact out-of-scope paths from diff_content and adv_memory before
+    # adversarial-review prompt construction. adv_memory cites paths from previous runs;
+    # diff_content may reference helper files adjacent to changed files.
+    local _pqc_scope_allowlist=""
+    _pqc_scope_allowlist=$(_extract_scope_from_design 2>/dev/null || true)
+    local _pqc_diff="$diff_content"
+    local _pqc_mem="$adv_memory"
+    if [ -n "$_pqc_scope_allowlist" ]; then
+        _pqc_diff=$(_redact_paths_outside_scope "$diff_content" "$_pqc_scope_allowlist" \
+            "adversarial_diff" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$diff_content")
+        _pqc_mem=$(_redact_paths_outside_scope "$adv_memory" "$_pqc_scope_allowlist" \
+            "adversarial_memory" "${COMPOUND_QUALITY_CYCLE:-0}" 2>/dev/null || printf '%s' "$adv_memory")
+    fi
+
     local prompt="You are a hostile code reviewer. Your job is to find EVERY possible issue in this diff.
 Look for:
 - Bugs (logic errors, off-by-one, null/undefined access, race conditions)
@@ -808,13 +822,13 @@ Look for:
 
 Be thorough and adversarial. List every issue with severity [Critical/Bug/Warning].
 Format: **[Severity]** file:line — description
-${adv_memory:+
+${_pqc_mem:+
 ## Known Security Issues from Previous Reviews
 These security issues have been found in past reviews. Check if any recur:
-${adv_memory}
+${_pqc_mem}
 }
 Diff:
-$diff_content"
+$_pqc_diff"
 
     local review_output
     review_output=$(_pipeline_quality_ai_text "$prompt" "haiku" "8")

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -421,6 +421,20 @@ ${_build_recall_ctx}"
         fi
     fi
 
+    # Seam (c): redact out-of-scope paths from build_context_body before writing to disk.
+    # Memory-context and historical recall may reference paths from previous pipeline runs
+    # in different scopes; strip them now so the loop agent never sees them.
+    if declare -f _redact_paths_outside_scope >/dev/null 2>&1 && \
+       declare -f _extract_scope_from_design >/dev/null 2>&1; then
+        local _bld_scope_allowlist=""
+        _bld_scope_allowlist=$(_extract_scope_from_design "$ARTIFACTS_DIR" 2>/dev/null || true)
+        if [ -n "$_bld_scope_allowlist" ]; then
+            build_context_body=$(_redact_paths_outside_scope "$build_context_body" \
+                "$_bld_scope_allowlist" "build_context" "${COMPOUND_QUALITY_CYCLE:-0}" \
+                2>/dev/null || printf '%s' "$build_context_body")
+        fi
+    fi
+
     # Layer A: Write synthesized context to sidecar (atomic write)
     local _ctx_file="${ARTIFACTS_DIR}/build-context.md"
     local _ctx_tmp="${_ctx_file}.tmp.$$"

--- a/scripts/lib/pipeline-stages-intake.sh
+++ b/scripts/lib/pipeline-stages-intake.sh
@@ -1144,6 +1144,22 @@ Produce this EXACT format:
 - [ ] [How we'll know the design is correct — testable criteria]
 - [ ] [Additional validation items]
 
+## Scope (REQUIRED — machine-parsed by the build pipeline)
+Include this section EXACTLY — the build loop reads the fenced block to enforce file boundaries.
+
+\`\`\`scope
+scripts/lib/example.sh
+scripts/lib/another.sh
+src/components/
+\`\`\`
+
+List EVERY file or directory the implementation will touch, one entry per line.
+- Exact file paths (e.g. \`scripts/lib/helpers.sh\`) or directory prefixes ending in \`/\` (e.g. \`src/\`)
+- Globs are supported: \`**/*.ts\` matches all TypeScript files recursively
+- Only list files in THIS repo — no external deps
+- The build agent will NOT edit files outside this list; if a change genuinely requires
+  an unlisted file, it will emit \`<<<LOOP:SCOPE_ESCALATION:reason>>>\` to pause for human review.
+
 Be concrete and specific. Reference actual file paths in the codebase. Consider edge cases and failure modes."
 
     # Inject skill prompts for design stage
@@ -1270,6 +1286,41 @@ $(printf '%s\n' "${INTELLIGENCE_INTAKE_CTX}")"
         return 1
     fi
     info "Design saved: ${DIM}$design_file${RESET} (${line_count} lines)"
+
+    # Enforce scope-fence policy (require_scope_fence: warn|error|off; default: warn).
+    # warn (default): log a notice and proceed — zero behaviour change for existing repos.
+    # error: exit non-zero with a message; operator must add a scope fence or set warn/off.
+    # off:  skip the check entirely (legacy issue replay).
+    local _sfence_mode="warn"
+    if [[ -s "${PIPELINE_CONFIG:-}" ]]; then
+        local _sfence_cfg
+        _sfence_cfg=$(jq -r '.require_scope_fence // "warn"' "${PIPELINE_CONFIG}" 2>/dev/null || echo "warn")
+        [[ "$_sfence_cfg" == "error" || "$_sfence_cfg" == "off" ]] && _sfence_mode="$_sfence_cfg"
+    fi
+
+    if [[ "$_sfence_mode" != "off" ]]; then
+        local _scope_fence_lines=""
+        if declare -f _extract_scope_from_design >/dev/null 2>&1; then
+            _scope_fence_lines=$(_extract_scope_from_design "$ARTIFACTS_DIR" 2>/dev/null || true)
+        fi
+
+        if [[ -z "$_scope_fence_lines" ]]; then
+            if [[ "$_sfence_mode" == "error" ]]; then
+                error "design.md is missing required \`scope\` fence — set require_scope_fence: warn or off in pipeline config to disable enforcement"
+                return 1
+            else
+                warn "design.md has no \`\`\`scope block — scope-redaction inactive for this issue (set require_scope_fence: error to enforce)"
+                emit_event "pipeline.scope_manifest_missing" \
+                    "stage=design" "issue=${ISSUE_NUMBER:-0}" 2>/dev/null || true
+            fi
+        else
+            local _fence_file_count
+            _fence_file_count=$(printf '%s\n' "$_scope_fence_lines" | grep -c '[^[:space:]]' 2>/dev/null || echo "0")
+            emit_event "pipeline.scope_manifest_loaded" \
+                "stage=design" "issue=${ISSUE_NUMBER:-0}" "file_count=${_fence_file_count}" 2>/dev/null || true
+            info "Scope fence loaded: ${_fence_file_count} entries — path redaction active"
+        fi
+    fi
 
     # Persist design (and plan, if present) to issue-scoped snapshot.
     if [[ -n "${ISSUE_NUMBER:-}" ]]; then

--- a/scripts/lib/pipeline-stages-review.sh
+++ b/scripts/lib/pipeline-stages-review.sh
@@ -353,9 +353,23 @@ Reviewer: Verify whether these files were intentionally skipped or represent inc
         emit_event "review.drift_detected" "issue=${ISSUE_NUMBER:-0}" || true
     fi
 
+    # Seam (e): redact out-of-scope paths from diff content before injecting into review prompt.
+    local _rev_diff_content
+    _rev_diff_content=$(cat "$diff_file" 2>/dev/null || true)
+    if declare -f _redact_paths_outside_scope >/dev/null 2>&1 && \
+       declare -f _extract_scope_from_design >/dev/null 2>&1; then
+        local _rev_scope_allowlist=""
+        _rev_scope_allowlist=$(_extract_scope_from_design "$ARTIFACTS_DIR" 2>/dev/null || true)
+        if [ -n "$_rev_scope_allowlist" ]; then
+            _rev_diff_content=$(_redact_paths_outside_scope "$_rev_diff_content" \
+                "$_rev_scope_allowlist" "review_diff" "${COMPOUND_QUALITY_CYCLE:-0}" \
+                2>/dev/null || cat "$diff_file")
+        fi
+    fi
+
     review_prompt+="
 ## Diff to Review
-$(cat "$diff_file")"
+${_rev_diff_content}"
 
     # Inject skill prompts for review stage
     _skill_prompts=""

--- a/scripts/sw-lib-helpers-test.sh
+++ b/scripts/sw-lib-helpers-test.sh
@@ -315,4 +315,110 @@ assert_eq "_trim handles empty string" "" "$(_trim "")"
 assert_eq "_trim handles single quotes" "it's a test" "$(_trim "  it's a test  ")"
 assert_eq "_trim handles tabs" "hello" "$(_trim "	hello	")"
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# _file_in_scope
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "_file_in_scope"
+
+# Empty allowlist → fail-open (return 0)
+_file_in_scope "scripts/lib/helpers.sh" "" && assert_pass "_file_in_scope: empty allowlist returns 0 (fail-open)" \
+    || assert_fail "_file_in_scope: empty allowlist returns 0 (fail-open)" ""
+
+# Literal match
+_file_in_scope "scripts/lib/helpers.sh" "scripts/lib/helpers.sh" && assert_pass "_file_in_scope: literal exact match" \
+    || assert_fail "_file_in_scope: literal exact match" ""
+
+# Literal non-match
+_file_in_scope ".claude/helpers/foo.cjs" "scripts/lib/helpers.sh" && assert_fail "_file_in_scope: literal non-match should return 1" "" \
+    || assert_pass "_file_in_scope: literal non-match returns 1"
+
+# Directory prefix (trailing /)
+_file_in_scope "scripts/lib/helpers.sh" "scripts/lib/" && assert_pass "_file_in_scope: directory prefix match" \
+    || assert_fail "_file_in_scope: directory prefix match" ""
+
+_file_in_scope ".claude/helpers/foo.cjs" "scripts/lib/" && assert_fail "_file_in_scope: directory prefix non-match should return 1" "" \
+    || assert_pass "_file_in_scope: directory prefix non-match returns 1"
+
+# Single-star glob
+_file_in_scope "scripts/lib/helpers.sh" "scripts/lib/*.sh" && assert_pass "_file_in_scope: single-star glob match" \
+    || assert_fail "_file_in_scope: single-star glob match" ""
+
+_file_in_scope "scripts/lib/sub/helpers.sh" "scripts/lib/*.sh" && assert_fail "_file_in_scope: single-star does not cross dirs" "" \
+    || assert_pass "_file_in_scope: single-star does not cross dirs"
+
+# Double-star glob (**) — matches across directories
+_file_in_scope "scripts/lib/sub/helpers.sh" "scripts/**" && assert_pass "_file_in_scope: double-star matches subdirs" \
+    || assert_fail "_file_in_scope: double-star matches subdirs" ""
+
+_file_in_scope ".claude/helpers/foo.cjs" "scripts/**" && assert_fail "_file_in_scope: double-star non-match returns 1" "" \
+    || assert_pass "_file_in_scope: double-star non-match returns 1"
+
+# Comment lines are ignored
+_file_in_scope "scripts/lib/helpers.sh" "# this is a comment
+scripts/lib/helpers.sh" && assert_pass "_file_in_scope: comment lines are skipped" \
+    || assert_fail "_file_in_scope: comment lines are skipped" ""
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _redact_paths_outside_scope
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "_redact_paths_outside_scope"
+
+# Pass-through when allowlist is empty
+_rps_out=$(_redact_paths_outside_scope "some text with scripts/lib/helpers.sh:42" "")
+assert_eq "_redact_paths_outside_scope: empty allowlist pass-through" \
+    "some text with scripts/lib/helpers.sh:42" "$_rps_out"
+
+# In-scope path is NOT redacted
+_rps_out=$(_redact_paths_outside_scope "fix scripts/lib/helpers.sh:42" "scripts/lib/helpers.sh" "test" "0")
+assert_eq "_redact_paths_outside_scope: in-scope path not redacted" \
+    "fix scripts/lib/helpers.sh:42" "$_rps_out"
+
+# Out-of-scope path IS redacted
+_rps_out=$(_redact_paths_outside_scope "found .claude/helpers/foo.cjs:88" "scripts/lib/helpers.sh" "test" "0")
+if echo "$_rps_out" | grep -qF ".claude/helpers/foo.cjs"; then
+    assert_fail "_redact_paths_outside_scope: OOS path removed" "path still visible in output: $_rps_out"
+else
+    assert_pass "_redact_paths_outside_scope: OOS path removed"
+fi
+assert_contains "_redact_paths_outside_scope: sentinel present" "$_rps_out" "[redacted:out-of-scope:TOKEN-1]"
+
+# URL is NOT redacted (negative filter)
+_rps_url_out=$(_redact_paths_outside_scope "see https://example.com/foo.js for details" "scripts/" "test" "0")
+assert_contains "_redact_paths_outside_scope: URL not redacted" "$_rps_url_out" "https://example.com/foo.js"
+
+# Version string is NOT redacted (negative filter — starts with digit)
+_rps_ver_out=$(_redact_paths_outside_scope "requires node 18.1.0 or newer" "scripts/" "test" "0")
+assert_contains "_redact_paths_outside_scope: version not redacted" "$_rps_ver_out" "18.1.0"
+
+# Code fence block is preserved verbatim
+_rps_fence_in=$'## diff\n```\nscripts/lib/helpers.sh:42\n```\nafter fence'
+_rps_fence_out=$(_redact_paths_outside_scope "$_rps_fence_in" "nothing/" "test" "0")
+assert_contains "_redact_paths_outside_scope: code fence preserved verbatim" \
+    "$_rps_fence_out" "scripts/lib/helpers.sh:42"
+
+# <out-of-scope-context> block preserved verbatim
+_rps_oos_in=$'line before\n<out-of-scope-context>\n.claude/helpers/foo.cjs:10\n</out-of-scope-context>\nline after'
+_rps_oos_out=$(_redact_paths_outside_scope "$_rps_oos_in" "scripts/lib/" "test" "0")
+assert_contains "_redact_paths_outside_scope: out-of-scope-context block preserved" \
+    "$_rps_oos_out" ".claude/helpers/foo.cjs:10"
+
+# Idempotency: running redaction twice produces no further changes
+_rps_once=$(_redact_paths_outside_scope "fixed .claude/helpers/bar.cjs:5" "scripts/" "test" "0")
+_rps_twice=$(_redact_paths_outside_scope "$_rps_once" "scripts/" "test" "0")
+assert_eq "_redact_paths_outside_scope: idempotent (second pass no-op)" "$_rps_once" "$_rps_twice"
+
+# Sidecar manifest is written when allowlist non-empty and OOS token found
+_rps_sidecar_dir=$(mktemp -d)
+ARTIFACTS_DIR="$_rps_sidecar_dir" _redact_paths_outside_scope \
+    "found .claude/helpers/baz.cjs" "scripts/lib/" "test_seam" "5" >/dev/null
+if [[ -f "${_rps_sidecar_dir}/oos-redactions-cycle-5.json" ]]; then
+    assert_pass "_redact_paths_outside_scope: sidecar manifest written"
+    _sidecar_content=$(cat "${_rps_sidecar_dir}/oos-redactions-cycle-5.json")
+    assert_contains "_redact_paths_outside_scope: sidecar contains original path" \
+        "$_sidecar_content" ".claude/helpers/baz.cjs"
+else
+    assert_fail "_redact_paths_outside_scope: sidecar manifest written" "file not found"
+fi
+rm -rf "$_rps_sidecar_dir"
+
 print_test_results

--- a/scripts/sw-lib-helpers-test.sh
+++ b/scripts/sw-lib-helpers-test.sh
@@ -353,6 +353,13 @@ _file_in_scope "scripts/lib/sub/helpers.sh" "scripts/**" && assert_pass "_file_i
 _file_in_scope ".claude/helpers/foo.cjs" "scripts/**" && assert_fail "_file_in_scope: double-star non-match returns 1" "" \
     || assert_pass "_file_in_scope: double-star non-match returns 1"
 
+# Double-star with suffix (e.g. **/*.ts) — must NOT fail-open
+_file_in_scope "scripts/lib/helpers.sh" "**/*.ts" && assert_fail "_file_in_scope: **/*.ts does not match non-.ts file" "" \
+    || assert_pass "_file_in_scope: **/*.ts does not match non-.ts file"
+
+_file_in_scope "src/components/Button.ts" "**/*.ts" && assert_pass "_file_in_scope: **/*.ts matches .ts file anywhere" \
+    || assert_fail "_file_in_scope: **/*.ts matches .ts file anywhere" ""
+
 # Comment lines are ignored
 _file_in_scope "scripts/lib/helpers.sh" "# this is a comment
 scripts/lib/helpers.sh" && assert_pass "_file_in_scope: comment lines are skipped" \
@@ -408,7 +415,7 @@ _rps_twice=$(_redact_paths_outside_scope "$_rps_once" "scripts/" "test" "0")
 assert_eq "_redact_paths_outside_scope: idempotent (second pass no-op)" "$_rps_once" "$_rps_twice"
 
 # Sidecar manifest is written when allowlist non-empty and OOS token found
-_rps_sidecar_dir=$(mktemp -d)
+_rps_sidecar_dir=$(mktemp -d "${TMPDIR:-/tmp}/sw-rps-sidecar.XXXXXX")
 ARTIFACTS_DIR="$_rps_sidecar_dir" _redact_paths_outside_scope \
     "found .claude/helpers/baz.cjs" "scripts/lib/" "test_seam" "5" >/dev/null
 if [[ -f "${_rps_sidecar_dir}/oos-redactions-cycle-5.json" ]]; then
@@ -420,5 +427,13 @@ else
     assert_fail "_redact_paths_outside_scope: sidecar manifest written" "file not found"
 fi
 rm -rf "$_rps_sidecar_dir"
+
+# Extensionless path with slash component is detected and redacted when OOS
+_rps_out=$(_redact_paths_outside_scope "check scripts/sw for issues" "scripts/lib/" "test" "0")
+if echo "$_rps_out" | grep -qF "scripts/sw"; then
+    assert_fail "_redact_paths_outside_scope: extensionless slashed path redacted" "path still visible: $_rps_out"
+else
+    assert_pass "_redact_paths_outside_scope: extensionless slashed path redacted"
+fi
 
 print_test_results


### PR DESCRIPTION
## Summary

Implements the architectural invariant established after 3 planning sessions and 11 ruflo specialist agent analysis passes:

> **No file path token in any agent prompt may name a file outside the design.md ` ```scope ` allow-list** — except inside an explicitly-tagged `<out-of-scope-context>` block.

This PR codifies the invariant at **prompt-construction time** (preventive), complementing the existing `safe_git_stage` detective guard. When the scope allowlist is empty (no `scope` fence in design.md), all seams pass through unchanged — zero behaviour change for existing repos.

## Core primitives (`scripts/lib/helpers.sh`)

- **`_file_in_scope`**: Bash 3.2-compatible allowlist membership test — handles literal paths, directory prefixes (`dir/`), single-star globs (dir-bounded, star doesn't cross `/`), and double-star globs (recursive). Fail-open on empty allowlist.
- **`_redact_paths_outside_scope`**: Per-line tokenizer pipeline:
  - Strips URLs before tokenizing (prevents hostname false positives)
  - Respects ` ``` ` code-fence blocks and `<out-of-scope-context>` escape markers (verbatim pass-through)
  - Applies negative filters: absolute paths, URLs, version strings, lang-prefixed tokens
  - Replaces OOS tokens with `[redacted:out-of-scope:TOKEN-N]` sentinels (idempotent)
  - Writes per-redaction audit records to `.claude/pipeline-artifacts/oos-redactions-cycle-N.json`
  - Emits `pipeline.prompt_path_redacted` telemetry

## 6 prompt-construction seams wrapped

| Seam | File | What it wraps |
|------|------|---------------|
| a (upstream) | `compound-audit.sh` | diff, prev_findings, file_contents before audit-prompt |
| b | `pipeline-quality-checks.sh` | adversarial diff + adv_memory |
| c | `pipeline-stages-build.sh` | build_context_body before sidecar write |
| d (attractor) | `pipeline-intelligence.sh` | blocking_items + feedback_content before GOAL injection |
| e | `pipeline-stages-review.sh` | diff file content at review prompt |
| f (final gate) | `loop-iteration.sh` | assembled compose_prompt before agent |

## Phase 0: scope fence config (`pipeline-stages-intake.sh`)

- Design stage prompt updated to instruct the agent to produce a ` ```scope ` block with format example
- `require_scope_fence: warn|error|off` config (default `warn` — zero behaviour change for repos without a fence)
- Emits `pipeline.scope_manifest_missing` / `pipeline.scope_manifest_loaded` events

## Why redaction, not partition

Partition fails: `blocking_items` appears one line below `"BLOCKING ISSUES — fix all of these before merge:"` AND again inside `feedback_content` under `"## Blocking Issues (must fix before merge)"`. A `"DO NOT EDIT"` label nested between two "fix" directives is a known LLM instruction-following failure class. Multi-file findings (one in-scope + one OOS path in the same finding text) cannot be partitioned at all.

Redaction breaks the invariant at the token level: if the path string isn't in the prompt, the agent cannot open/edit the file by name. The sidecar manifest preserves the audit trail.

## Test plan

- [ ] `bash scripts/sw-lib-helpers-test.sh` — 75/75 (11 `_file_in_scope` + 13 `_redact_paths_outside_scope` cases)
- [ ] `bash scripts/sw-lib-pipeline-intelligence-test.sh` — 125/125
- [ ] `bash scripts/sw-lib-compound-audit-test.sh` — 89/89
- [ ] `bash scripts/sw-lib-pipeline-quality-checks-test.sh` — 66/66
- [ ] `bash scripts/sw-lib-pipeline-stages-test.sh` — 153/153
- [ ] `bash scripts/sw-postmortem-460-test.sh` — 72/72
- [ ] `npm test` — full suite green

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)