### PR TITLE
fix(cq): wire compound-audit-findings.json into _extract_blocking_items

### DIFF
--- a/scripts/lib/pipeline-intelligence.sh
+++ b/scripts/lib/pipeline-intelligence.sh
@@ -1441,7 +1441,8 @@ _dedup_add_item() {
 # Collects critical/high-severity findings from available artifact sources into a
 # numbered list. Sources: adversarial-review.json (with .md fallback),
 # security-audit.log, negative-review.md [Critical] lines, dod-audit.md
-# unchecked items, and classified-findings.json needs_backtrack flag.
+# unchecked items, classified-findings.json needs_backtrack flag, and
+# compound-audit-findings.json critical/high findings.
 # Deduplicates by file:line fingerprint (best-effort, exact-line match).
 # Outputs to stdout; empty output means no blocking items found.
 #
@@ -1548,6 +1549,33 @@ _extract_blocking_items() {
         needs_backtrack=$(jq -r '.needs_backtrack // false' "$ARTIFACTS_DIR/classified-findings.json" 2>/dev/null || echo "false")
         if [[ "$needs_backtrack" == "true" ]]; then
             backtrack_note="> ⚠ Backtrack flagged by classifier — structural issues may require revisiting design"
+        fi
+    fi
+
+    # ── 6. compound-audit-findings.json — critical/high cascade findings ──
+    # Cascade audit produces structured findings (file, line, description,
+    # suggestion) that count toward gate severity but were previously not
+    # injected into the rebuild GOAL. Surface them here so the build agent
+    # gets the most actionable feedback the pipeline produces.
+    # gsub flattens embedded newlines so one finding == one line == one
+    # dedup entry; without it, multi-line .description/.suggestion would
+    # split into orphaned continuation lines that lose their file:line fp.
+    if [[ -f "$ARTIFACTS_DIR/compound-audit-findings.json" ]] && \
+       pipeline_artifact_is_current "$ARTIFACTS_DIR/compound-audit-findings.json" && \
+       jq -e . "$ARTIFACTS_DIR/compound-audit-findings.json" >/dev/null 2>&1; then
+        local cascade_lines
+        cascade_lines=$(jq -r '
+          def flat: gsub("[\r\n]+"; " ");
+          .[]
+          | select(.severity == "critical" or .severity == "high")
+          | "\(.file // "unknown"):\(.line // "?") \u2014 \((.description // "finding") | flat)"
+            + (if (.suggestion // "") != "" then " (suggestion: \((.suggestion) | flat))" else "" end)
+        ' "$ARTIFACTS_DIR/compound-audit-findings.json" 2>/dev/null || true)
+        if [[ -n "$cascade_lines" ]]; then
+            while IFS= read -r line; do
+                [[ -z "$line" ]] && continue
+                _dedup_add_item "$line" "compound-audit" "$tmp_fps" "$tmp_items"
+            done <<< "$cascade_lines"
         fi
     fi
 

--- a/scripts/sw-lib-pipeline-intelligence-test.sh
+++ b/scripts/sw-lib-pipeline-intelligence-test.sh
@@ -705,6 +705,179 @@ assert_eq "_extract_blocking_items: dod source in mixed result" "1" "${has_dod:-
 rm -f "$ARTIFACTS_DIR/adversarial-review.md" "$ARTIFACTS_DIR/negative-review.md" "$ARTIFACTS_DIR/dod-audit.md"
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# compound-audit-findings.json source (source-6)
+# ═══════════════════════════════════════════════════════════════════════════════
+print_test_section "compound-audit-findings.json source"
+
+# Ensure all other artifact sources are absent so only source-6 is active.
+rm -f "$ARTIFACTS_DIR/adversarial-review.json" "$ARTIFACTS_DIR/adversarial-review.md" \
+      "$ARTIFACTS_DIR/negative-review.md" "$ARTIFACTS_DIR/dod-audit.md" \
+      "$ARTIFACTS_DIR/security-audit.log" "$ARTIFACTS_DIR/security-source-scan.log" \
+      "$ARTIFACTS_DIR/security-source-scan.json" "$ARTIFACTS_DIR/classified-findings.json" \
+      "$ARTIFACTS_DIR/compound-audit-findings.json"
+
+# ── Test 1: artifact absent — no output ──
+blocking_result=$(_extract_blocking_items)
+assert_eq "cascade artifact absent: no output" "" "$blocking_result"
+
+# ── Test 2: critical entry included ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+_orig_artifacts="$ARTIFACTS_DIR"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"src/auth.sh","line":"42","description":"null deref in auth","suggestion":""}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_cascade=$(echo "$blocking_result" | grep -c "src/auth.sh:42" 2>/dev/null || true)
+assert_eq "cascade critical entry: file:line in output" "1" "${has_cascade:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 3: high entry included ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"high","file":"lib/parser.sh","line":"7","description":"unquoted variable expansion","suggestion":""}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_high=$(echo "$blocking_result" | grep -c "lib/parser.sh:7" 2>/dev/null || true)
+assert_eq "cascade high entry: file:line in output" "1" "${has_high:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 4: medium/low excluded ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[
+  {"severity":"medium","file":"util.sh","line":"3","description":"medium concern","suggestion":""},
+  {"severity":"low","file":"util.sh","line":"9","description":"low concern","suggestion":""}
+]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+assert_eq "cascade medium/low: no output" "" "$blocking_result"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 5: dedup with adversarial-review.json — same file:line appears once ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+# adversarial-review.json entry: location field used as fingerprint
+cat > "$_casc_dir/adversarial-review.json" <<'EOADV'
+[{"severity":"critical","location":"src/dup.sh:55","description":"first mention"}]
+EOADV
+# cascade entry: same file:line
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"src/dup.sh","line":"55","description":"second mention","suggestion":""}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+dup_count=$(echo "$blocking_result" | grep -c "dup.sh:55" 2>/dev/null || true)
+assert_eq "cascade dedup with adversarial: file:line appears once" "1" "${dup_count:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 6: malformed JSON — no crash, empty output ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+printf 'not-json\n' > "$_casc_dir/compound-audit-findings.json"
+blocking_result=$(_extract_blocking_items 2>/dev/null || true)
+assert_eq "cascade malformed JSON: no crash, empty output" "" "$blocking_result"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 7: empty array — no items added ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+printf '[]\n' > "$_casc_dir/compound-audit-findings.json"
+blocking_result=$(_extract_blocking_items)
+assert_eq "cascade empty array: no output" "" "$blocking_result"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 8: stale artifact (SHA mismatch) — output is empty ──
+# pipeline_artifact_is_current reads .[0].created_at_commit from the array and
+# prefix-matches it against git rev-parse --short HEAD (which mock_git returns
+# as "/tmp/mock-repo"). Embedding a SHA of "deadbeef" ensures a mismatch and
+# the file is treated as stale, so no items are added.
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"stale.sh","line":"1","description":"stale finding","suggestion":"","created_at_commit":"deadbeef"}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+assert_eq "cascade stale artifact (SHA mismatch): output empty" "" "$blocking_result"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 9: suggestion present — output contains (suggestion: fix it) ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"main.sh","line":"10","description":"some issue","suggestion":"fix it"}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_suggestion=$(echo "$blocking_result" | grep -c "(suggestion: fix it)" 2>/dev/null || true)
+assert_eq "cascade suggestion present: (suggestion: fix it) in output" "1" "${has_suggestion:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 10: suggestion empty — output does NOT contain (suggestion: ) ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"main.sh","line":"10","description":"some issue","suggestion":""}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_empty_sugg=$(echo "$blocking_result" | grep -c "(suggestion: )" 2>/dev/null || true)
+assert_eq "cascade suggestion empty: no (suggestion: ) in output" "0" "${has_empty_sugg:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 11: suggestion field missing — output does NOT contain (suggestion: ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"main.sh","line":"10","description":"some issue"}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_no_sugg=$(echo "$blocking_result" | grep -c "(suggestion:" 2>/dev/null || true)
+assert_eq "cascade suggestion missing: no (suggestion: in output" "0" "${has_no_sugg:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 12: multi-line description — item appears as single numbered entry ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+# Use jq to generate a fixture with a literal newline embedded in description.
+jq -n '[{"severity":"critical","file":"multi.sh","line":"5","description":"line one\nline two","suggestion":""}]' \
+    > "$_casc_dir/compound-audit-findings.json"
+blocking_result=$(_extract_blocking_items)
+item_count=$(echo "$blocking_result" | grep -c "^[0-9]*\." 2>/dev/null || true)
+assert_eq "cascade multi-line description: single numbered entry" "1" "${item_count:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ── Test 13: mixed sources — cascade + adversarial + negative all present ──
+_casc_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-casc-test.XXXXXX")"
+ARTIFACTS_DIR="$_casc_dir"
+echo "- **[Critical]** a.sh:1 — adversarial finding" > "$_casc_dir/adversarial-review.md"
+echo "[Critical] b.sh:2 — negative finding" > "$_casc_dir/negative-review.md"
+cat > "$_casc_dir/compound-audit-findings.json" <<'EOCASC'
+[{"severity":"critical","file":"c.sh","line":"3","description":"cascade finding","suggestion":""}]
+EOCASC
+blocking_result=$(_extract_blocking_items)
+has_adv=$(echo "$blocking_result" | grep -c "adversarial finding" 2>/dev/null || true)
+has_neg=$(echo "$blocking_result" | grep -c "negative finding" 2>/dev/null || true)
+has_casc=$(echo "$blocking_result" | grep -c "c.sh:3" 2>/dev/null || true)
+total_items=$(echo "$blocking_result" | grep -c "^[0-9]*\." 2>/dev/null || true)
+assert_eq "mixed sources: adversarial entry present" "1" "${has_adv:-0}"
+assert_eq "mixed sources: negative entry present" "1" "${has_neg:-0}"
+assert_eq "mixed sources: cascade entry present" "1" "${has_casc:-0}"
+assert_eq "mixed sources: total item count is 3" "3" "${total_items:-0}"
+ARTIFACTS_DIR="$_orig_artifacts"
+rm -rf "$_casc_dir"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # RETURN trap self-clearing in compound_rebuild_with_feedback
 # Regression for: original_goal unbound under set -u when trap re-fired in caller
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/scripts/sw-quality-test.sh
+++ b/scripts/sw-quality-test.sh
@@ -218,6 +218,91 @@ fi
 
 echo ""
 
+# ─── 10. _write_quality_feedback wiring: cascade findings reach quality-feedback.md ──
+# Integration-level: seed compound-audit-findings.json with a critical entry,
+# call _write_quality_feedback directly (sourced from pipeline-intelligence.sh),
+# and assert the "## Blocking Issues" section contains the expected file:line.
+# This catches wiring regressions that unit tests cannot catch.
+
+echo -e "${BOLD}  compound-audit-findings.json → quality-feedback.md wiring${RESET}"
+
+(
+    set -euo pipefail
+
+    _integ_dir="$(mktemp -d "${TMPDIR:-/tmp}/sw-qw-integ.XXXXXX")"
+    _integ_feedback="$_integ_dir/quality-feedback.md"
+
+    # Provide minimal stubs required by pipeline-intelligence.sh on source.
+    ARTIFACTS_DIR="$_integ_dir"
+    EVENTS_FILE="$_integ_dir/events.jsonl"
+    STATE_FILE="$_integ_dir/state.json"
+    BASE_BRANCH="main"
+    ISSUE_NUMBER="0"
+    ISSUE_LABELS=""
+    INTELLIGENCE_COMPLEXITY="5"
+    PIPELINE_CONFIG="$_integ_dir/pipeline-config.json"
+    PIPELINE_NAME="standard"
+    PROJECT_ROOT="$_integ_dir"
+    IGNORE_BUDGET="true"
+    OUTER_STAGE=""
+    INNER_STAGE=""
+    NO_GITHUB="true"
+    SCRIPT_DIR="$SCRIPT_DIR"
+
+    mkdir -p "$_integ_dir"
+    echo '{"stages":[{"id":"compound_quality","config":{"audit_intensity":"auto"}}]}' \
+        > "$_integ_dir/pipeline-config.json"
+
+    now_iso() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+    now_epoch() { date +%s; }
+    emit_event() { :; }
+    daemon_log() { :; }
+    info() { :; }
+    success() { :; }
+    warn() { :; }
+    error() { :; } >&2
+    rotate_jsonl() { :; }
+    log_stage() { :; }
+    write_state() { :; }
+    set_outer_stage() { OUTER_STAGE="${1:-}"; INNER_STAGE=""; write_state; }
+    clear_outer_stage() { OUTER_STAGE=""; INNER_STAGE=""; write_state; }
+
+    # Clear guard so we can re-source even if the lib was loaded in parent shell.
+    _PIPELINE_INTELLIGENCE_LOADED=""
+    source "$SCRIPT_DIR/lib/pipeline-intelligence.sh"
+
+    # Seed compound-audit-findings.json with a critical finding (no SHA stamp →
+    # pipeline_artifact_is_current treats it as current via pass-through).
+    cat > "$_integ_dir/compound-audit-findings.json" <<'EOINTEG'
+[{"severity":"critical","file":"wiring/check.sh","line":"99","description":"wiring regression detected","suggestion":"add guard"}]
+EOINTEG
+
+    # Call _write_quality_feedback; it will call _extract_blocking_items internally.
+    _write_quality_feedback "correctness" "$_integ_feedback"
+
+    _feedback_content="$(cat "$_integ_feedback" 2>/dev/null || true)"
+    rm -rf "$_integ_dir"
+
+    # Signal result to parent shell via exit code + printed sentinel.
+    if echo "$_feedback_content" | grep -qF "wiring/check.sh:99"; then
+        echo "INTEG_WIRING_PASS"
+    else
+        echo "INTEG_WIRING_FAIL"
+    fi
+) > /tmp/sw_qw_integ_result.txt 2>/dev/null || true
+
+_integ_result=$(cat /tmp/sw_qw_integ_result.txt 2>/dev/null || true)
+rm -f /tmp/sw_qw_integ_result.txt
+
+if [[ "$_integ_result" == "INTEG_WIRING_PASS" ]]; then
+    assert_pass "compound-audit-findings.json: critical entry reaches ## Blocking Issues in quality-feedback.md"
+else
+    assert_fail "compound-audit-findings.json: critical entry reaches ## Blocking Issues in quality-feedback.md" \
+        "expected wiring/check.sh:99 in Blocking Issues section"
+fi
+
+echo ""
+
 # ═══════════════════════════════════════════════════════════════════════════════
 # Results
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `_extract_blocking_items()` had 5 artifact sources; `compound-audit-findings.json` (cascade audit output) was counted toward gate severity but **never injected into the rebuild GOAL**
- Build agent was receiving adversarial/negative/dod feedback but never the cascade audit's specific `file:line:description:suggestion` findings — root cause of repeated #635 failures
- Adds source 6: reads `critical`/`high` entries from `compound-audit-findings.json`, formats them as numbered blocking items using the same triple-guard and dedup pattern as all other sources
- Newlines in `.description`/`.suggestion` are flattened via `jq def flat:` to prevent fingerprint corruption

## Changes

- `scripts/lib/pipeline-intelligence.sh` — source-6 block in `_extract_blocking_items()`, header comment updated
- `scripts/sw-lib-pipeline-intelligence-test.sh` — 13 new unit tests (absent, critical/high, medium/low excluded, adversarial dedup, malformed JSON, empty array, stale artifact, suggestion formatting ×3, multi-line description, mixed sources)
- `scripts/sw-quality-test.sh` — 1 pipeline-level integration test verifying `_write_quality_feedback` wiring

## Test plan

- [x] `npm test` — all suites pass (exit 0)
- [x] Architecture review: insertion point, guard pattern, arg order, bash 3.2 compat all verified
- [x] Code review: PASS — test fixture pattern correct, no global state leaks, integration test exercises correct wiring boundary
- [ ] CI green
- [ ] Verify on #635 repro: `quality-feedback.md` "## Blocking Issues" now contains `_RESYNC_RETRY_BUDGET` scope finding

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)