### PR TITLE
fix(build): stop injecting goal-agnostic memory on cold pipeline runs

### DIFF
--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -410,7 +410,13 @@ ${_skill_prompts}
         if [[ "$_raw_recall_ctx" != "$_build_recall_ctx" && -n "$_raw_recall_ctx" ]]; then
             warn "Ruflo: recall output was sanitized before injection (potential injection attempt or malformed data)"
         fi
-        local _ruflo_min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}"
+        # Validate threshold: must be a non-negative integer; fall back to 50 if not.
+        local _ruflo_min_len
+        if [[ "${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}" =~ ^[0-9]+$ ]]; then
+            _ruflo_min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN}"
+        else
+            _ruflo_min_len=50
+        fi
         if [[ -n "$_build_recall_ctx" && "${#_build_recall_ctx}" -ge "$_ruflo_min_len" ]]; then
             build_context_body="${build_context_body}
 

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -411,13 +411,18 @@ ${_skill_prompts}
             warn "Ruflo: recall output was sanitized before injection (potential injection attempt or malformed data)"
         fi
         # Validate threshold: must be a non-negative integer; fall back to 50 if not.
+        # Use :-50 in both places so an unset variable doesn't trigger nounset (set -u).
         local _ruflo_min_len
         if [[ "${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}" =~ ^[0-9]+$ ]]; then
-            _ruflo_min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN}"
+            _ruflo_min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}"
         else
             _ruflo_min_len=50
         fi
-        if [[ -n "$_build_recall_ctx" && "${#_build_recall_ctx}" -ge "$_ruflo_min_len" ]]; then
+        # Length gate uses the RAW (pre-sanitization) length so that stripping
+        # injected markdown headers doesn't cause substantive content to fall
+        # below the threshold. Sanitization can only remove content, so if the
+        # raw result is too short, the sanitized result will be too.
+        if [[ -n "$_build_recall_ctx" && "${#_raw_recall_ctx}" -ge "$_ruflo_min_len" ]]; then
             build_context_body="${build_context_body}
 
 ## Historical Build Context
@@ -425,7 +430,7 @@ ${_build_recall_ctx}"
             info "Ruflo: injected historical build context (${#_build_recall_ctx} chars)"
         else
             if [[ -n "$_build_recall_ctx" ]]; then
-                info "Ruflo: recall result too short to be useful (${#_build_recall_ctx} chars, min=${_ruflo_min_len}) — skipping injection"
+                info "Ruflo: recall result too short to be useful (${#_raw_recall_ctx} chars raw, min=${_ruflo_min_len}) — skipping injection"
             else
                 info "Ruflo: no similar outcomes found yet for this repo. Outcomes accumulate across pipeline runs in the repo and issue namespaces."
             fi

--- a/scripts/lib/pipeline-stages-build.sh
+++ b/scripts/lib/pipeline-stages-build.sh
@@ -206,14 +206,14 @@ stage_build() {
     local dod_file="$ARTIFACTS_DIR/dod.md"
     local loop_args=()
 
-    # Memory integration — inject context if memory system available
+    # Memory integration — inject goal-aware context if memory system has prior runs.
+    # No fallback: if the focused search returns nothing, the block is omitted entirely.
+    # A goal-agnostic fallback was removed (see PR fix/cold-pipeline-memory-injection)
+    # because it injected unrelated failure history on cold (first-run) issues.
     local memory_context=""
     if type intelligence_search_memory >/dev/null 2>&1; then
         local mem_dir="${HOME}/.shipwright/memory"
         memory_context=$(intelligence_search_memory "build stage for: ${GOAL:-}" "$mem_dir" 5 2>/dev/null) || true
-    fi
-    if [[ -z "$memory_context" ]] && [[ -x "$SCRIPT_DIR/sw-memory.sh" ]]; then
-        memory_context=$(bash "$SCRIPT_DIR/sw-memory.sh" inject "build" 2>/dev/null) || true
     fi
 
     # Build clean goal (no synthesis context)
@@ -410,14 +410,19 @@ ${_skill_prompts}
         if [[ "$_raw_recall_ctx" != "$_build_recall_ctx" && -n "$_raw_recall_ctx" ]]; then
             warn "Ruflo: recall output was sanitized before injection (potential injection attempt or malformed data)"
         fi
-        if [[ -n "$_build_recall_ctx" ]]; then
+        local _ruflo_min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}"
+        if [[ -n "$_build_recall_ctx" && "${#_build_recall_ctx}" -ge "$_ruflo_min_len" ]]; then
             build_context_body="${build_context_body}
 
 ## Historical Build Context
 ${_build_recall_ctx}"
             info "Ruflo: injected historical build context (${#_build_recall_ctx} chars)"
         else
-            info "Ruflo: no similar outcomes found yet for this repo. Outcomes accumulate across pipeline runs in the repo and issue namespaces."
+            if [[ -n "$_build_recall_ctx" ]]; then
+                info "Ruflo: recall result too short to be useful (${#_build_recall_ctx} chars, min=${_ruflo_min_len}) — skipping injection"
+            else
+                info "Ruflo: no similar outcomes found yet for this repo. Outcomes accumulate across pipeline runs in the repo and issue namespaces."
+            fi
         fi
     fi
 

--- a/scripts/sw-build-prompt-memory-guard-test.sh
+++ b/scripts/sw-build-prompt-memory-guard-test.sh
@@ -78,7 +78,9 @@ ${memory_context}"
     fi
 
     # Lines ~392-422 of pipeline-stages-build.sh (post-fix):
-    # inject ruflo recall only when non-empty AND length >= min_len
+    # inject ruflo recall only when non-empty AND RAW length >= min_len.
+    # (Raw length is used so sanitization of injected headers doesn't drop
+    #  substantive content below the threshold.)
     if [[ -n "$mock_ruflo_result" && "${#mock_ruflo_result}" -ge "$min_len" ]]; then
         body="${body}
 ## Historical Build Context

--- a/scripts/sw-build-prompt-memory-guard-test.sh
+++ b/scripts/sw-build-prompt-memory-guard-test.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║  shipwright build prompt memory-guard regression test                     ║
+# ║                                                                           ║
+# ║  Verifies the build stage does NOT inject goal-agnostic historical        ║
+# ║  memory on cold (first-run) pipelines, and DOES inject it correctly on   ║
+# ║  warm runs or when ruflo recall returns a sufficiently long result.       ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+#
+# Regression for: removal of goal-agnostic memory fallback from stage_build()
+# that caused irrelevant historical context to leak into cold-pipeline prompts.
+#
+# The test exercises the COMPOSITION LOGIC only — not the full stage_build()
+# pipeline loop. A small inline helper (_test_compose_memory_block) mirrors
+# the exact injection decision code present in pipeline-stages-build.sh so
+# the assertions remain valid against the fixed behaviour.
+#
+set -euo pipefail
+trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/test-helpers.sh"
+
+# ─── assert_not_contains — not provided by test-helpers.sh, defined here ────
+assert_not_contains() {
+    local desc="$1"
+    local haystack="$2"
+    local needle="$3"
+    if grep -qF -- "$needle" <<< "$haystack" 2>/dev/null; then
+        assert_fail "$desc" "output should NOT contain: $needle"
+    else
+        assert_pass "$desc"
+    fi
+}
+
+# ─── Environment ─────────────────────────────────────────────────────────────
+print_test_header "Build Prompt: Memory Injection Guard"
+
+setup_test_env "build-prompt-memory-guard"
+_test_cleanup_hook() { cleanup_test_env; }
+
+# ─── Helper: mirrors the memory-injection decision from stage_build() ────────
+#
+# Arguments:
+#   $1  goal string (unused in logic, included for readability)
+#   $2  mock_focused_result  — what intelligence_search_memory / sw-memory inject
+#                              returns; empty string = cold-run (no prior context)
+#   $3  mock_ruflo_result    — what ruflo_recall_similar_outcomes returns;
+#                              empty string = no ruflo hit
+#
+# The function prints the assembled context body to stdout.
+# SHIPWRIGHT_RUFLO_RECALL_MIN_LEN can be overridden via env (default 50).
+#
+_test_compose_memory_block() {
+    local goal="${1:-}"
+    local mock_focused_result="${2:-}"
+    local mock_ruflo_result="${3:-}"
+    local min_len="${SHIPWRIGHT_RUFLO_RECALL_MIN_LEN:-50}"
+
+    # Fixed behaviour: memory_context comes ONLY from focused (goal-scoped) search.
+    # The goal-agnostic fallback has been removed; cold issues produce empty string.
+    local memory_context="$mock_focused_result"
+    local body=""
+
+    # Lines ~234-240 of pipeline-stages-build.sh (post-fix):
+    # inject memory_context only when non-empty
+    if [[ -n "$memory_context" ]]; then
+        body="${body}
+Historical context (lessons from previous pipelines):
+${memory_context}"
+    fi
+
+    # Lines ~392-422 of pipeline-stages-build.sh (post-fix):
+    # inject ruflo recall only when non-empty AND length >= min_len
+    if [[ -n "$mock_ruflo_result" && "${#mock_ruflo_result}" -ge "$min_len" ]]; then
+        body="${body}
+## Historical Build Context
+${mock_ruflo_result}"
+    fi
+
+    printf '%s' "$body"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T1 — Cold issue: both searches return nothing → no headers at all
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T1: cold issue - no memory injection"
+out=$(_test_compose_memory_block "Add JWT auth" "" "")
+assert_not_contains "no 'Historical context' header on cold issue"    "$out" "Historical context"
+assert_not_contains "no 'Historical Build Context' block on cold issue" "$out" "Historical Build Context"
+assert_not_contains "prompt body is empty on cold issue"              "$out" "lessons from previous pipelines"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T2 — Warm issue: focused search returns content → Historical context injected
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T2: warm issue - focused match injects 'Historical context'"
+out=$(_test_compose_memory_block "Add JWT auth" "Lesson: always validate input at boundaries" "")
+assert_contains     "Historical context present when focused match"           "$out" "Historical context"
+assert_contains     "lesson text appears in injected block"                   "$out" "Lesson: always validate input"
+assert_not_contains "no spurious 'Historical Build Context' without ruflo"    "$out" "Historical Build Context"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T3 — Ruflo returns >= 50 chars → ## Historical Build Context injected
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T3: ruflo long result (>=50 chars) → inject '## Historical Build Context'"
+long_result="This is a long ruflo recall result that definitely exceeds fifty characters."
+out=$(_test_compose_memory_block "Add JWT auth" "" "$long_result")
+assert_contains     "Historical Build Context present when ruflo long"        "$out" "## Historical Build Context"
+assert_contains     "ruflo content appears in block"                          "$out" "$long_result"
+assert_not_contains "no 'Historical context' header without focused match"    "$out" "Historical context"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T4 — Ruflo returns < 50 chars → block is suppressed
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T4: ruflo short result (<50 chars) → suppress '## Historical Build Context'"
+short_result="brief"
+out=$(_test_compose_memory_block "Add JWT auth" "" "$short_result")
+assert_not_contains "Historical Build Context absent when ruflo short"        "$out" "Historical Build Context"
+assert_not_contains "short ruflo content not injected"                        "$out" "$short_result"
+
+# Boundary: exactly 49 chars is below threshold → still suppressed
+boundary_short="$(printf '%0.s-' {1..49})"   # 49 dashes
+out=$(_test_compose_memory_block "Add JWT auth" "" "$boundary_short")
+assert_not_contains "Historical Build Context absent at len=49"               "$out" "Historical Build Context"
+
+# Boundary: exactly 50 chars meets threshold → injected
+boundary_exact="$(printf '%0.s-' {1..50})"   # 50 dashes
+out=$(_test_compose_memory_block "Add JWT auth" "" "$boundary_exact")
+assert_contains     "Historical Build Context present at len=50"              "$out" "## Historical Build Context"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T5 — SHIPWRIGHT_RUFLO_RECALL_MIN_LEN=0 overrides threshold; 1-char input accepted
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T5: SHIPWRIGHT_RUFLO_RECALL_MIN_LEN=0 overrides default threshold"
+out=$(SHIPWRIGHT_RUFLO_RECALL_MIN_LEN=0 _test_compose_memory_block "Add JWT auth" "" "x")
+assert_contains     "Historical Build Context present when threshold=0"       "$out" "## Historical Build Context"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# T6 — Both focused match and ruflo long result → both blocks present
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "  T6: both focused match and ruflo long result → both blocks present"
+warm_context="Prior lesson: cache the token exchange response to reduce latency."
+ruflo_context="Ruflo previously saw: always use refresh token rotation for security compliance."
+out=$(_test_compose_memory_block "Add JWT auth" "$warm_context" "$ruflo_context")
+assert_contains "Historical context present"                                  "$out" "Historical context"
+assert_contains "Historical Build Context present"                            "$out" "## Historical Build Context"
+assert_contains "focused context text present"                                "$out" "cache the token exchange"
+assert_contains "ruflo context text present"                                  "$out" "refresh token rotation"
+
+print_test_results

--- a/scripts/sw-build-prompt-memory-guard-test.sh
+++ b/scripts/sw-build-prompt-memory-guard-test.sh
@@ -13,7 +13,10 @@
 # The test exercises the COMPOSITION LOGIC only — not the full stage_build()
 # pipeline loop. A small inline helper (_test_compose_memory_block) mirrors
 # the exact injection decision code present in pipeline-stages-build.sh so
-# the assertions remain valid against the fixed behaviour.
+# The helper mirrors the injection decision logic, not the full sanitization
+# pipeline (control-char stripping, 2000-char truncation, header removal).
+# Tests use clean ASCII strings well under 2000 chars, so the omission is
+# intentional and noted here rather than implied to be exact parity.
 #
 set -euo pipefail
 trap 'echo "ERROR: $BASH_SOURCE:$LINENO exited with status $?" >&2' ERR
@@ -38,6 +41,10 @@ print_test_header "Build Prompt: Memory Injection Guard"
 
 setup_test_env "build-prompt-memory-guard"
 _test_cleanup_hook() { cleanup_test_env; }
+# Prevent env leakage: pin the threshold to the default so external overrides
+# don't affect the boundary assertions. Tests that need a different value set it
+# locally via SHIPWRIGHT_RUFLO_RECALL_MIN_LEN=N _test_compose_memory_block ...
+unset SHIPWRIGHT_RUFLO_RECALL_MIN_LEN
 
 # ─── Helper: mirrors the memory-injection decision from stage_build() ────────
 #


### PR DESCRIPTION
## Summary

- **Root cause**: on brand-new issues the focused goal-aware memory search returns nothing, triggering a fallback to `sw-memory.sh inject "build"` — a stage-keyed dump of all historical failures regardless of relevance. This injected an authoritative-looking "Historical context" block that the build agent treated as a to-do list, editing unrelated files and reintroducing bugs fixed by prior PRs (#605, #626, #630).
- **Fix 1**: remove the `sw-memory.sh inject "build"` fallback entirely. If `intelligence_search_memory` returns nothing, the historical-context block is omitted.
- **Fix 2**: add `SHIPWRIGHT_RUFLO_RECALL_MIN_LEN` threshold (default 50 chars) for ruflo recall injection. Short/trivial recall results are logged and skipped rather than pasted into the prompt.
- **Regression test**: `sw-build-prompt-memory-guard-test.sh` — 18 tests covering cold-issue suppression, warm-issue injection, len=49/50 boundary, env override, and combined paths.

## Test plan

- [x] `bash scripts/sw-build-prompt-memory-guard-test.sh` — 18/18 pass
- [x] `npm test` — full suite green
- [ ] Restart a cold pipeline run on a new issue and confirm `iteration-1.prompt.txt` contains no "Historical context" or "## Historical Build Context" blocks

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)