### PR TITLE
feat(telemetry): scope manifest events, escalation detection, drift report

### DIFF
--- a/scripts/lib/pipeline-stages.sh
+++ b/scripts/lib/pipeline-stages.sh
@@ -58,7 +58,8 @@ _extract_scope_from_design() {
                 "issue=${ISSUE_NUMBER:-0}" 2>/dev/null || true
     else
         local _file_count
-        _file_count=$(printf '%s\n' "$_scope_out" | grep -c . 2>/dev/null || echo 0)
+        _file_count=$(printf '%s\n' "$_scope_out" | grep -c . 2>/dev/null || true)
+        _file_count=${_file_count:-0}
         declare -f emit_event >/dev/null 2>&1 && \
             emit_event "pipeline.scope_manifest_loaded" \
                 "stage=${PIPELINE_STAGE:-unknown}" \

--- a/scripts/lib/pipeline-stages.sh
+++ b/scripts/lib/pipeline-stages.sh
@@ -46,9 +46,27 @@ _extract_scope_from_design() {
     [[ -f "$design_file" ]] || design_file="${artifacts_dir}/design.md"
     [[ -f "$design_file" ]] || return 0
 
-    awk '/^```scope[[:space:]]*$/{found=1; next} found && /^```/{exit} found{print}' \
+    local _scope_out
+    _scope_out=$(awk '/^```scope[[:space:]]*$/{found=1; next} found && /^```/{exit} found{print}' \
         "$design_file" 2>/dev/null \
-        | grep -v '^[[:space:]]*$' || true
+        | grep -v '^[[:space:]]*$' || true)
+
+    if [ -z "$_scope_out" ]; then
+        declare -f emit_event >/dev/null 2>&1 && \
+            emit_event "pipeline.scope_manifest_missing" \
+                "stage=${PIPELINE_STAGE:-unknown}" \
+                "issue=${ISSUE_NUMBER:-0}" 2>/dev/null || true
+    else
+        local _file_count
+        _file_count=$(printf '%s\n' "$_scope_out" | grep -c . 2>/dev/null || echo 0)
+        declare -f emit_event >/dev/null 2>&1 && \
+            emit_event "pipeline.scope_manifest_loaded" \
+                "stage=${PIPELINE_STAGE:-unknown}" \
+                "issue=${ISSUE_NUMBER:-0}" \
+                "file_count=${_file_count}" 2>/dev/null || true
+    fi
+
+    printf '%s\n' "$_scope_out"
 }
 
 # _compute_scope_violations — Compare changed_files against scope_allowlist.

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -3279,7 +3279,7 @@ ${GOAL}"
         if grep -q '<<<LOOP:SCOPE_ESCALATION:' "$log_file" 2>/dev/null; then
             local _esc_reason
             _esc_reason=$(grep -o '<<<LOOP:SCOPE_ESCALATION:[^>]*>>>' "$log_file" 2>/dev/null \
-                | head -1 | sed 's/<<<LOOP:SCOPE_ESCALATION:\(.*\)>>>/\1/')
+                | head -1 | sed 's/<<<LOOP:SCOPE_ESCALATION:\(.*\)>>>/\1/' || true)
             type emit_event >/dev/null 2>&1 && emit_event "pipeline.scope_escalation" \
                 "iteration=$ITERATION" \
                 "reason=${_esc_reason:-unspecified}" \

--- a/scripts/sw-loop.sh
+++ b/scripts/sw-loop.sh
@@ -3275,6 +3275,18 @@ ${GOAL}"
         # Record iteration data for stuckness detection (diff hash, error hash, exit code)
         record_iteration_stuckness_data "$exit_code"
 
+        # Detect <<<LOOP:SCOPE_ESCALATION:reason>>> signal — agent is flagging a new-scope need
+        if grep -q '<<<LOOP:SCOPE_ESCALATION:' "$log_file" 2>/dev/null; then
+            local _esc_reason
+            _esc_reason=$(grep -o '<<<LOOP:SCOPE_ESCALATION:[^>]*>>>' "$log_file" 2>/dev/null \
+                | head -1 | sed 's/<<<LOOP:SCOPE_ESCALATION:\(.*\)>>>/\1/')
+            type emit_event >/dev/null 2>&1 && emit_event "pipeline.scope_escalation" \
+                "iteration=$ITERATION" \
+                "reason=${_esc_reason:-unspecified}" \
+                "job_id=${PIPELINE_JOB_ID:-loop-$$}" 2>/dev/null || true
+            warn "Agent signaled scope escalation (iteration $ITERATION): ${_esc_reason:-unspecified}"
+        fi
+
         # Detect fatal CLI errors (API key, auth, network, session/usage limits) — abort immediately
         if check_fatal_error "$log_file" "$exit_code" "$_err_file"; then
             STATUS="error"

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -4221,6 +4221,64 @@ pipeline_show() {
     echo ""
 }
 
+# ─── Drift Report ───────────────────────────────────────────────────────────
+
+pipeline_drift_report() {
+    local events_file="${HOME}/.shipwright/events.jsonl"
+    if [[ ! -f "$events_file" ]]; then
+        warn "No events log found at $events_file — run a pipeline first."
+        return 0
+    fi
+
+    echo ""
+    echo -e "${PURPLE}${BOLD}━━━ Scope Drift Report ━━━${RESET}"
+    echo ""
+
+    # Scope manifest adoption
+    local missing_count loaded_count
+    missing_count=$(grep -c '"pipeline.scope_manifest_missing"' "$events_file" 2>/dev/null || echo 0)
+    loaded_count=$(grep -c '"pipeline.scope_manifest_loaded"' "$events_file" 2>/dev/null || echo 0)
+    echo -e "${BOLD}  Scope fence adoption:${RESET}"
+    echo -e "    Stages with fence:    ${GREEN}${loaded_count}${RESET}"
+    echo -e "    Stages without fence: ${YELLOW}${missing_count}${RESET}"
+    echo ""
+
+    # Path redactions
+    local redacted_count
+    redacted_count=$(grep -c '"pipeline.prompt_path_redacted"' "$events_file" 2>/dev/null || echo 0)
+    echo -e "${BOLD}  Out-of-scope path redactions:${RESET}"
+    echo -e "    Total redacted: ${redacted_count}"
+    if [[ "$redacted_count" -gt 0 ]] && command -v jq >/dev/null 2>&1; then
+        echo -e "    By seam:"
+        grep '"pipeline.prompt_path_redacted"' "$events_file" 2>/dev/null \
+            | jq -r '.prompt_section // .seam // "unknown"' 2>/dev/null \
+            | sort | uniq -c | sort -rn \
+            | awk '{printf "      %-40s %s\n", $2, $1}' || true
+    fi
+    echo ""
+
+    # Staging violations (pre-existing)
+    local violation_count
+    violation_count=$(grep -c '"loop.scope_violation"' "$events_file" 2>/dev/null || echo 0)
+    echo -e "${BOLD}  Staging violations (loop.scope_violation):${RESET}"
+    echo -e "    Total: ${violation_count}"
+    echo ""
+
+    # Scope escalations
+    local escalation_count
+    escalation_count=$(grep -c '"pipeline.scope_escalation"' "$events_file" 2>/dev/null || echo 0)
+    echo -e "${BOLD}  Scope escalations (agent requested scope expansion):${RESET}"
+    echo -e "    Total: ${escalation_count}"
+    if [[ "$escalation_count" -gt 0 ]] && command -v jq >/dev/null 2>&1; then
+        echo -e "    Reasons:"
+        grep '"pipeline.scope_escalation"' "$events_file" 2>/dev/null \
+            | jq -r '.reason // "unspecified"' 2>/dev/null \
+            | sort | uniq -c | sort -rn \
+            | awk '{printf "      %-60s %s\n", $2, $1}' || true
+    fi
+    echo ""
+}
+
 # ─── Main ───────────────────────────────────────────────────────────────────
 
 case "$SUBCOMMAND" in
@@ -4230,6 +4288,7 @@ case "$SUBCOMMAND" in
     abort)          pipeline_abort ;;
     list)           pipeline_list ;;
     show)           pipeline_show ;;
+    drift)          pipeline_drift_report ;;
     test)
         SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
         exec "$SCRIPT_DIR/sw-pipeline-test.sh" "$@"

--- a/scripts/sw-pipeline.sh
+++ b/scripts/sw-pipeline.sh
@@ -558,6 +558,7 @@ show_help() {
     echo -e "  ${CYAN}abort${RESET}                   Stop pipeline and mark aborted"
     echo -e "  ${CYAN}list${RESET}                    Show available pipeline templates"
     echo -e "  ${CYAN}show${RESET}    <name>          Display pipeline stages"
+    echo -e "  ${CYAN}drift${RESET}                   Show scope drift report (redactions, violations, escalations)"
     echo ""
     echo -e "${BOLD}START OPTIONS${RESET}"
     echo -e "  ${DIM}--goal \"description\"${RESET}     What to build (required unless --issue)"
@@ -4224,7 +4225,7 @@ pipeline_show() {
 # ─── Drift Report ───────────────────────────────────────────────────────────
 
 pipeline_drift_report() {
-    local events_file="${HOME}/.shipwright/events.jsonl"
+    local events_file="${EVENTS_FILE:-${HOME}/.shipwright/events.jsonl}"
     if [[ ! -f "$events_file" ]]; then
         warn "No events log found at $events_file — run a pipeline first."
         return 0
@@ -4236,8 +4237,10 @@ pipeline_drift_report() {
 
     # Scope manifest adoption
     local missing_count loaded_count
-    missing_count=$(grep -c '"pipeline.scope_manifest_missing"' "$events_file" 2>/dev/null || echo 0)
-    loaded_count=$(grep -c '"pipeline.scope_manifest_loaded"' "$events_file" 2>/dev/null || echo 0)
+    missing_count=$(grep -c '"pipeline.scope_manifest_missing"' "$events_file" 2>/dev/null || true)
+    missing_count=${missing_count:-0}
+    loaded_count=$(grep -c '"pipeline.scope_manifest_loaded"' "$events_file" 2>/dev/null || true)
+    loaded_count=${loaded_count:-0}
     echo -e "${BOLD}  Scope fence adoption:${RESET}"
     echo -e "    Stages with fence:    ${GREEN}${loaded_count}${RESET}"
     echo -e "    Stages without fence: ${YELLOW}${missing_count}${RESET}"
@@ -4245,7 +4248,8 @@ pipeline_drift_report() {
 
     # Path redactions
     local redacted_count
-    redacted_count=$(grep -c '"pipeline.prompt_path_redacted"' "$events_file" 2>/dev/null || echo 0)
+    redacted_count=$(grep -c '"pipeline.prompt_path_redacted"' "$events_file" 2>/dev/null || true)
+    redacted_count=${redacted_count:-0}
     echo -e "${BOLD}  Out-of-scope path redactions:${RESET}"
     echo -e "    Total redacted: ${redacted_count}"
     if [[ "$redacted_count" -gt 0 ]] && command -v jq >/dev/null 2>&1; then
@@ -4253,20 +4257,22 @@ pipeline_drift_report() {
         grep '"pipeline.prompt_path_redacted"' "$events_file" 2>/dev/null \
             | jq -r '.prompt_section // .seam // "unknown"' 2>/dev/null \
             | sort | uniq -c | sort -rn \
-            | awk '{printf "      %-40s %s\n", $2, $1}' || true
+            | awk '{count=$1; $1=""; sub(/^ /,""); printf "      %-40s %s\n", $0, count}' || true
     fi
     echo ""
 
     # Staging violations (pre-existing)
     local violation_count
-    violation_count=$(grep -c '"loop.scope_violation"' "$events_file" 2>/dev/null || echo 0)
+    violation_count=$(grep -c '"loop.scope_violation"' "$events_file" 2>/dev/null || true)
+    violation_count=${violation_count:-0}
     echo -e "${BOLD}  Staging violations (loop.scope_violation):${RESET}"
     echo -e "    Total: ${violation_count}"
     echo ""
 
     # Scope escalations
     local escalation_count
-    escalation_count=$(grep -c '"pipeline.scope_escalation"' "$events_file" 2>/dev/null || echo 0)
+    escalation_count=$(grep -c '"pipeline.scope_escalation"' "$events_file" 2>/dev/null || true)
+    escalation_count=${escalation_count:-0}
     echo -e "${BOLD}  Scope escalations (agent requested scope expansion):${RESET}"
     echo -e "    Total: ${escalation_count}"
     if [[ "$escalation_count" -gt 0 ]] && command -v jq >/dev/null 2>&1; then
@@ -4274,7 +4280,7 @@ pipeline_drift_report() {
         grep '"pipeline.scope_escalation"' "$events_file" 2>/dev/null \
             | jq -r '.reason // "unspecified"' 2>/dev/null \
             | sort | uniq -c | sort -rn \
-            | awk '{printf "      %-60s %s\n", $2, $1}' || true
+            | awk '{count=$1; $1=""; sub(/^ /,""); printf "      %-60s %s\n", $0, count}' || true
     fi
     echo ""
 }


### PR DESCRIPTION
## Summary

- Adds `pipeline.scope_manifest_missing` and `pipeline.scope_manifest_loaded` events to `_extract_scope_from_design` so operators can track fence adoption per stage/issue
- Adds `<<<LOOP:SCOPE_ESCALATION:reason>>>` signal detection in the main build loop with `pipeline.scope_escalation` event emission
- Adds `shipwright pipeline drift` subcommand summarising all scope-related events from `events.jsonl` (fence adoption, path redactions by seam, staging violations, escalations with reason breakdown)

Depends on PR #631 (scope-redaction invariant) for the `pipeline.prompt_path_redacted` events to appear in the drift report.

## Test plan

- [ ] `bash -n scripts/lib/pipeline-stages.sh` — syntax clean
- [ ] `bash -n scripts/sw-loop.sh` — syntax clean
- [ ] `bash -n scripts/sw-pipeline.sh` — syntax clean
- [ ] `bash scripts/sw-lib-helpers-test.sh` — 75/75 pass
- [ ] `bash scripts/sw-lib-pipeline-intelligence-test.sh` — 125/125 pass
- [ ] `shipwright pipeline drift` — prints report (empty counts are fine when no events present)
- [ ] After a pipeline run with a design.md scope fence: `events.jsonl` contains `pipeline.scope_manifest_loaded`
- [ ] After a pipeline run without a scope fence: `events.jsonl` contains `pipeline.scope_manifest_missing`

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)