### PR TITLE
feat(ci): pipeline-smoke gate for machinery PRs (closes #606)

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -1,0 +1,60 @@
+name: Pipeline Machinery Smoke
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/lib/pipeline-*.sh'
+      - 'scripts/sw-pipeline.sh'
+      - 'scripts/sw-loop.sh'
+      - 'scripts/lib/helpers.sh'
+      - '.claude/helpers/**'
+
+jobs:
+  scope-smoke:
+    name: scope-smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jq
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Scope-redaction helpers present
+        run: bash scripts/sw-pipeline-test.sh test_scope_redaction_helpers_present
+
+      - name: In-scope path not redacted
+        run: bash scripts/sw-pipeline-test.sh test_scope_redaction_in_scope_no_redaction
+
+      - name: Out-of-scope path triggers redaction
+        run: bash scripts/sw-pipeline-test.sh test_scope_redaction_oos_event_fires
+
+      - name: Drift subcommand wired
+        run: bash scripts/sw-pipeline-test.sh test_scope_drift_subcommand_present
+
+      - name: SCOPE_ESCALATION detection in sw-loop.sh
+        run: bash scripts/sw-pipeline-test.sh test_scope_escalation_detection_in_loop
+
+      - name: scope_manifest events in _extract_scope_from_design
+        run: bash scripts/sw-pipeline-test.sh test_scope_manifest_events_in_extract
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## Pipeline Machinery Scope-Redaction Smoke (${{ matrix.os }})" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ job.status }}" = "success" ]; then
+            echo "✅ All scope-redaction smoke assertions passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ Scope-redaction smoke failed — check steps above" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/scripts/sw-lib-pipeline-stages-test.sh
+++ b/scripts/sw-lib-pipeline-stages-test.sh
@@ -2310,7 +2310,7 @@ if [[ -f "$_psb_source" ]]; then
 
     # The outer compound guard must be gone — the opening 'if' line must NOT combine
     # type-check and commit_count on one line (old: if type X && [[ commit_count -gt 0 ]]).
-    if echo "$_store_block" | grep -q 'type ruflo_store_issue_outcome.*commit_count' 2>/dev/null; then
+    if grep -q 'type ruflo_store_issue_outcome.*commit_count' <<< "$_store_block" 2>/dev/null; then
         assert_fail \
             "build outcome store: outer commit_count > 0 guard is absent (block runs unconditionally)" \
             "Found combined type+commit_count guard — outer guard must be split (commit_count moved inside)"
@@ -2320,7 +2320,7 @@ if [[ -f "$_psb_source" ]]; then
     fi
 
     # _build_status variable must be set inside the block.
-    if echo "$_store_block" | grep -q '_build_status' 2>/dev/null; then
+    if grep -q '_build_status' <<< "$_store_block" 2>/dev/null; then
         assert_pass "build outcome store: _build_status variable is present in store block"
     else
         assert_fail "build outcome store: _build_status variable is present in store block" \
@@ -2328,7 +2328,7 @@ if [[ -f "$_psb_source" ]]; then
     fi
 
     # _build_key variable must be set inside the block.
-    if echo "$_store_block" | grep -q '_build_key' 2>/dev/null; then
+    if grep -q '_build_key' <<< "$_store_block" 2>/dev/null; then
         assert_pass "build outcome store: _build_key variable is present in store block"
     else
         assert_fail "build outcome store: _build_key variable is present in store block" \
@@ -2336,7 +2336,7 @@ if [[ -f "$_psb_source" ]]; then
     fi
 
     # The literal string "no-commits" must appear to handle the zero-commit path.
-    if echo "$_store_block" | grep -q 'no-commits' 2>/dev/null; then
+    if grep -q 'no-commits' <<< "$_store_block" 2>/dev/null; then
         assert_pass "build outcome store: 'no-commits' status appears in store block"
     else
         assert_fail "build outcome store: 'no-commits' status appears in store block" \

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -4304,6 +4304,12 @@ main() {
         "test_workflow_workspace_branch_re_export_step_present:PR3: workflow has idempotent WORKSPACE_BRANCH re-export step"
         "test_self_healing_merge_build_test_exists:Merge: self_healing_merge_build_test function exists in sw-pipeline.sh"
         "test_self_healing_merge_build_test_dispatch_wired:Merge: stage loop dispatches self_healing_merge_build_test on merge failure with retry context"
+        "test_scope_redaction_helpers_present:Scope: _file_in_scope and _redact_paths_outside_scope exist in helpers.sh"
+        "test_scope_redaction_in_scope_no_redaction:Scope: in-scope path is not redacted"
+        "test_scope_redaction_oos_event_fires:Scope: out-of-scope path triggers redaction sentinel"
+        "test_scope_drift_subcommand_present:Scope: drift subcommand wired in sw-pipeline.sh"
+        "test_scope_escalation_detection_in_loop:Scope: SCOPE_ESCALATION detection and event emission in sw-loop.sh"
+        "test_scope_manifest_events_in_extract:Scope: scope_manifest_missing/loaded events in _extract_scope_from_design"
     )
 
     for entry in "${tests[@]}"; do
@@ -4609,6 +4615,127 @@ test_workflow_workspace_branch_re_export_step_present() {
     fi
     if ! grep -q 'Re-export workspace branch\|idempotent.*WORKSPACE_BRANCH\|WORKSPACE_BRANCH.*idempotent' "$workflow" 2>/dev/null; then
         echo "FAIL: workflow missing idempotent WORKSPACE_BRANCH re-export step (expected after fix)"
+        return 1
+    fi
+    return 0
+}
+
+# ─── Scope Redaction Smoke Tests (PR-D) ──────────────────────────────────────
+
+test_scope_redaction_helpers_present() {
+    local helpers_sh="$REPO_DIR/scripts/lib/helpers.sh"
+    if [[ ! -f "$helpers_sh" ]]; then
+        echo "SKIP: helpers.sh not found"
+        return 0
+    fi
+    if ! grep -q '_file_in_scope' "$helpers_sh" 2>/dev/null; then
+        echo "SKIP: _file_in_scope not yet merged (depends on PR-B)"
+        return 0
+    fi
+    if ! grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null; then
+        echo "SKIP: _redact_paths_outside_scope not yet merged (depends on PR-B)"
+        return 0
+    fi
+    return 0
+}
+
+test_scope_redaction_in_scope_no_redaction() {
+    # A finding that references only in-scope paths must NOT trigger redaction.
+    local helpers_sh="$REPO_DIR/scripts/lib/helpers.sh"
+    [[ -f "$helpers_sh" ]] || { echo "SKIP: helpers.sh not found"; return 0; }
+    grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null \
+        || { echo "SKIP: _redact_paths_outside_scope not yet merged (depends on PR-B)"; return 0; }
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/scope-smoke-ok.XXXXXX")
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    local allowlist="scripts/lib/helpers.sh"$'\n'"scripts/lib/pipeline-stages.sh"
+    local finding="helpers.sh:42 — _redact_paths_outside_scope called with empty allowlist"
+
+    local redacted
+    redacted=$(
+        COMPOUND_QUALITY_CYCLE=0 \
+        bash -c "
+            source '$helpers_sh' 2>/dev/null
+            _redact_paths_outside_scope $(printf '%q' "$finding") $(printf '%q' "$allowlist") 'smoke_test' '0' 2>/dev/null
+        " 2>/dev/null || echo "$finding"
+    )
+
+    if echo "$redacted" | grep -q '\[redacted:out-of-scope:'; then
+        echo "FAIL: in-scope path was redacted — got: $redacted"
+        return 1
+    fi
+    return 0
+}
+
+test_scope_redaction_oos_event_fires() {
+    # A finding referencing an out-of-scope path must trigger redaction.
+    local helpers_sh="$REPO_DIR/scripts/lib/helpers.sh"
+    [[ -f "$helpers_sh" ]] || { echo "SKIP: helpers.sh not found"; return 0; }
+    grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null \
+        || { echo "SKIP: _redact_paths_outside_scope not yet merged (depends on PR-B)"; return 0; }
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/scope-smoke-oos.XXXXXX")
+    trap 'rm -rf "$tmp_dir"' RETURN
+
+    local allowlist="scripts/lib/helpers.sh"
+    local finding=".claude/helpers/intelligence.cjs:99 — execSync called outside scope"
+
+    local redacted
+    redacted=$(
+        COMPOUND_QUALITY_CYCLE=0 \
+        bash -c "
+            source '$helpers_sh' 2>/dev/null
+            _redact_paths_outside_scope $(printf '%q' "$finding") $(printf '%q' "$allowlist") 'smoke_oos' '0' 2>/dev/null
+        " 2>/dev/null || echo "$finding"
+    )
+
+    if ! echo "$redacted" | grep -q '\[redacted:out-of-scope:'; then
+        echo "FAIL: out-of-scope path was not redacted — got: $redacted"
+        return 1
+    fi
+    return 0
+}
+
+test_scope_drift_subcommand_present() {
+    if ! grep -q 'pipeline_drift_report\|drift)' "$REAL_PIPELINE_SCRIPT" 2>/dev/null; then
+        echo "FAIL: drift subcommand not found in sw-pipeline.sh"
+        return 1
+    fi
+    return 0
+}
+
+test_scope_escalation_detection_in_loop() {
+    local loop_sh="$REPO_DIR/scripts/sw-loop.sh"
+    if [[ ! -f "$loop_sh" ]]; then
+        echo "SKIP: sw-loop.sh not found"
+        return 0
+    fi
+    if ! grep -q 'LOOP:SCOPE_ESCALATION' "$loop_sh" 2>/dev/null; then
+        echo "FAIL: SCOPE_ESCALATION detection not found in sw-loop.sh"
+        return 1
+    fi
+    if ! grep -q 'pipeline.scope_escalation' "$loop_sh" 2>/dev/null; then
+        echo "FAIL: pipeline.scope_escalation event not emitted in sw-loop.sh"
+        return 1
+    fi
+    return 0
+}
+
+test_scope_manifest_events_in_extract() {
+    local stages_sh="$REPO_DIR/scripts/lib/pipeline-stages.sh"
+    if [[ ! -f "$stages_sh" ]]; then
+        echo "SKIP: pipeline-stages.sh not found"
+        return 0
+    fi
+    if ! grep -q 'pipeline.scope_manifest_missing' "$stages_sh" 2>/dev/null; then
+        echo "FAIL: pipeline.scope_manifest_missing not emitted in pipeline-stages.sh"
+        return 1
+    fi
+    if ! grep -q 'pipeline.scope_manifest_loaded' "$stages_sh" 2>/dev/null; then
+        echo "FAIL: pipeline.scope_manifest_loaded not emitted in pipeline-stages.sh"
         return 1
     fi
     return 0

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -4646,10 +4646,6 @@ test_scope_redaction_in_scope_no_redaction() {
     grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null \
         || { echo "SKIP: _redact_paths_outside_scope not yet merged (depends on PR-B)"; return 0; }
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/scope-smoke-ok.XXXXXX")
-    trap 'rm -rf "$tmp_dir"' RETURN
-
     local allowlist="scripts/lib/helpers.sh"$'\n'"scripts/lib/pipeline-stages.sh"
     local finding="scripts/lib/helpers.sh:42 — _redact_paths_outside_scope called with empty allowlist"
 
@@ -4675,10 +4671,6 @@ test_scope_redaction_oos_path_redacted() {
     [[ -f "$helpers_sh" ]] || { echo "SKIP: helpers.sh not found"; return 0; }
     grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null \
         || { echo "SKIP: _redact_paths_outside_scope not yet merged (depends on PR-B)"; return 0; }
-
-    local tmp_dir
-    tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/scope-smoke-oos.XXXXXX")
-    trap 'rm -rf "$tmp_dir"' RETURN
 
     local allowlist="scripts/lib/helpers.sh"
     local finding=".claude/helpers/intelligence.cjs:99 — execSync called outside scope"

--- a/scripts/sw-pipeline-test.sh
+++ b/scripts/sw-pipeline-test.sh
@@ -4306,7 +4306,7 @@ main() {
         "test_self_healing_merge_build_test_dispatch_wired:Merge: stage loop dispatches self_healing_merge_build_test on merge failure with retry context"
         "test_scope_redaction_helpers_present:Scope: _file_in_scope and _redact_paths_outside_scope exist in helpers.sh"
         "test_scope_redaction_in_scope_no_redaction:Scope: in-scope path is not redacted"
-        "test_scope_redaction_oos_event_fires:Scope: out-of-scope path triggers redaction sentinel"
+        "test_scope_redaction_oos_path_redacted:Scope: out-of-scope path triggers redaction sentinel in output"
         "test_scope_drift_subcommand_present:Scope: drift subcommand wired in sw-pipeline.sh"
         "test_scope_escalation_detection_in_loop:Scope: SCOPE_ESCALATION detection and event emission in sw-loop.sh"
         "test_scope_manifest_events_in_extract:Scope: scope_manifest_missing/loaded events in _extract_scope_from_design"
@@ -4651,7 +4651,7 @@ test_scope_redaction_in_scope_no_redaction() {
     trap 'rm -rf "$tmp_dir"' RETURN
 
     local allowlist="scripts/lib/helpers.sh"$'\n'"scripts/lib/pipeline-stages.sh"
-    local finding="helpers.sh:42 — _redact_paths_outside_scope called with empty allowlist"
+    local finding="scripts/lib/helpers.sh:42 — _redact_paths_outside_scope called with empty allowlist"
 
     local redacted
     redacted=$(
@@ -4669,8 +4669,8 @@ test_scope_redaction_in_scope_no_redaction() {
     return 0
 }
 
-test_scope_redaction_oos_event_fires() {
-    # A finding referencing an out-of-scope path must trigger redaction.
+test_scope_redaction_oos_path_redacted() {
+    # A finding referencing an out-of-scope path must produce a redaction sentinel in the output.
     local helpers_sh="$REPO_DIR/scripts/lib/helpers.sh"
     [[ -f "$helpers_sh" ]] || { echo "SKIP: helpers.sh not found"; return 0; }
     grep -q '_redact_paths_outside_scope' "$helpers_sh" 2>/dev/null \


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pipeline-smoke.yml` that triggers on PRs touching `scripts/lib/pipeline-*.sh`, `sw-pipeline.sh`, `sw-loop.sh`, `scripts/lib/helpers.sh`, or `.claude/helpers/**`
- Adds 6 scope-redaction smoke assertions to `sw-pipeline-test.sh` — each runnable as a named test via `bash scripts/sw-pipeline-test.sh <test_name>`
- Tests SKIP gracefully when scope-redaction functions are absent (pre PR-B merge) so this gate can be merged first without breaking CI

## Test plan

- [ ] Push a PR touching `scripts/lib/helpers.sh` → pipeline-smoke workflow triggers
- [ ] `test_scope_redaction_helpers_present` — SKIP before PR-B merges, PASS after
- [ ] `test_scope_redaction_in_scope_no_redaction` — SKIP before PR-B merges, PASS after
- [ ] `test_scope_redaction_oos_event_fires` — SKIP before PR-B merges, PASS after
- [ ] `test_scope_drift_subcommand_present` — PASS (drift subcommand landed in PR-C/#632)
- [ ] `test_scope_escalation_detection_in_loop` — PASS (escalation detection landed in PR-C/#632)
- [ ] `test_scope_manifest_events_in_extract` — PASS (manifest events landed in PR-C/#632)

## Dependencies

- Depends on PR #631 (PR-B: scope-redaction invariant) for full functional gate
- Depends on PR #632 (PR-C: telemetry events) for 3 structural assertions

Closes #606

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)